### PR TITLE
added ops-bot configuration to allow auto-merge functionality

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -1,0 +1,8 @@
+# This file controls which features from the `ops-bot` repository below are enabled.
+# - https://github.com/rapidsai/ops-bot
+
+auto_merger: true
+branch_checker: true
+label_checker: true
+release_drafter: false
+forward_merger: false


### PR DESCRIPTION
This adds the configuration required that should allow the ability for PRs to be merged by using `/merge` as long as they are passing all required approvals and repository checks. 

closes: https://github.com/rapidsai/ops/issues/4453