### PR TITLE
feat\!: Replace data_batch state machine with RAII lock accessor types

### DIFF
--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -39,6 +39,15 @@ class memory_space;
 
 namespace cucascade {
 
+/**
+ * @brief Observable state of a data_batch.
+ *
+ * Tracks whether the batch is idle, shared-locked (read_only), or
+ * exclusively-locked (mutable_locked). Updated atomically during
+ * state transitions.
+ */
+enum class batch_state { idle, read_only, mutable_locked };
+
 // Forward declarations -- required before data_batch because it friends them.
 template <typename PtrType>
 class read_only_data_batch;
@@ -60,7 +69,7 @@ class mutable_data_batch;
  * @note Non-copyable and non-movable. The object itself never moves; only the
  *       smart pointer to it is transferred between states.
  */
-class data_batch {
+class data_batch : public std::enable_shared_from_this<data_batch> {
  public:
   // -- Construction --
 
@@ -119,8 +128,17 @@ class data_batch {
    */
   size_t get_subscriber_count() const;
 
+  /**
+   * @brief Get the observable lock state of this batch.
+   *
+   * Atomic, lock-free. Returns the current state: idle, read_only, or
+   * mutable_locked. Updated during every state transition.
+   *
+   * @return The current batch_state.
+   */
+  batch_state get_state() const { return _state.load(std::memory_order_relaxed); }
+
   // -- Static transition methods (D-13/D-14/D-15/D-17) --
-  // All transitions go through idle -- no locked-to-locked shortcuts.
 
   /**
    * @brief Transition from idle to read-only (shared lock).
@@ -197,6 +215,76 @@ class data_batch {
   template <typename PtrType>
   [[nodiscard]] static std::optional<mutable_data_batch<PtrType>> try_to_mutable(PtrType& batch);
 
+  // -- Non-static transitions (shared_ptr only, via shared_from_this) --
+  // The caller's shared_ptr is NOT consumed. These only work when the
+  // data_batch is managed by a shared_ptr (throws bad_weak_ptr otherwise).
+
+  /**
+   * @brief Transition from idle to read-only (shared lock) without consuming the caller's pointer.
+   *
+   * Uses shared_from_this() to obtain a new shared_ptr. Blocks until the
+   * shared lock is acquired.
+   *
+   * @return A read_only_data_batch holding the shared lock.
+   */
+  [[nodiscard]] read_only_data_batch<std::shared_ptr<data_batch>> to_read_only();
+
+  /**
+   * @brief Transition from idle to mutable (exclusive lock) without consuming the caller's pointer.
+   *
+   * Uses shared_from_this() to obtain a new shared_ptr. Blocks until the
+   * exclusive lock is acquired.
+   *
+   * @return A mutable_data_batch holding the exclusive lock.
+   */
+  [[nodiscard]] mutable_data_batch<std::shared_ptr<data_batch>> to_mutable();
+
+  /**
+   * @brief Try to transition from idle to read-only (non-blocking, shared_ptr only).
+   *
+   * @return An optional containing the read-only accessor on success, or
+   *         std::nullopt if the lock could not be acquired immediately.
+   */
+  [[nodiscard]] std::optional<read_only_data_batch<std::shared_ptr<data_batch>>> try_to_read_only();
+
+  /**
+   * @brief Try to transition from idle to mutable (non-blocking, shared_ptr only).
+   *
+   * @return An optional containing the mutable accessor on success, or
+   *         std::nullopt if the lock could not be acquired immediately.
+   */
+  [[nodiscard]] std::optional<mutable_data_batch<std::shared_ptr<data_batch>>> try_to_mutable();
+
+  // -- Locked-to-locked static transitions --
+
+  /**
+   * @brief Transition from read-only to mutable (upgrade lock).
+   *
+   * Releases the shared lock, then acquires an exclusive lock (may block).
+   * The source accessor is consumed via move.
+   *
+   * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
+   * @param accessor Rvalue reference to the read-only accessor (consumed).
+   * @return A mutable_data_batch holding the exclusive lock.
+   */
+  template <typename PtrType>
+  [[nodiscard]] static mutable_data_batch<PtrType> readonly_to_mutable(
+    read_only_data_batch<PtrType>&& accessor);
+
+  /**
+   * @brief Transition from mutable to read-only (downgrade lock).
+   *
+   * Releases the exclusive lock, then acquires a shared lock (may block).
+   * The source accessor is consumed via move.
+   *
+   * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
+   * @param accessor Rvalue reference to the mutable accessor (consumed).
+   * @return A read_only_data_batch holding the shared lock.
+   */
+  template <typename PtrType>
+  [[nodiscard]] static read_only_data_batch<PtrType> mutable_to_readonly(
+    mutable_data_batch<PtrType>&& accessor);
+
  private:
   // -- Friend declarations (D-24/REPO-04) --
   template <typename PtrType>
@@ -245,10 +333,11 @@ class data_batch {
                   rmm::cuda_stream_view stream);
 
   // -- Members --
-  const uint64_t _batch_id;                     ///< Immutable batch identifier
-  std::unique_ptr<idata_representation> _data;  ///< Owned data representation
-  mutable std::shared_mutex _rw_mutex;          ///< Reader-writer mutex
-  std::atomic<size_t> _subscriber_count{0};     ///< Atomic subscriber interest count
+  const uint64_t _batch_id;                            ///< Immutable batch identifier
+  std::unique_ptr<idata_representation> _data;         ///< Owned data representation
+  mutable std::shared_mutex _rw_mutex;                 ///< Reader-writer mutex
+  std::atomic<size_t> _subscriber_count{0};            ///< Atomic subscriber interest count
+  std::atomic<batch_state> _state{batch_state::idle};  ///< Observable lock state
 };
 
 /**
@@ -454,6 +543,7 @@ read_only_data_batch<PtrType> data_batch::to_read_only(PtrType&& batch)
 {
   auto ptr = std::move(batch);
   std::shared_lock<std::shared_mutex> lock(ptr->_rw_mutex);
+  ptr->_state.store(batch_state::read_only, std::memory_order_relaxed);
   return read_only_data_batch<PtrType>(std::move(ptr), std::move(lock));
 }
 
@@ -464,6 +554,7 @@ mutable_data_batch<PtrType> data_batch::to_mutable(PtrType&& batch)
 {
   auto ptr = std::move(batch);
   std::unique_lock<std::shared_mutex> lock(ptr->_rw_mutex);
+  ptr->_state.store(batch_state::mutable_locked, std::memory_order_relaxed);
   return mutable_data_batch<PtrType>(std::move(ptr), std::move(lock));
 }
 
@@ -473,6 +564,7 @@ template <typename PtrType>
 PtrType data_batch::to_idle(read_only_data_batch<PtrType>&& accessor)
 {
   auto ptr = std::move(accessor._batch);
+  ptr->_state.store(batch_state::idle, std::memory_order_relaxed);
   accessor._lock.unlock();
   return ptr;
 }
@@ -483,6 +575,7 @@ template <typename PtrType>
 PtrType data_batch::to_idle(mutable_data_batch<PtrType>&& accessor)
 {
   auto ptr = std::move(accessor._batch);
+  ptr->_state.store(batch_state::idle, std::memory_order_relaxed);
   accessor._lock.unlock();
   return ptr;
 }
@@ -494,6 +587,7 @@ std::optional<read_only_data_batch<PtrType>> data_batch::try_to_read_only(PtrTyp
 {
   std::shared_lock<std::shared_mutex> lock(batch->_rw_mutex, std::try_to_lock);
   if (!lock.owns_lock()) { return std::nullopt; }
+  batch->_state.store(batch_state::read_only, std::memory_order_relaxed);
   auto ptr = std::move(batch);
   return read_only_data_batch<PtrType>(std::move(ptr), std::move(lock));
 }
@@ -505,8 +599,35 @@ std::optional<mutable_data_batch<PtrType>> data_batch::try_to_mutable(PtrType& b
 {
   std::unique_lock<std::shared_mutex> lock(batch->_rw_mutex, std::try_to_lock);
   if (!lock.owns_lock()) { return std::nullopt; }
+  batch->_state.store(batch_state::mutable_locked, std::memory_order_relaxed);
   auto ptr = std::move(batch);
   return mutable_data_batch<PtrType>(std::move(ptr), std::move(lock));
+}
+
+// -- data_batch::readonly_to_mutable (upgrade lock, TRANS-07) --
+
+template <typename PtrType>
+mutable_data_batch<PtrType> data_batch::readonly_to_mutable(
+  read_only_data_batch<PtrType>&& accessor)
+{
+  auto ptr = std::move(accessor._batch);
+  accessor._lock.unlock();
+  std::unique_lock<std::shared_mutex> lock(ptr->_rw_mutex);
+  ptr->_state.store(batch_state::mutable_locked, std::memory_order_relaxed);
+  return mutable_data_batch<PtrType>(std::move(ptr), std::move(lock));
+}
+
+// -- data_batch::mutable_to_readonly (downgrade lock, TRANS-08) --
+
+template <typename PtrType>
+read_only_data_batch<PtrType> data_batch::mutable_to_readonly(
+  mutable_data_batch<PtrType>&& accessor)
+{
+  auto ptr = std::move(accessor._batch);
+  accessor._lock.unlock();
+  std::shared_lock<std::shared_mutex> lock(ptr->_rw_mutex);
+  ptr->_state.store(batch_state::read_only, std::memory_order_relaxed);
+  return read_only_data_batch<PtrType>(std::move(ptr), std::move(lock));
 }
 
 // -- read_only_data_batch::clone (deep copy, CLONE-01) --

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -46,9 +46,9 @@ namespace cucascade {
  *
  * State transitions allowed:
  * - idle -> in_transit, task_created
- * - task_created -> processing, idle
+ * - task_created -> processing, idle, in_transit
  * - processing -> idle
- * - in_transit -> idle
+ * - in_transit -> idle, task_created
  */
 enum class batch_state {
   idle,          ///< Batch is idle, not being processed or in transit
@@ -450,9 +450,11 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
   /**
    * @brief Attempt to lock this batch for in-transit operations (e.g., downgrade).
    *
-   * Transitions the batch from idle to in_transit state.
+   * Transitions the batch from idle or task_created to in_transit state.
+   * When transitioning from task_created, the task_created_count is preserved
+   * so the pending task remains valid after the data is moved.
    *
-   * @return true if the batch was successfully locked (processing_count == 0 and state is idle)
+   * @return true if the batch was successfully locked (processing_count == 0 and state is idle or task_created with task_created_count > 0)
    * @return false if the batch could not be locked
    */
   bool try_to_lock_for_in_transit();
@@ -462,11 +464,13 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
    *
    * Transitions the batch from in_transit back to idle state.
    *
-   * @return true if the batch was successfully transitioned to idle
+   * @return true if the batch was successfully transitioned to the target state
    * @return false if the batch is not in in_transit state
    *
-   * @param target_state Optional state to transition to when releasing in_transit. If not set,
-   *        the batch returns to idle.
+   * @param target_state Optional state to transition to when releasing in_transit.
+   *        Supported target states: idle (default), task_created.
+   *        When restoring to task_created, the existing task_created_count is preserved,
+   *        allowing pending tasks to resume after data movement completes.
    */
   bool try_to_release_in_transit(std::optional<batch_state> target_state = std::nullopt);
 

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -1,4 +1,3 @@
-
 /*
  * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
@@ -22,15 +21,14 @@
 #include <cucascade/data/representation_converter.hpp>
 #include <cucascade/memory/common.hpp>
 
-#include <cudf/table/table.hpp>
-
-#include <condition_variable>
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <mutex>
 #include <optional>
+#include <shared_mutex>
 #include <stdexcept>
+#include <type_traits>
 #include <utility>
 
 namespace cucascade {
@@ -41,502 +39,394 @@ class memory_space;
 
 namespace cucascade {
 
-/**
- * @brief Represents the current state of a data_batch.
- *
- * State transitions allowed:
- * - idle -> in_transit, task_created
- * - task_created -> processing, idle
- * - processing -> idle
- * - in_transit -> idle
- */
-enum class batch_state {
-  idle,          ///< Batch is idle, not being processed or in transit
-  task_created,  ///< A task has been created for this batch, pending processing
-  processing,    ///< Batch is currently being processed
-  in_transit     ///< Batch is currently being moved to a different memory tier
-};
+// Forward declarations -- required before data_batch because it friends them.
+template <typename PtrType>
+class read_only_data_batch;
+template <typename PtrType>
+class mutable_data_batch;
 
 /**
- * @brief Interface for probing the data_batch class.
+ * @brief Core data batch type representing the "idle" (unlocked) state.
  *
- * Applications may implement this interface to hold additional application specific
- * data_batch metadata while probing the data_batch by overriding the provided methods
- * that expose the data_batch state when certain events occur, like state transitions.
+ * Owns the data representation, a reader-writer mutex, and subscriber bookkeeping.
+ * Almost nothing is publicly accessible -- data, tier, and memory space are private
+ * and can only be reached through RAII accessor types that hold the appropriate lock.
+ *
+ * State transitions are static template methods that move ownership of the smart
+ * pointer (PtrType) into an accessor, making the source pointer null at the call
+ * site. This provides compile-time enforcement: once a batch is locked, the caller
+ * cannot access the idle handle.
+ *
+ * @note Non-copyable and non-movable. The object itself never moves; only the
+ *       smart pointer to it is transferred between states.
  */
-class idata_batch_probe {
+class data_batch {
  public:
-  virtual ~idata_batch_probe() = default;
+  // -- Construction --
 
   /**
-   * @brief The function that is called everytime a data_batch transitions into a new batch_state.
+   * @brief Construct a new data_batch.
    *
-   * @note It is the implementer's responsibility that a call to this function returns quickly, as
-   *       this function is called in a thread-safe manner, and will block other mutating changes
-   *       while this executes. Primarily intended for bookkeeping purposes.
+   * @param batch_id Unique identifier for this batch (immutable after construction).
+   * @param data     Owned data representation; must not be null.
    */
-  virtual void state_transitioned_to([[maybe_unused]] const batch_state new_state,
-                                     [[maybe_unused]] const uint64_t batch_id,
-                                     [[maybe_unused]] const idata_representation& data,
-                                     [[maybe_unused]] const size_t processing_count,
-                                     [[maybe_unused]] const size_t task_created_count)
-  {
-    // The default impl is no-op.
-  }
-};
+  data_batch(uint64_t batch_id, std::unique_ptr<idata_representation> data);
 
-// Forward declarations
-class data_batch;
-class data_batch_processing_handle;
+  /** @brief Default destructor. */
+  ~data_batch() = default;
 
-/**
- * @brief RAII handle that manages processing state for a data_batch.
- *
- * When this handle goes out of scope, it decrements the processing count of the
- * associated data_batch. If the processing count drops to zero, the batch state
- * transitions from processing back to idle.
- *
- * @note This class is move-only to ensure proper ownership semantics.
- * @note Uses a weak_ptr so the handle does not keep the batch alive; if the batch
- *       is destroyed before release(), release() is a no-op.
- */
-class data_batch_processing_handle {
- public:
-  /**
-   * @brief Default constructor creates an empty handle.
-   */
-  data_batch_processing_handle() = default;
+  // -- Deleted move/copy (D-04/CORE-07) --
+  data_batch(data_batch&&)                 = delete;
+  data_batch& operator=(data_batch&&)      = delete;
+  data_batch(const data_batch&)            = delete;
+  data_batch& operator=(const data_batch&) = delete;
+
+  // -- Lock-free public API --
 
   /**
-   * @brief Construct a handle from a shared_ptr (stores weak_ptr; does not keep batch alive).
+   * @brief Get the unique batch identifier.
    *
-   * @param batch shared_ptr to the data_batch to manage
-   */
-  explicit data_batch_processing_handle(std::shared_ptr<data_batch> batch)
-    : _batch(batch ? std::optional<std::weak_ptr<data_batch>>(std::move(batch)) : std::nullopt)
-  {
-  }
-
-  /**
-   * @brief Destructor decrements processing count and potentially transitions state.
-   */
-  ~data_batch_processing_handle();
-
-  // Move-only semantics
-  data_batch_processing_handle(const data_batch_processing_handle&)            = delete;
-  data_batch_processing_handle& operator=(const data_batch_processing_handle&) = delete;
-
-  /**
-   * @brief Move constructor - transfers ownership of the handle.
-   */
-  data_batch_processing_handle(data_batch_processing_handle&& other) noexcept
-    : _batch(std::exchange(other._batch, std::nullopt))
-  {
-  }
-
-  /**
-   * @brief Move assignment operator - transfers ownership of the handle.
-   */
-  data_batch_processing_handle& operator=(data_batch_processing_handle&& other) noexcept
-  {
-    if (this != &other) {
-      release();
-      _batch = std::exchange(other._batch, std::nullopt);
-    }
-    return *this;
-  }
-
-  /**
-   * @brief Check if this handle is valid (managing a batch).
-   */
-  bool valid() const { return _batch.has_value() && !_batch->expired(); }
-
-  /**
-   * @brief Explicitly release the handle, decrementing the processing count.
-   */
-  void release();
-
- private:
-  std::optional<std::weak_ptr<data_batch>> _batch;  ///< Weak reference to the managed data_batch
-};
-
-/**
- * @brief Result of attempting to lock a batch for processing.
- */
-enum class lock_for_processing_status {
-  success,
-  task_not_created,
-  invalid_state,
-  memory_space_mismatch,
-  missing_data,
-  not_attempted
-};
-
-struct lock_for_processing_result {
-  bool success{false};
-  data_batch_processing_handle handle{};
-  lock_for_processing_status status{lock_for_processing_status::not_attempted};
-
-  lock_for_processing_result() = default;
-  lock_for_processing_result(bool success,
-                             data_batch_processing_handle&& handle,
-                             lock_for_processing_status status)
-    : success(success), handle(std::move(handle)), status(status)
-  {
-  }
-
-  // Move-only to mirror handle semantics
-  lock_for_processing_result(lock_for_processing_result&&) noexcept            = default;
-  lock_for_processing_result& operator=(lock_for_processing_result&&) noexcept = default;
-  lock_for_processing_result(const lock_for_processing_result&)                = delete;
-  lock_for_processing_result& operator=(const lock_for_processing_result&)     = delete;
-};
-
-/**
- * @brief A data batch represents a collection of data that can be moved between different memory
- * tiers.
- *
- * data_batch is the core unit of data management in cuCascade. It wraps an
- * idata_representation and provides processing counting functionality to track when data is being
- * actively used. This enables safe memory management and efficient data movement
- * between GPU memory, host memory, and storage tiers.
- *
- * Key characteristics:
- * - Move-only semantics (no copy constructor/assignment)
- * - Processing counting for safe shared access and eviction prevention
- * - State management (idle, task_created, processing, in_transit) for lifecycle tracking
- * - Delegated tier management to underlying idata_representation
- * - Unique batch ID for tracking and debugging purposes
- * - Lifecycle managed by smart pointers (std::shared_ptr or std::unique_ptr)
- *
- * @note This class is not thread-safe for construction/destruction, but the state management
- *       operations are protected by an internal mutex and thread-safe.
- */
-class data_batch : public std::enable_shared_from_this<data_batch> {
- public:
-  /**
-   * @brief Construct a new data_batch with the given ID and data representation.
+   * Lock-free -- safe to call without acquiring an accessor.
    *
-   * @param batch_id Unique identifier for this batch
-   * @param data Ownership of the data representation is transferred to this batch
-   * @param probe @copydoc idata_batch_probe
-   */
-  data_batch(uint64_t batch_id,
-             std::unique_ptr<idata_representation> data,
-             std::unique_ptr<idata_batch_probe> probe = std::make_unique<idata_batch_probe>());
-
-  /**
-   * @brief Move constructor - transfers ownership of the batch and its data.
-   *
-   * Moves the batch_id and data from the other batch, then resets the other batch's
-   * batch_id to 0 and data pointer to nullptr.
-   *
-   * @param other The batch to move from (will have batch_id set to 0 and data set to nullptr)
-   * @throws std::runtime_error if the source batch has active processing (processing_count != 0)
-   */
-  data_batch(data_batch&& other);
-
-  /**
-   * @brief Move assignment operator - transfers ownership of the batch and its data.
-   *
-   * Performs self-assignment check, then moves the batch_id and data from the other batch.
-   * Resets the other batch's batch_id to 0 and data pointer to nullptr.
-   *
-   * @param other The batch to move from (will have batch_id set to 0 and data set to nullptr)
-   * @return data_batch& Reference to this batch
-   * @throws std::runtime_error if the source batch has active processing (processing_count != 0)
-   */
-  data_batch& operator=(data_batch&& other);
-
-  /**
-   * @brief Get the current memory tier where this batch's data resides.
-   *
-   * @return Tier The memory tier (GPU, HOST, or STORAGE)
-   */
-  memory::Tier get_current_tier() const;
-
-  /**
-   * @brief Get the unique identifier for this data batch.
-   *
-   * @return uint64_t The batch ID assigned during construction
+   * @return The batch ID (immutable after construction).
    */
   uint64_t get_batch_id() const;
 
   /**
-   * @brief Get the current state of this batch.
+   * @brief Increment the subscriber interest count.
    *
-   * @return batch_state The current state (idle, task_created, processing, or in_transit)
+   * Atomic, lock-free. Returns true on the first subscription (0 -> 1).
+   *
+   * @return true if this was the first subscriber, false otherwise.
    */
-  batch_state get_state() const;
+  bool subscribe();
 
   /**
-   * @brief Get the current processing count (mutex-protected).
+   * @brief Decrement the subscriber interest count.
    *
-   * @return size_t The number of active processing handles
+   * Atomic, lock-free.
+   *
+   * @throws std::runtime_error if subscriber count is already zero.
    */
-  size_t get_processing_count() const;
+  void unsubscribe();
 
   /**
-   * @brief Get the underlying data representation.
+   * @brief Get the current subscriber count.
    *
-   * Returns a pointer to the idata_representation that holds the actual data.
-   * This allows access to tier-specific operations and data access methods.
+   * Atomic, lock-free.
    *
-   * @return idata_representation* Pointer to the data representation (non-owning)
+   * @return The number of active subscribers.
+   */
+  size_t get_subscriber_count() const;
+
+  // -- Static transition methods (D-13/D-14/D-15/D-17) --
+  // All transitions go through idle -- no locked-to-locked shortcuts.
+
+  /**
+   * @brief Transition from idle to read-only (shared lock).
+   *
+   * Blocks until the shared lock is acquired. The source pointer is
+   * moved-from and becomes null.
+   *
+   * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
+   * @param batch Rvalue reference to the idle batch pointer (moved-from).
+   * @return A read_only_data_batch holding the shared lock.
+   */
+  template <typename PtrType>
+  [[nodiscard]] static read_only_data_batch<PtrType> to_read_only(PtrType&& batch);
+
+  /**
+   * @brief Transition from idle to mutable (exclusive lock).
+   *
+   * Blocks until the exclusive lock is acquired. The source pointer is
+   * moved-from and becomes null.
+   *
+   * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
+   * @param batch Rvalue reference to the idle batch pointer (moved-from).
+   * @return A mutable_data_batch holding the exclusive lock.
+   */
+  template <typename PtrType>
+  [[nodiscard]] static mutable_data_batch<PtrType> to_mutable(PtrType&& batch);
+
+  /**
+   * @brief Transition from read-only back to idle (release shared lock).
+   *
+   * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
+   * @param accessor Rvalue reference to the read-only accessor (consumed).
+   * @return The batch pointer, now in idle state.
+   */
+  template <typename PtrType>
+  [[nodiscard]] static PtrType to_idle(read_only_data_batch<PtrType>&& accessor);
+
+  /**
+   * @brief Transition from mutable back to idle (release exclusive lock).
+   *
+   * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
+   * @param accessor Rvalue reference to the mutable accessor (consumed).
+   * @return The batch pointer, now in idle state.
+   */
+  template <typename PtrType>
+  [[nodiscard]] static PtrType to_idle(mutable_data_batch<PtrType>&& accessor);
+
+  /**
+   * @brief Try to transition from idle to read-only (non-blocking).
+   *
+   * Attempts to acquire the shared lock without blocking. On success, the
+   * source pointer is nullified. On failure, the source pointer is unchanged.
+   *
+   * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
+   * @param batch Mutable lvalue reference to the idle batch pointer.
+   * @return An optional containing the read-only accessor on success, or
+   *         std::nullopt if the lock could not be acquired immediately.
+   */
+  template <typename PtrType>
+  [[nodiscard]] static std::optional<read_only_data_batch<PtrType>> try_to_read_only(
+    PtrType& batch);
+
+  /**
+   * @brief Try to transition from idle to mutable (non-blocking).
+   *
+   * Attempts to acquire the exclusive lock without blocking. On success, the
+   * source pointer is nullified. On failure, the source pointer is unchanged.
+   *
+   * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
+   * @param batch Mutable lvalue reference to the idle batch pointer.
+   * @return An optional containing the mutable accessor on success, or
+   *         std::nullopt if the lock could not be acquired immediately.
+   */
+  template <typename PtrType>
+  [[nodiscard]] static std::optional<mutable_data_batch<PtrType>> try_to_mutable(PtrType& batch);
+
+ private:
+  // -- Friend declarations (D-24/REPO-04) --
+  template <typename PtrType>
+  friend class read_only_data_batch;
+  template <typename PtrType>
+  friend class mutable_data_batch;
+
+  // -- Private data accessors (D-23/CORE-02) --
+  // Only friend accessor classes can call these methods.
+
+  /**
+   * @brief Get the memory tier of the held data.
+   * @return The current memory tier.
+   */
+  memory::Tier get_current_tier() const;
+
+  /**
+   * @brief Get a raw pointer to the data representation.
+   * @return Non-owning pointer to the data, or nullptr if empty.
    */
   idata_representation* get_data() const;
 
   /**
-   * @brief Get the memory_space where this batch currently resides.
-   *
-   * Delegates to the underlying idata_representation to determine the memory space.
-   *
-   * @return cucascade::memory::memory_space* Pointer to the memory space
+   * @brief Get a raw pointer to the memory space.
+   * @return Non-owning pointer to the memory space, or nullptr if data is null.
    */
-  cucascade::memory::memory_space* get_memory_space() const;
+  memory::memory_space* get_memory_space() const;
 
   /**
-   * @brief Set a condition variable to be notified on state changes.
-   *
-   * The CV is notified outside of the batch mutex.
-   */
-  void set_state_change_cv(std::condition_variable* cv);
-
-  /**
-   * @brief Blocking call: wait until the batch can accept a new task, then create it.
-   *
-   * Blocks until the batch leaves in_transit state, then performs the same transition
-   * as try_to_create_task(). Always succeeds when it returns.
-   */
-  void wait_to_create_task();
-
-  /**
-   * @brief Blocking call: wait until a created task can be cancelled, then cancel it.
-   *
-   * Blocks until the batch is in task_created or processing state, then performs
-   * the same transition as try_to_cancel_task(). Always succeeds when it returns.
-   */
-  void wait_to_cancel_task();
-
-  /**
-   * @brief Blocking call: wait until the batch can be locked for processing, then lock it.
-   *
-   * Blocks until the batch is in task_created or processing state with a pending
-   * task_created_count. Non-waitable failures (missing_data, memory_space_mismatch)
-   * are returned immediately with the appropriate status.
-   *
-   * @param requested_memory_space The memory space the caller expects to process from.
-   * @return lock_for_processing_result success=true with handle on success; success=false
-   *         with status describing non-waitable failure.
-   */
-  lock_for_processing_result wait_to_lock_for_processing(
-    memory::memory_space_id requested_memory_space);
-
-  /**
-   * @brief Blocking call: wait until the batch can be locked for in-transit, then lock it.
-   *
-   * Blocks until processing_count == 0 and the batch is in idle or task_created state,
-   * then performs the same transition as try_to_lock_for_in_transit(). Always succeeds
-   * when it returns.
-   */
-  void wait_to_lock_for_in_transit();
-
-  /**
-   * @brief Blocking call: wait until the batch is in in_transit state, then release it.
-   *
-   * Blocks until the batch is in in_transit state, then performs the same transition
-   * as try_to_release_in_transit(). Always succeeds when it returns.
-   *
-   * @param target_state Optional state to transition to when releasing in_transit. If not set,
-   *        the batch returns to idle.
-   */
-  void wait_to_release_in_transit(std::optional<batch_state> target_state = std::nullopt);
-  /**
-   * @brief Replace the underlying data representation.
-   *        Requires no active processing.
+   * @brief Replace the data representation.
+   * @param data New data representation (takes ownership).
    */
   void set_data(std::unique_ptr<idata_representation> data);
 
   /**
-   * @brief Convert the underlying representation to the target representation type.
-   *        Requires no active processing.
+   * @brief Convert the data representation in-place.
    *
-   * Uses the provided representation_converter_registry to look up the appropriate converter
-   * from the current representation type to the target type.
-   *
-   * @tparam TargetRepresentation The target idata_representation type to convert to
-   * @param registry The converter registry to use for looking up converters
-   * @param target_memory_space The memory space where the new representation will be allocated
-   * @param stream CUDA stream for memory operations
-   * @throws std::runtime_error if no converter is registered for the type pair
-   * @throws std::runtime_error if there is active processing on this batch
+   * @tparam TargetRepresentation Target representation type.
+   * @param registry   Converter registry for type-keyed dispatch.
+   * @param target_memory_space Target memory space for the new representation.
+   * @param stream     CUDA stream for memory operations.
    */
   template <typename TargetRepresentation>
   void convert_to(representation_converter_registry& registry,
-                  const cucascade::memory::memory_space* target_memory_space,
+                  const memory::memory_space* target_memory_space,
                   rmm::cuda_stream_view stream);
 
-  /**
-   * @brief Clones the underlying representation and returns a new data_batch with the cloned data.
-   *        Requires no active processing.
-   *
-   * @param new_batch_id The batch ID for the cloned batch
-   * @param target_memory_space The memory space where the new representation will be allocated
-   * @param stream CUDA stream for memory operations
-   * @param probe Optional @copydoc idata_batch_probe
-   * @return std::shared_ptr<data_batch> A new data_batch with cloned data
-   * @throws std::runtime_error if there is active processing on this batch
-   */
-  template <typename TargetRepresentation>
-  std::shared_ptr<data_batch> clone_to(
-    representation_converter_registry& registry,
-    uint64_t new_batch_id,
-    const cucascade::memory::memory_space* target_memory_space,
-    rmm::cuda_stream_view stream,
-    std::optional<std::unique_ptr<idata_batch_probe>> probe = std::nullopt);
-
-  /**
-   * @brief Attempt to create a task for this batch.
-   *
-   * Transitions the batch from idle to task_created state and increments task_created_counter.
-   * If the batch is already in task_created state, only increments task_created_counter.
-   * If the batch is in processing state, increments task_created_counter but stays in processing.
-   * This must be called before try_to_lock_for_processing().
-   *
-   * @return true if the batch is in idle, task_created, or processing state
-   * @return false if the batch is in in_transit state
-   */
-  bool try_to_create_task();
-
-  /**
-   * @brief Get the current task_created counter (mutex-protected).
-   *
-   * This counter tracks how many task_created requests are pending for this batch.
-   * It is incremented by try_to_create_task() and decremented by try_to_lock_for_processing().
-   *
-   * @return size_t The number of pending task_created requests
-   */
-  size_t get_task_created_count() const;
-
-  /**
-   * @brief Cancel a created task and return to idle state.
-   *
-   * Transitions the batch from task_created back to idle state.
-   *
-   * @return true if the batch was successfully transitioned to idle
-   * @return false if the batch is not in task_created state
-   */
-  bool try_to_cancel_task();
-
-  /**
-   * @brief Attempt to lock this batch for processing operations.
-   *
-   * Returns a processing handle if the batch is in task_created state or already processing.
-   * If successful, decrements task_created_counter, increments processing count,
-   * and transitions to processing state (if not already processing).
-   *
-   * @param requested_memory_space The memory space the caller expects to process from. If the
-   *        batch is not currently in this space, locking fails with
-   *        lock_for_processing_status::memory_space_mismatch.
-   *
-   * @return lock_for_processing_result success=true with handle on success; success=false otherwise
-   *         with a status describing the failure.
-   * @throws std::runtime_error if task_created_count is zero (try_to_create_task() must be
-   *         called before this method) while in a lockable state.
-   */
-  lock_for_processing_result try_to_lock_for_processing(
-    memory::memory_space_id requested_memory_space);
-
-  /**
-   * @brief Attempt to lock this batch for in-transit operations (e.g., downgrade).
-   *
-   * Transitions the batch from idle to in_transit state.
-   *
-   * @return true if the batch was successfully locked (processing_count == 0 and state is idle)
-   * @return false if the batch could not be locked
-   */
-  bool try_to_lock_for_in_transit();
-
-  /**
-   * @brief Release the in-transit lock and return to idle state.
-   *
-   * Transitions the batch from in_transit back to idle state.
-   *
-   * @return true if the batch was successfully transitioned to idle
-   * @return false if the batch is not in in_transit state
-   *
-   * @param target_state Optional state to transition to when releasing in_transit. If not set,
-   *        the batch returns to idle.
-   */
-  bool try_to_release_in_transit(std::optional<batch_state> target_state = std::nullopt);
-
-  /**
-   * @brief Create a deep copy of this data batch.
-   *
-   * Creates a new data_batch with the specified batch_id and a cloned copy of
-   * the underlying data representation. The new batch will be in idle state with
-   * no active processing.
-   *
-   * During the clone operation, the processing count is incremented to protect
-   * the data from eviction, and decremented after the clone completes.
-   *
-   * @param new_batch_id The batch ID for the cloned batch
-   * @param stream CUDA stream for memory operations
-   * @param probe Optional @copydoc idata_batch_probe
-   * @return std::shared_ptr<data_batch> A new data_batch with copied data
-   * @throws std::runtime_error if the batch is in in_transit state
-   * @throws std::runtime_error if the underlying data is null
-   */
-  std::shared_ptr<data_batch> clone(
-    uint64_t new_batch_id,
-    rmm::cuda_stream_view stream,
-    std::optional<std::unique_ptr<idata_batch_probe>> probe = std::nullopt);
-
- private:
-  friend class data_batch_processing_handle;
-
-  /**
-   * @brief Decrement processing count and potentially transition state.
-   *
-   * Called by data_batch_processing_handle when it goes out of scope.
-   * If processing count drops to zero, transitions from processing to idle.
-   */
-  void decrement_processing_count();
-
-  /**
-   * @brief Handle a state transition by updating _state and invoking the probe callback.
-   *
-   * Must be called while the caller holds _mutex. Passes all member fields except _mutex
-   * and _state_change_cv in immutable forms to the probe callback.
-   *
-   * @param new_state The state to transition to
-   * @param lock Reference to the lock proving the mutex is held
-   */
-  void update_state_to(batch_state new_state, const std::unique_lock<std::mutex>& lock);
-
-  mutable std::mutex _mutex;  ///< Mutex for thread-safe access to state and processing count
-  std::condition_variable _internal_cv;            ///< CV used by blocking wait_to_* calls
-  uint64_t _batch_id;                              ///< Unique identifier for this data batch
-  std::unique_ptr<idata_representation> _data;     ///< Pointer to the actual data representation
-  size_t _processing_count   = 0;                  ///< Count of active processing handles
-  size_t _task_created_count = 0;                  ///< Count of pending task_created requests
-  batch_state _state         = batch_state::idle;  ///< Current state of the batch
-  std::unique_ptr<idata_batch_probe> _probe;       ///< Probe for observing state transitions
-  std::condition_variable* _state_change_cv = nullptr;  ///< Optional CV to notify on state change
+  // -- Members --
+  const uint64_t _batch_id;                     ///< Immutable batch identifier
+  std::unique_ptr<idata_representation> _data;  ///< Owned data representation
+  mutable std::shared_mutex _rw_mutex;          ///< Reader-writer mutex
+  std::atomic<size_t> _subscriber_count{0};     ///< Atomic subscriber interest count
 };
 
-// Template implementation
-template <typename TargetRepresentation>
-void data_batch::convert_to(representation_converter_registry& registry,
-                            const cucascade::memory::memory_space* target_memory_space,
-                            rmm::cuda_stream_view stream)
-{
-  std::unique_lock<std::mutex> lock(_mutex);
+/**
+ * @brief RAII read-only accessor for data_batch.
+ *
+ * Holds a shared lock on the parent data_batch's mutex, permitting concurrent
+ * readers. Data is accessible through named methods that delegate to data_batch's
+ * private interface. Clone operations are available to create independent copies
+ * while the read lock is held.
+ *
+ * Move-only. The shared lock is released when this object is destroyed or moved-from.
+ *
+ * @tparam PtrType Smart pointer type (std::shared_ptr<data_batch> or
+ *         std::unique_ptr<data_batch>).
+ */
+template <typename PtrType>
+class read_only_data_batch {
+ public:
+  // -- Named accessor methods (D-09/ACC-01) --
 
-  if (_processing_count != 0) {
-    throw std::runtime_error("Cannot convert representation while there is active processing");
+  /** @brief Get the batch identifier. */
+  uint64_t get_batch_id() const { return _batch->get_batch_id(); }
+
+  /** @brief Get the memory tier of the held data. */
+  memory::Tier get_current_tier() const { return _batch->get_current_tier(); }
+
+  /** @brief Get a raw pointer to the data representation. */
+  idata_representation* get_data() const { return _batch->get_data(); }
+
+  /** @brief Get a raw pointer to the memory space. */
+  memory::memory_space* get_memory_space() const { return _batch->get_memory_space(); }
+
+  // -- Clone operations (D-18/D-19/D-20/CLONE-01/CLONE-02) --
+
+  /**
+   * @brief Create an independent deep copy of the batch data.
+   *
+   * The clone has a new batch ID and its own copy of the data representation,
+   * residing in the same memory space as the original.
+   *
+   * @param new_batch_id Batch ID for the cloned batch.
+   * @param stream       CUDA stream for memory operations.
+   * @return A new data_batch wrapped in PtrType.
+   * @throws std::runtime_error if the data is null.
+   */
+  [[nodiscard]] PtrType clone(uint64_t new_batch_id, rmm::cuda_stream_view stream) const;
+
+  /**
+   * @brief Create an independent deep copy with representation conversion.
+   *
+   * The clone has a new batch ID and its data is converted to TargetRepresentation
+   * using the provided converter registry.
+   *
+   * @tparam TargetRepresentation Target representation type.
+   * @param registry           Converter registry for type-keyed dispatch.
+   * @param new_batch_id       Batch ID for the cloned batch.
+   * @param target_memory_space Target memory space for the converted data.
+   * @param stream              CUDA stream for memory operations.
+   * @return A new data_batch wrapped in PtrType.
+   */
+  template <typename TargetRepresentation>
+  [[nodiscard]] PtrType clone_to(representation_converter_registry& registry,
+                                 uint64_t new_batch_id,
+                                 const memory::memory_space* target_memory_space,
+                                 rmm::cuda_stream_view stream) const;
+
+  // -- Move-only (D-12/ACC-05/ACC-06) --
+  read_only_data_batch(read_only_data_batch&&) noexcept            = default;
+  read_only_data_batch& operator=(read_only_data_batch&&) noexcept = default;
+  read_only_data_batch(const read_only_data_batch&)                = delete;
+  read_only_data_batch& operator=(const read_only_data_batch&)     = delete;
+
+ private:
+  friend class data_batch;
+
+  /**
+   * @brief Private constructor -- only data_batch static methods can create instances.
+   *
+   * @param parent Smart pointer to the parent data_batch (moved in).
+   * @param lock   Shared lock already acquired on the parent's mutex.
+   */
+  read_only_data_batch(PtrType parent, std::shared_lock<std::shared_mutex> lock);
+
+  // INVARIANT: _batch must be declared before _lock -- destruction order is load-bearing.
+  // When destroyed, _lock releases the shared lock first, then _batch drops the parent
+  // reference. This prevents accessing a destroyed mutex.
+  PtrType _batch;                             ///< Parent lifetime (destroyed second)
+  std::shared_lock<std::shared_mutex> _lock;  ///< Shared lock (destroyed first)
+};
+
+/**
+ * @brief RAII mutable accessor for data_batch.
+ *
+ * Holds an exclusive lock on the parent data_batch's mutex, permitting a single
+ * writer with no concurrent readers. Provides all read methods plus write methods
+ * (set_data, convert_to) that delegate to data_batch's private interface.
+ *
+ * Move-only. The exclusive lock is released when this object is destroyed or moved-from.
+ *
+ * @tparam PtrType Smart pointer type (std::shared_ptr<data_batch> or
+ *         std::unique_ptr<data_batch>).
+ */
+template <typename PtrType>
+class mutable_data_batch {
+ public:
+  // -- Read methods (same as read_only, ACC-02) --
+
+  /** @brief Get the batch identifier. */
+  uint64_t get_batch_id() const { return _batch->get_batch_id(); }
+
+  /** @brief Get the memory tier of the held data. */
+  memory::Tier get_current_tier() const { return _batch->get_current_tier(); }
+
+  /** @brief Get a raw pointer to the data representation. */
+  idata_representation* get_data() const { return _batch->get_data(); }
+
+  /** @brief Get a raw pointer to the memory space. */
+  memory::memory_space* get_memory_space() const { return _batch->get_memory_space(); }
+
+  // -- Write methods (D-10/ACC-02) --
+
+  /**
+   * @brief Replace the data representation.
+   * @param data New data representation (takes ownership).
+   */
+  void set_data(std::unique_ptr<idata_representation> data) { _batch->set_data(std::move(data)); }
+
+  /**
+   * @brief Convert the data representation in-place.
+   *
+   * @tparam TargetRepresentation Target representation type.
+   * @param registry           Converter registry for type-keyed dispatch.
+   * @param target_memory_space Target memory space for the new representation.
+   * @param stream              CUDA stream for memory operations.
+   */
+  template <typename TargetRepresentation>
+  void convert_to(representation_converter_registry& registry,
+                  const memory::memory_space* target_memory_space,
+                  rmm::cuda_stream_view stream)
+  {
+    _batch->template convert_to<TargetRepresentation>(registry, target_memory_space, stream);
   }
 
+  // -- Move-only (D-12/ACC-05/ACC-06) --
+  mutable_data_batch(mutable_data_batch&&) noexcept            = default;
+  mutable_data_batch& operator=(mutable_data_batch&&) noexcept = default;
+  mutable_data_batch(const mutable_data_batch&)                = delete;
+  mutable_data_batch& operator=(const mutable_data_batch&)     = delete;
+
+ private:
+  friend class data_batch;
+
+  /**
+   * @brief Private constructor -- only data_batch static methods can create instances.
+   *
+   * @param parent Smart pointer to the parent data_batch (moved in).
+   * @param lock   Exclusive lock already acquired on the parent's mutex.
+   */
+  mutable_data_batch(PtrType parent, std::unique_lock<std::shared_mutex> lock);
+
+  // INVARIANT: _batch must be declared before _lock -- destruction order is load-bearing.
+  // When destroyed, _lock releases the exclusive lock first, then _batch drops the parent
+  // reference. This prevents accessing a destroyed mutex.
+  PtrType _batch;                             ///< Parent lifetime (destroyed second)
+  std::unique_lock<std::shared_mutex> _lock;  ///< Exclusive lock (destroyed first)
+};
+
+// =============================================================================
+// Template implementations
+// =============================================================================
+
+// -- data_batch::convert_to --
+
+template <typename TargetRepresentation>
+void data_batch::convert_to(representation_converter_registry& registry,
+                            const memory::memory_space* target_memory_space,
+                            rmm::cuda_stream_view stream)
+{
   auto new_representation =
     registry.convert<TargetRepresentation>(*_data, target_memory_space, stream);
   auto old_representation = std::move(_data);
@@ -557,26 +447,115 @@ void data_batch::convert_to(representation_converter_registry& registry,
   }
 }
 
-template <typename TargetRepresentation>
-std::shared_ptr<data_batch> data_batch::clone_to(
-  representation_converter_registry& registry,
-  uint64_t new_batch_id,
-  const cucascade::memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view stream,
-  std::optional<std::unique_ptr<idata_batch_probe>> probe)
+// -- data_batch::to_read_only (idle -> shared lock, TRANS-01) --
+
+template <typename PtrType>
+read_only_data_batch<PtrType> data_batch::to_read_only(PtrType&& batch)
 {
-  std::lock_guard<std::mutex> lock(_mutex);
+  auto ptr = std::move(batch);
+  std::shared_lock<std::shared_mutex> lock(ptr->_rw_mutex);
+  return read_only_data_batch<PtrType>(std::move(ptr), std::move(lock));
+}
 
-  if (_processing_count != 0) {
-    throw std::runtime_error("Cannot convert representation while there is active processing");
+// -- data_batch::to_mutable (idle -> exclusive lock, TRANS-02) --
+
+template <typename PtrType>
+mutable_data_batch<PtrType> data_batch::to_mutable(PtrType&& batch)
+{
+  auto ptr = std::move(batch);
+  std::unique_lock<std::shared_mutex> lock(ptr->_rw_mutex);
+  return mutable_data_batch<PtrType>(std::move(ptr), std::move(lock));
+}
+
+// -- data_batch::to_idle (release shared lock, TRANS-03) --
+
+template <typename PtrType>
+PtrType data_batch::to_idle(read_only_data_batch<PtrType>&& accessor)
+{
+  auto ptr = std::move(accessor._batch);
+  accessor._lock.unlock();
+  return ptr;
+}
+
+// -- data_batch::to_idle (release exclusive lock, TRANS-04) --
+
+template <typename PtrType>
+PtrType data_batch::to_idle(mutable_data_batch<PtrType>&& accessor)
+{
+  auto ptr = std::move(accessor._batch);
+  accessor._lock.unlock();
+  return ptr;
+}
+
+// -- data_batch::try_to_read_only (non-blocking, TRANS-05) --
+
+template <typename PtrType>
+std::optional<read_only_data_batch<PtrType>> data_batch::try_to_read_only(PtrType& batch)
+{
+  std::shared_lock<std::shared_mutex> lock(batch->_rw_mutex, std::try_to_lock);
+  if (!lock.owns_lock()) { return std::nullopt; }
+  auto ptr = std::move(batch);
+  return read_only_data_batch<PtrType>(std::move(ptr), std::move(lock));
+}
+
+// -- data_batch::try_to_mutable (non-blocking, TRANS-06) --
+
+template <typename PtrType>
+std::optional<mutable_data_batch<PtrType>> data_batch::try_to_mutable(PtrType& batch)
+{
+  std::unique_lock<std::shared_mutex> lock(batch->_rw_mutex, std::try_to_lock);
+  if (!lock.owns_lock()) { return std::nullopt; }
+  auto ptr = std::move(batch);
+  return mutable_data_batch<PtrType>(std::move(ptr), std::move(lock));
+}
+
+// -- read_only_data_batch::clone (deep copy, CLONE-01) --
+
+template <typename PtrType>
+PtrType read_only_data_batch<PtrType>::clone(uint64_t new_batch_id,
+                                             rmm::cuda_stream_view stream) const
+{
+  if (_batch->_data == nullptr) { throw std::runtime_error("Cannot clone: data is null"); }
+  auto cloned_data = _batch->_data->clone(stream);
+  if constexpr (std::is_same_v<PtrType, std::shared_ptr<data_batch>>) {
+    return std::make_shared<data_batch>(new_batch_id, std::move(cloned_data));
+  } else {
+    return std::make_unique<data_batch>(new_batch_id, std::move(cloned_data));
   }
+}
 
+// -- read_only_data_batch::clone_to (deep copy + conversion, CLONE-02) --
+
+template <typename PtrType>
+template <typename TargetRepresentation>
+PtrType read_only_data_batch<PtrType>::clone_to(representation_converter_registry& registry,
+                                                uint64_t new_batch_id,
+                                                const memory::memory_space* target_memory_space,
+                                                rmm::cuda_stream_view stream) const
+{
   auto new_representation =
-    registry.convert<TargetRepresentation>(*_data, target_memory_space, stream);
-  return std::make_shared<data_batch>(
-    new_batch_id,
-    std::move(new_representation),
-    probe ? std::move(*probe) : std::make_unique<idata_batch_probe>());
+    registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
+  if constexpr (std::is_same_v<PtrType, std::shared_ptr<data_batch>>) {
+    return std::make_shared<data_batch>(new_batch_id, std::move(new_representation));
+  } else {
+    return std::make_unique<data_batch>(new_batch_id, std::move(new_representation));
+  }
+}
+
+// -- Accessor private constructors --
+
+template <typename PtrType>
+read_only_data_batch<PtrType>::read_only_data_batch(PtrType parent,
+                                                    std::shared_lock<std::shared_mutex> lock)
+  : _batch(std::move(parent)), _lock(std::move(lock))
+{
+}
+
+template <typename PtrType>
+mutable_data_batch<PtrType>::mutable_data_batch(PtrType parent,
+                                                std::unique_lock<std::shared_mutex> lock)
+  : _batch(std::move(parent)), _lock(std::move(lock))
+{
 }
 
 }  // namespace cucascade

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -28,7 +28,6 @@
 #include <optional>
 #include <shared_mutex>
 #include <stdexcept>
-#include <type_traits>
 #include <utility>
 
 namespace cucascade {
@@ -49,9 +48,7 @@ namespace cucascade {
 enum class batch_state { idle, read_only, mutable_locked };
 
 // Forward declarations -- required before data_batch because it friends them.
-template <typename PtrType>
 class read_only_data_batch;
-template <typename PtrType>
 class mutable_data_batch;
 
 /**
@@ -61,10 +58,9 @@ class mutable_data_batch;
  * Almost nothing is publicly accessible -- data, tier, and memory space are private
  * and can only be reached through RAII accessor types that hold the appropriate lock.
  *
- * State transitions are static template methods that move ownership of the smart
- * pointer (PtrType) into an accessor, making the source pointer null at the call
- * site. This provides compile-time enforcement: once a batch is locked, the caller
- * cannot access the idle handle.
+ * State transitions are static methods that move ownership of the accessor,
+ * making the source null at the call site. This provides compile-time enforcement:
+ * once a batch is locked, the caller cannot access the idle handle.
  *
  * @note Non-copyable and non-movable. The object itself never moves; only the
  *       smart pointer to it is transferred between states.
@@ -143,24 +139,20 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
   /**
    * @brief Transition from read-only back to idle (release shared lock).
    *
-   * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
    * @param accessor Rvalue reference to the read-only accessor (consumed).
    * @return The batch pointer, now in idle state.
    */
-  template <typename PtrType>
-  [[nodiscard]] static PtrType to_idle(read_only_data_batch<PtrType>&& accessor);
+  [[nodiscard]] static std::shared_ptr<data_batch> to_idle(read_only_data_batch&& accessor);
 
   /**
    * @brief Transition from mutable back to idle (release exclusive lock).
    *
-   * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
    * @param accessor Rvalue reference to the mutable accessor (consumed).
    * @return The batch pointer, now in idle state.
    */
-  template <typename PtrType>
-  [[nodiscard]] static PtrType to_idle(mutable_data_batch<PtrType>&& accessor);
+  [[nodiscard]] static std::shared_ptr<data_batch> to_idle(mutable_data_batch&& accessor);
 
-  // -- Non-static transitions (shared_ptr only, via shared_from_this) --
+  // -- Non-static transitions (via shared_from_this) --
   // The caller's shared_ptr is NOT consumed. These only work when the
   // data_batch is managed by a shared_ptr (throws bad_weak_ptr otherwise).
 
@@ -172,7 +164,7 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
    *
    * @return A read_only_data_batch holding the shared lock.
    */
-  [[nodiscard]] read_only_data_batch<std::shared_ptr<data_batch>> to_read_only();
+  [[nodiscard]] read_only_data_batch to_read_only();
 
   /**
    * @brief Transition from idle to mutable (exclusive lock) without consuming the caller's pointer.
@@ -182,23 +174,23 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
    *
    * @return A mutable_data_batch holding the exclusive lock.
    */
-  [[nodiscard]] mutable_data_batch<std::shared_ptr<data_batch>> to_mutable();
+  [[nodiscard]] mutable_data_batch to_mutable();
 
   /**
-   * @brief Try to transition from idle to read-only (non-blocking, shared_ptr only).
+   * @brief Try to transition from idle to read-only (non-blocking).
    *
    * @return An optional containing the read-only accessor on success, or
    *         std::nullopt if the lock could not be acquired immediately.
    */
-  [[nodiscard]] std::optional<read_only_data_batch<std::shared_ptr<data_batch>>> try_to_read_only();
+  [[nodiscard]] std::optional<read_only_data_batch> try_to_read_only();
 
   /**
-   * @brief Try to transition from idle to mutable (non-blocking, shared_ptr only).
+   * @brief Try to transition from idle to mutable (non-blocking).
    *
    * @return An optional containing the mutable accessor on success, or
    *         std::nullopt if the lock could not be acquired immediately.
    */
-  [[nodiscard]] std::optional<mutable_data_batch<std::shared_ptr<data_batch>>> try_to_mutable();
+  [[nodiscard]] std::optional<mutable_data_batch> try_to_mutable();
 
   // -- Locked-to-locked static transitions --
 
@@ -208,13 +200,10 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
    * Releases the shared lock, then acquires an exclusive lock (may block).
    * The source accessor is consumed via move.
    *
-   * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
    * @param accessor Rvalue reference to the read-only accessor (consumed).
    * @return A mutable_data_batch holding the exclusive lock.
    */
-  template <typename PtrType>
-  [[nodiscard]] static mutable_data_batch<PtrType> readonly_to_mutable(
-    read_only_data_batch<PtrType>&& accessor);
+  [[nodiscard]] static mutable_data_batch readonly_to_mutable(read_only_data_batch&& accessor);
 
   /**
    * @brief Transition from mutable to read-only (downgrade lock).
@@ -222,19 +211,14 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
    * Releases the exclusive lock, then acquires a shared lock (may block).
    * The source accessor is consumed via move.
    *
-   * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
    * @param accessor Rvalue reference to the mutable accessor (consumed).
    * @return A read_only_data_batch holding the shared lock.
    */
-  template <typename PtrType>
-  [[nodiscard]] static read_only_data_batch<PtrType> mutable_to_readonly(
-    mutable_data_batch<PtrType>&& accessor);
+  [[nodiscard]] static read_only_data_batch mutable_to_readonly(mutable_data_batch&& accessor);
 
  private:
   // -- Friend declarations (D-24/REPO-04) --
-  template <typename PtrType>
   friend class read_only_data_batch;
-  template <typename PtrType>
   friend class mutable_data_batch;
 
   // -- Private data accessors (D-23/CORE-02) --
@@ -281,11 +265,7 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
  * while the read lock is held.
  *
  * Move-only. The shared lock is released when this object is destroyed or moved-from.
- *
- * @tparam PtrType Smart pointer type (std::shared_ptr<data_batch> or
- *         std::unique_ptr<data_batch>).
  */
-template <typename PtrType>
 class read_only_data_batch {
  public:
   // -- Named accessor methods (D-09/ACC-01) --
@@ -312,10 +292,11 @@ class read_only_data_batch {
    *
    * @param new_batch_id Batch ID for the cloned batch.
    * @param stream       CUDA stream for memory operations.
-   * @return A new data_batch wrapped in PtrType.
+   * @return A new data_batch wrapped in shared_ptr.
    * @throws std::runtime_error if the data is null.
    */
-  [[nodiscard]] PtrType clone(uint64_t new_batch_id, rmm::cuda_stream_view stream) const;
+  [[nodiscard]] std::shared_ptr<data_batch> clone(uint64_t new_batch_id,
+                                                  rmm::cuda_stream_view stream) const;
 
   /**
    * @brief Create an independent deep copy with representation conversion.
@@ -328,13 +309,14 @@ class read_only_data_batch {
    * @param new_batch_id       Batch ID for the cloned batch.
    * @param target_memory_space Target memory space for the converted data.
    * @param stream              CUDA stream for memory operations.
-   * @return A new data_batch wrapped in PtrType.
+   * @return A new data_batch wrapped in shared_ptr.
    */
   template <typename TargetRepresentation>
-  [[nodiscard]] PtrType clone_to(representation_converter_registry& registry,
-                                 uint64_t new_batch_id,
-                                 const memory::memory_space* target_memory_space,
-                                 rmm::cuda_stream_view stream) const;
+  [[nodiscard]] std::shared_ptr<data_batch> clone_to(
+    representation_converter_registry& registry,
+    uint64_t new_batch_id,
+    const memory::memory_space* target_memory_space,
+    rmm::cuda_stream_view stream) const;
 
   // -- Move-only (D-12/ACC-05/ACC-06) --
   read_only_data_batch(read_only_data_batch&&) noexcept            = default;
@@ -346,18 +328,19 @@ class read_only_data_batch {
   friend class data_batch;
 
   /**
-   * @brief Private constructor -- only data_batch static methods can create instances.
+   * @brief Private constructor -- only data_batch methods can create instances.
    *
-   * @param parent Smart pointer to the parent data_batch (moved in).
+   * @param parent Shared pointer to the parent data_batch (moved in).
    * @param lock   Shared lock already acquired on the parent's mutex.
    */
-  read_only_data_batch(PtrType parent, std::shared_lock<std::shared_mutex> lock);
+  read_only_data_batch(std::shared_ptr<data_batch> parent,
+                       std::shared_lock<std::shared_mutex> lock);
 
   // INVARIANT: _batch must be declared before _lock -- destruction order is load-bearing.
   // When destroyed, _lock releases the shared lock first, then _batch drops the parent
   // reference. This prevents accessing a destroyed mutex.
-  PtrType _batch;                             ///< Parent lifetime (destroyed second)
-  std::shared_lock<std::shared_mutex> _lock;  ///< Shared lock (destroyed first)
+  std::shared_ptr<data_batch> _batch;           ///< Parent lifetime (destroyed second)
+  std::shared_lock<std::shared_mutex> _lock;    ///< Shared lock (destroyed first)
 };
 
 /**
@@ -368,11 +351,7 @@ class read_only_data_batch {
  * (set_data, convert_to) and clone operations (clone, clone_to).
  *
  * Move-only. The exclusive lock is released when this object is destroyed or moved-from.
- *
- * @tparam PtrType Smart pointer type (std::shared_ptr<data_batch> or
- *         std::unique_ptr<data_batch>).
  */
-template <typename PtrType>
 class mutable_data_batch {
  public:
   // -- Read methods (same as read_only, ACC-02) --
@@ -424,10 +403,11 @@ class mutable_data_batch {
    *
    * @param new_batch_id Batch ID for the cloned batch.
    * @param stream       CUDA stream for memory operations.
-   * @return A new data_batch wrapped in PtrType.
+   * @return A new data_batch wrapped in shared_ptr.
    * @throws std::runtime_error if the data is null.
    */
-  [[nodiscard]] PtrType clone(uint64_t new_batch_id, rmm::cuda_stream_view stream) const;
+  [[nodiscard]] std::shared_ptr<data_batch> clone(uint64_t new_batch_id,
+                                                  rmm::cuda_stream_view stream) const;
 
   /**
    * @brief Create an independent deep copy with representation conversion.
@@ -440,13 +420,14 @@ class mutable_data_batch {
    * @param new_batch_id       Batch ID for the cloned batch.
    * @param target_memory_space Target memory space for the converted data.
    * @param stream              CUDA stream for memory operations.
-   * @return A new data_batch wrapped in PtrType.
+   * @return A new data_batch wrapped in shared_ptr.
    */
   template <typename TargetRepresentation>
-  [[nodiscard]] PtrType clone_to(representation_converter_registry& registry,
-                                 uint64_t new_batch_id,
-                                 const memory::memory_space* target_memory_space,
-                                 rmm::cuda_stream_view stream) const;
+  [[nodiscard]] std::shared_ptr<data_batch> clone_to(
+    representation_converter_registry& registry,
+    uint64_t new_batch_id,
+    const memory::memory_space* target_memory_space,
+    rmm::cuda_stream_view stream) const;
 
   // -- Move-only (D-12/ACC-05/ACC-06) --
   mutable_data_batch(mutable_data_batch&&) noexcept            = default;
@@ -458,112 +439,45 @@ class mutable_data_batch {
   friend class data_batch;
 
   /**
-   * @brief Private constructor -- only data_batch static methods can create instances.
+   * @brief Private constructor -- only data_batch methods can create instances.
    *
-   * @param parent Smart pointer to the parent data_batch (moved in).
+   * @param parent Shared pointer to the parent data_batch (moved in).
    * @param lock   Exclusive lock already acquired on the parent's mutex.
    */
-  mutable_data_batch(PtrType parent, std::unique_lock<std::shared_mutex> lock);
+  mutable_data_batch(std::shared_ptr<data_batch> parent,
+                     std::unique_lock<std::shared_mutex> lock);
 
   // INVARIANT: _batch must be declared before _lock -- destruction order is load-bearing.
   // When destroyed, _lock releases the exclusive lock first, then _batch drops the parent
   // reference. This prevents accessing a destroyed mutex.
-  PtrType _batch;                             ///< Parent lifetime (destroyed second)
-  std::unique_lock<std::shared_mutex> _lock;  ///< Exclusive lock (destroyed first)
+  std::shared_ptr<data_batch> _batch;           ///< Parent lifetime (destroyed second)
+  std::unique_lock<std::shared_mutex> _lock;    ///< Exclusive lock (destroyed first)
 };
 
 // =============================================================================
-// Template implementations
+// Template implementations (TargetRepresentation-templated methods only)
 // =============================================================================
-
-// -- data_batch::to_idle (release shared lock, TRANS-03) --
-
-template <typename PtrType>
-PtrType data_batch::to_idle(read_only_data_batch<PtrType>&& accessor)
-{
-  auto ptr = std::move(accessor._batch);
-  ptr->_state.store(batch_state::idle, std::memory_order_relaxed);
-  accessor._lock.unlock();
-  return ptr;
-}
-
-// -- data_batch::to_idle (release exclusive lock, TRANS-04) --
-
-template <typename PtrType>
-PtrType data_batch::to_idle(mutable_data_batch<PtrType>&& accessor)
-{
-  auto ptr = std::move(accessor._batch);
-  ptr->_state.store(batch_state::idle, std::memory_order_relaxed);
-  accessor._lock.unlock();
-  return ptr;
-}
-
-// -- data_batch::readonly_to_mutable (upgrade lock, TRANS-07) --
-
-template <typename PtrType>
-mutable_data_batch<PtrType> data_batch::readonly_to_mutable(
-  read_only_data_batch<PtrType>&& accessor)
-{
-  auto ptr = std::move(accessor._batch);
-  accessor._lock.unlock();
-  std::unique_lock<std::shared_mutex> lock(ptr->_rw_mutex);
-  ptr->_state.store(batch_state::mutable_locked, std::memory_order_relaxed);
-  return mutable_data_batch<PtrType>(std::move(ptr), std::move(lock));
-}
-
-// -- data_batch::mutable_to_readonly (downgrade lock, TRANS-08) --
-
-template <typename PtrType>
-read_only_data_batch<PtrType> data_batch::mutable_to_readonly(
-  mutable_data_batch<PtrType>&& accessor)
-{
-  auto ptr = std::move(accessor._batch);
-  accessor._lock.unlock();
-  std::shared_lock<std::shared_mutex> lock(ptr->_rw_mutex);
-  ptr->_state.store(batch_state::read_only, std::memory_order_relaxed);
-  return read_only_data_batch<PtrType>(std::move(ptr), std::move(lock));
-}
-
-// -- read_only_data_batch::clone (deep copy, CLONE-01) --
-
-template <typename PtrType>
-PtrType read_only_data_batch<PtrType>::clone(uint64_t new_batch_id,
-                                             rmm::cuda_stream_view stream) const
-{
-  if (_batch->_data == nullptr) { throw std::runtime_error("Cannot clone: data is null"); }
-  auto cloned_data = _batch->_data->clone(stream);
-  if constexpr (std::is_same_v<PtrType, std::shared_ptr<data_batch>>) {
-    return std::make_shared<data_batch>(new_batch_id, std::move(cloned_data));
-  } else {
-    return std::make_unique<data_batch>(new_batch_id, std::move(cloned_data));
-  }
-}
 
 // -- read_only_data_batch::clone_to (deep copy + conversion, CLONE-02) --
 
-template <typename PtrType>
 template <typename TargetRepresentation>
-PtrType read_only_data_batch<PtrType>::clone_to(representation_converter_registry& registry,
-                                                uint64_t new_batch_id,
-                                                const memory::memory_space* target_memory_space,
-                                                rmm::cuda_stream_view stream) const
+std::shared_ptr<data_batch> read_only_data_batch::clone_to(
+  representation_converter_registry& registry,
+  uint64_t new_batch_id,
+  const memory::memory_space* target_memory_space,
+  rmm::cuda_stream_view stream) const
 {
   auto new_representation =
     registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
-  if constexpr (std::is_same_v<PtrType, std::shared_ptr<data_batch>>) {
-    return std::make_shared<data_batch>(new_batch_id, std::move(new_representation));
-  } else {
-    return std::make_unique<data_batch>(new_batch_id, std::move(new_representation));
-  }
+  return std::make_shared<data_batch>(new_batch_id, std::move(new_representation));
 }
 
 // -- mutable_data_batch::convert_to (in-place conversion, ACC-02) --
 
-template <typename PtrType>
 template <typename TargetRepresentation>
-void mutable_data_batch<PtrType>::convert_to(representation_converter_registry& registry,
-                                             const memory::memory_space* target_memory_space,
-                                             rmm::cuda_stream_view stream)
+void mutable_data_batch::convert_to(representation_converter_registry& registry,
+                                    const memory::memory_space* target_memory_space,
+                                    rmm::cuda_stream_view stream)
 {
   auto new_representation =
     registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
@@ -582,53 +496,18 @@ void mutable_data_batch<PtrType>::convert_to(representation_converter_registry& 
   }
 }
 
-// -- mutable_data_batch::clone (deep copy, CLONE-01) --
-
-template <typename PtrType>
-PtrType mutable_data_batch<PtrType>::clone(uint64_t new_batch_id,
-                                           rmm::cuda_stream_view stream) const
-{
-  if (_batch->_data == nullptr) { throw std::runtime_error("Cannot clone: data is null"); }
-  auto cloned_data = _batch->_data->clone(stream);
-  if constexpr (std::is_same_v<PtrType, std::shared_ptr<data_batch>>) {
-    return std::make_shared<data_batch>(new_batch_id, std::move(cloned_data));
-  } else {
-    return std::make_unique<data_batch>(new_batch_id, std::move(cloned_data));
-  }
-}
-
 // -- mutable_data_batch::clone_to (deep copy + conversion, CLONE-02) --
 
-template <typename PtrType>
 template <typename TargetRepresentation>
-PtrType mutable_data_batch<PtrType>::clone_to(representation_converter_registry& registry,
-                                              uint64_t new_batch_id,
-                                              const memory::memory_space* target_memory_space,
-                                              rmm::cuda_stream_view stream) const
+std::shared_ptr<data_batch> mutable_data_batch::clone_to(
+  representation_converter_registry& registry,
+  uint64_t new_batch_id,
+  const memory::memory_space* target_memory_space,
+  rmm::cuda_stream_view stream) const
 {
   auto new_representation =
     registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
-  if constexpr (std::is_same_v<PtrType, std::shared_ptr<data_batch>>) {
-    return std::make_shared<data_batch>(new_batch_id, std::move(new_representation));
-  } else {
-    return std::make_unique<data_batch>(new_batch_id, std::move(new_representation));
-  }
-}
-
-// -- Accessor private constructors --
-
-template <typename PtrType>
-read_only_data_batch<PtrType>::read_only_data_batch(PtrType parent,
-                                                    std::shared_lock<std::shared_mutex> lock)
-  : _batch(std::move(parent)), _lock(std::move(lock))
-{
-}
-
-template <typename PtrType>
-mutable_data_batch<PtrType>::mutable_data_batch(PtrType parent,
-                                                std::unique_lock<std::shared_mutex> lock)
-  : _batch(std::move(parent)), _lock(std::move(lock))
-{
+  return std::make_shared<data_batch>(new_batch_id, std::move(new_representation));
 }
 
 }  // namespace cucascade

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -141,32 +141,6 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
   // -- Static transition methods (D-13/D-14/D-15/D-17) --
 
   /**
-   * @brief Transition from idle to read-only (shared lock).
-   *
-   * Blocks until the shared lock is acquired. The source pointer is
-   * moved-from and becomes null.
-   *
-   * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
-   * @param batch Rvalue reference to the idle batch pointer (moved-from).
-   * @return A read_only_data_batch holding the shared lock.
-   */
-  template <typename PtrType>
-  [[nodiscard]] static read_only_data_batch<PtrType> to_read_only(PtrType&& batch);
-
-  /**
-   * @brief Transition from idle to mutable (exclusive lock).
-   *
-   * Blocks until the exclusive lock is acquired. The source pointer is
-   * moved-from and becomes null.
-   *
-   * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
-   * @param batch Rvalue reference to the idle batch pointer (moved-from).
-   * @return A mutable_data_batch holding the exclusive lock.
-   */
-  template <typename PtrType>
-  [[nodiscard]] static mutable_data_batch<PtrType> to_mutable(PtrType&& batch);
-
-  /**
    * @brief Transition from read-only back to idle (release shared lock).
    *
    * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
@@ -185,35 +159,6 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
    */
   template <typename PtrType>
   [[nodiscard]] static PtrType to_idle(mutable_data_batch<PtrType>&& accessor);
-
-  /**
-   * @brief Try to transition from idle to read-only (non-blocking).
-   *
-   * Attempts to acquire the shared lock without blocking. On success, the
-   * source pointer is nullified. On failure, the source pointer is unchanged.
-   *
-   * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
-   * @param batch Mutable lvalue reference to the idle batch pointer.
-   * @return An optional containing the read-only accessor on success, or
-   *         std::nullopt if the lock could not be acquired immediately.
-   */
-  template <typename PtrType>
-  [[nodiscard]] static std::optional<read_only_data_batch<PtrType>> try_to_read_only(
-    PtrType& batch);
-
-  /**
-   * @brief Try to transition from idle to mutable (non-blocking).
-   *
-   * Attempts to acquire the exclusive lock without blocking. On success, the
-   * source pointer is nullified. On failure, the source pointer is unchanged.
-   *
-   * @tparam PtrType Smart pointer type (shared_ptr or unique_ptr to data_batch).
-   * @param batch Mutable lvalue reference to the idle batch pointer.
-   * @return An optional containing the mutable accessor on success, or
-   *         std::nullopt if the lock could not be acquired immediately.
-   */
-  template <typename PtrType>
-  [[nodiscard]] static std::optional<mutable_data_batch<PtrType>> try_to_mutable(PtrType& batch);
 
   // -- Non-static transitions (shared_ptr only, via shared_from_this) --
   // The caller's shared_ptr is NOT consumed. These only work when the
@@ -319,19 +264,6 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
    */
   void set_data(std::unique_ptr<idata_representation> data);
 
-  /**
-   * @brief Convert the data representation in-place.
-   *
-   * @tparam TargetRepresentation Target representation type.
-   * @param registry   Converter registry for type-keyed dispatch.
-   * @param target_memory_space Target memory space for the new representation.
-   * @param stream     CUDA stream for memory operations.
-   */
-  template <typename TargetRepresentation>
-  void convert_to(representation_converter_registry& registry,
-                  const memory::memory_space* target_memory_space,
-                  rmm::cuda_stream_view stream);
-
   // -- Members --
   const uint64_t _batch_id;                            ///< Immutable batch identifier
   std::unique_ptr<idata_representation> _data;         ///< Owned data representation
@@ -433,7 +365,7 @@ class read_only_data_batch {
  *
  * Holds an exclusive lock on the parent data_batch's mutex, permitting a single
  * writer with no concurrent readers. Provides all read methods plus write methods
- * (set_data, convert_to) that delegate to data_batch's private interface.
+ * (set_data, convert_to) and clone operations (clone, clone_to).
  *
  * Move-only. The exclusive lock is released when this object is destroyed or moved-from.
  *
@@ -468,6 +400,10 @@ class mutable_data_batch {
   /**
    * @brief Convert the data representation in-place.
    *
+   * Replaces the held data with a new representation produced by the converter
+   * registry. If the conversion involves the GPU tier, synchronizes the stream
+   * before the old representation is destroyed to prevent use-after-free.
+   *
    * @tparam TargetRepresentation Target representation type.
    * @param registry           Converter registry for type-keyed dispatch.
    * @param target_memory_space Target memory space for the new representation.
@@ -476,10 +412,41 @@ class mutable_data_batch {
   template <typename TargetRepresentation>
   void convert_to(representation_converter_registry& registry,
                   const memory::memory_space* target_memory_space,
-                  rmm::cuda_stream_view stream)
-  {
-    _batch->template convert_to<TargetRepresentation>(registry, target_memory_space, stream);
-  }
+                  rmm::cuda_stream_view stream);
+
+  // -- Clone operations (CLONE-01/CLONE-02) --
+
+  /**
+   * @brief Create an independent deep copy of the batch data.
+   *
+   * The clone has a new batch ID and its own copy of the data representation,
+   * residing in the same memory space as the original.
+   *
+   * @param new_batch_id Batch ID for the cloned batch.
+   * @param stream       CUDA stream for memory operations.
+   * @return A new data_batch wrapped in PtrType.
+   * @throws std::runtime_error if the data is null.
+   */
+  [[nodiscard]] PtrType clone(uint64_t new_batch_id, rmm::cuda_stream_view stream) const;
+
+  /**
+   * @brief Create an independent deep copy with representation conversion.
+   *
+   * The clone has a new batch ID and its data is converted to TargetRepresentation
+   * using the provided converter registry.
+   *
+   * @tparam TargetRepresentation Target representation type.
+   * @param registry           Converter registry for type-keyed dispatch.
+   * @param new_batch_id       Batch ID for the cloned batch.
+   * @param target_memory_space Target memory space for the converted data.
+   * @param stream              CUDA stream for memory operations.
+   * @return A new data_batch wrapped in PtrType.
+   */
+  template <typename TargetRepresentation>
+  [[nodiscard]] PtrType clone_to(representation_converter_registry& registry,
+                                 uint64_t new_batch_id,
+                                 const memory::memory_space* target_memory_space,
+                                 rmm::cuda_stream_view stream) const;
 
   // -- Move-only (D-12/ACC-05/ACC-06) --
   mutable_data_batch(mutable_data_batch&&) noexcept            = default;
@@ -509,55 +476,6 @@ class mutable_data_batch {
 // Template implementations
 // =============================================================================
 
-// -- data_batch::convert_to --
-
-template <typename TargetRepresentation>
-void data_batch::convert_to(representation_converter_registry& registry,
-                            const memory::memory_space* target_memory_space,
-                            rmm::cuda_stream_view stream)
-{
-  auto new_representation =
-    registry.convert<TargetRepresentation>(*_data, target_memory_space, stream);
-  auto old_representation = std::move(_data);
-  _data = std::move(new_representation);
-
-  bool needs_sync =
-    old_representation != nullptr &&
-    (old_representation->get_current_tier() == memory::Tier::GPU ||
-     _data->get_current_tier() == memory::Tier::GPU);
-
-  lock.unlock();
-
-  if (needs_sync) {
-    // Conversions involving GPU may enqueue async operations on the provided
-    // stream that read from the source memory.  Synchronize before the old
-    // representation is destroyed to avoid use-after-free.
-    stream.synchronize();
-  }
-}
-
-// -- data_batch::to_read_only (idle -> shared lock, TRANS-01) --
-
-template <typename PtrType>
-read_only_data_batch<PtrType> data_batch::to_read_only(PtrType&& batch)
-{
-  auto ptr = std::move(batch);
-  std::shared_lock<std::shared_mutex> lock(ptr->_rw_mutex);
-  ptr->_state.store(batch_state::read_only, std::memory_order_relaxed);
-  return read_only_data_batch<PtrType>(std::move(ptr), std::move(lock));
-}
-
-// -- data_batch::to_mutable (idle -> exclusive lock, TRANS-02) --
-
-template <typename PtrType>
-mutable_data_batch<PtrType> data_batch::to_mutable(PtrType&& batch)
-{
-  auto ptr = std::move(batch);
-  std::unique_lock<std::shared_mutex> lock(ptr->_rw_mutex);
-  ptr->_state.store(batch_state::mutable_locked, std::memory_order_relaxed);
-  return mutable_data_batch<PtrType>(std::move(ptr), std::move(lock));
-}
-
 // -- data_batch::to_idle (release shared lock, TRANS-03) --
 
 template <typename PtrType>
@@ -578,30 +496,6 @@ PtrType data_batch::to_idle(mutable_data_batch<PtrType>&& accessor)
   ptr->_state.store(batch_state::idle, std::memory_order_relaxed);
   accessor._lock.unlock();
   return ptr;
-}
-
-// -- data_batch::try_to_read_only (non-blocking, TRANS-05) --
-
-template <typename PtrType>
-std::optional<read_only_data_batch<PtrType>> data_batch::try_to_read_only(PtrType& batch)
-{
-  std::shared_lock<std::shared_mutex> lock(batch->_rw_mutex, std::try_to_lock);
-  if (!lock.owns_lock()) { return std::nullopt; }
-  batch->_state.store(batch_state::read_only, std::memory_order_relaxed);
-  auto ptr = std::move(batch);
-  return read_only_data_batch<PtrType>(std::move(ptr), std::move(lock));
-}
-
-// -- data_batch::try_to_mutable (non-blocking, TRANS-06) --
-
-template <typename PtrType>
-std::optional<mutable_data_batch<PtrType>> data_batch::try_to_mutable(PtrType& batch)
-{
-  std::unique_lock<std::shared_mutex> lock(batch->_rw_mutex, std::try_to_lock);
-  if (!lock.owns_lock()) { return std::nullopt; }
-  batch->_state.store(batch_state::mutable_locked, std::memory_order_relaxed);
-  auto ptr = std::move(batch);
-  return mutable_data_batch<PtrType>(std::move(ptr), std::move(lock));
 }
 
 // -- data_batch::readonly_to_mutable (upgrade lock, TRANS-07) --
@@ -653,6 +547,64 @@ PtrType read_only_data_batch<PtrType>::clone_to(representation_converter_registr
                                                 uint64_t new_batch_id,
                                                 const memory::memory_space* target_memory_space,
                                                 rmm::cuda_stream_view stream) const
+{
+  auto new_representation =
+    registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
+  if constexpr (std::is_same_v<PtrType, std::shared_ptr<data_batch>>) {
+    return std::make_shared<data_batch>(new_batch_id, std::move(new_representation));
+  } else {
+    return std::make_unique<data_batch>(new_batch_id, std::move(new_representation));
+  }
+}
+
+// -- mutable_data_batch::convert_to (in-place conversion, ACC-02) --
+
+template <typename PtrType>
+template <typename TargetRepresentation>
+void mutable_data_batch<PtrType>::convert_to(representation_converter_registry& registry,
+                                             const memory::memory_space* target_memory_space,
+                                             rmm::cuda_stream_view stream)
+{
+  auto new_representation =
+    registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
+  auto old_representation = std::move(_batch->_data);
+  _batch->_data           = std::move(new_representation);
+
+  bool needs_sync =
+    old_representation != nullptr && (old_representation->get_current_tier() == memory::Tier::GPU ||
+                                      _batch->_data->get_current_tier() == memory::Tier::GPU);
+
+  if (needs_sync) {
+    // Conversions involving GPU may enqueue async operations on the provided
+    // stream that read from the source memory.  Synchronize before the old
+    // representation is destroyed to avoid use-after-free.
+    stream.synchronize();
+  }
+}
+
+// -- mutable_data_batch::clone (deep copy, CLONE-01) --
+
+template <typename PtrType>
+PtrType mutable_data_batch<PtrType>::clone(uint64_t new_batch_id,
+                                           rmm::cuda_stream_view stream) const
+{
+  if (_batch->_data == nullptr) { throw std::runtime_error("Cannot clone: data is null"); }
+  auto cloned_data = _batch->_data->clone(stream);
+  if constexpr (std::is_same_v<PtrType, std::shared_ptr<data_batch>>) {
+    return std::make_shared<data_batch>(new_batch_id, std::move(cloned_data));
+  } else {
+    return std::make_unique<data_batch>(new_batch_id, std::move(cloned_data));
+  }
+}
+
+// -- mutable_data_batch::clone_to (deep copy + conversion, CLONE-02) --
+
+template <typename PtrType>
+template <typename TargetRepresentation>
+PtrType mutable_data_batch<PtrType>::clone_to(representation_converter_registry& registry,
+                                              uint64_t new_batch_id,
+                                              const memory::memory_space* target_memory_space,
+                                              rmm::cuda_stream_view stream) const
 {
   auto new_representation =
     registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -275,7 +275,9 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
  * private interface. Clone operations are available to create independent copies
  * while the read lock is held.
  *
- * Move-only. The shared lock is released when this object is destroyed or moved-from.
+ * Copyable. Copying acquires a new shared lock on the same parent data_batch,
+ * incrementing the reader count. The shared lock is released when this object
+ * is destroyed, moved-from, or overwritten by assignment.
  */
 class read_only_data_batch {
  public:
@@ -329,12 +331,14 @@ class read_only_data_batch {
     const memory::memory_space* target_memory_space,
     rmm::cuda_stream_view stream) const;
 
-  // -- Move-only (D-12/ACC-05/ACC-06) --
+  // -- Move support --
   read_only_data_batch(read_only_data_batch&& other) noexcept;
   read_only_data_batch& operator=(read_only_data_batch&& other) noexcept;
   ~read_only_data_batch();
-  read_only_data_batch(const read_only_data_batch&)            = delete;
-  read_only_data_batch& operator=(const read_only_data_batch&) = delete;
+
+  // -- Copy support: acquires a new shared lock, increments reader count --
+  read_only_data_batch(const read_only_data_batch& other);
+  read_only_data_batch& operator=(const read_only_data_batch& other);
 
  private:
   friend class data_batch;

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -248,12 +248,23 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
    */
   void set_data(std::unique_ptr<idata_representation> data);
 
+  /**
+   * @brief Get the number of active read_only_data_batch instances holding this batch.
+   *
+   * Atomic, lock-free. Counts concurrent shared-lock holders. Transitions to zero
+   * when the last read_only_data_batch is destroyed (or moved-from).
+   *
+   * @return The current reader count.
+   */
+  size_t get_read_only_count() const { return _read_only_count.load(std::memory_order_acquire); }
+
   // -- Members --
   const uint64_t _batch_id;                            ///< Immutable batch identifier
   std::unique_ptr<idata_representation> _data;         ///< Owned data representation
   mutable std::shared_mutex _rw_mutex;                 ///< Reader-writer mutex
   std::atomic<size_t> _subscriber_count{0};            ///< Atomic subscriber interest count
   std::atomic<batch_state> _state{batch_state::idle};  ///< Observable lock state
+  std::atomic<size_t> _read_only_count{0};  ///< Count of active read_only_data_batch instances
 };
 
 /**
@@ -319,10 +330,11 @@ class read_only_data_batch {
     rmm::cuda_stream_view stream) const;
 
   // -- Move-only (D-12/ACC-05/ACC-06) --
-  read_only_data_batch(read_only_data_batch&&) noexcept            = default;
-  read_only_data_batch& operator=(read_only_data_batch&&) noexcept = default;
-  read_only_data_batch(const read_only_data_batch&)                = delete;
-  read_only_data_batch& operator=(const read_only_data_batch&)     = delete;
+  read_only_data_batch(read_only_data_batch&& other) noexcept;
+  read_only_data_batch& operator=(read_only_data_batch&& other) noexcept;
+  ~read_only_data_batch();
+  read_only_data_batch(const read_only_data_batch&)            = delete;
+  read_only_data_batch& operator=(const read_only_data_batch&) = delete;
 
  private:
   friend class data_batch;
@@ -430,10 +442,11 @@ class mutable_data_batch {
     rmm::cuda_stream_view stream) const;
 
   // -- Move-only (D-12/ACC-05/ACC-06) --
-  mutable_data_batch(mutable_data_batch&&) noexcept            = default;
-  mutable_data_batch& operator=(mutable_data_batch&&) noexcept = default;
-  mutable_data_batch(const mutable_data_batch&)                = delete;
-  mutable_data_batch& operator=(const mutable_data_batch&)     = delete;
+  mutable_data_batch(mutable_data_batch&& other) noexcept;
+  mutable_data_batch& operator=(mutable_data_batch&& other) noexcept;
+  ~mutable_data_batch();
+  mutable_data_batch(const mutable_data_batch&)            = delete;
+  mutable_data_batch& operator=(const mutable_data_batch&) = delete;
 
  private:
   friend class data_batch;

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -134,6 +134,16 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
    */
   batch_state get_state() const { return _state.load(std::memory_order_relaxed); }
 
+  /**
+   * @brief Get the number of active read_only_data_batch instances holding this batch.
+   *
+   * Atomic, lock-free. Counts concurrent shared-lock holders. Transitions to zero
+   * when the last read_only_data_batch is destroyed (or moved-from).
+   *
+   * @return The current reader count.
+   */
+  size_t get_read_only_count() const { return _read_only_count.load(std::memory_order_acquire); }
+
   // -- Static transition methods (D-13/D-14/D-15/D-17) --
 
   /**
@@ -247,16 +257,6 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
    * @param data New data representation (takes ownership).
    */
   void set_data(std::unique_ptr<idata_representation> data);
-
-  /**
-   * @brief Get the number of active read_only_data_batch instances holding this batch.
-   *
-   * Atomic, lock-free. Counts concurrent shared-lock holders. Transitions to zero
-   * when the last read_only_data_batch is destroyed (or moved-from).
-   *
-   * @return The current reader count.
-   */
-  size_t get_read_only_count() const { return _read_only_count.load(std::memory_order_acquire); }
 
   // -- Members --
   const uint64_t _batch_id;                            ///< Immutable batch identifier

--- a/include/cucascade/data/data_repository.hpp
+++ b/include/cucascade/data/data_repository.hpp
@@ -79,8 +79,6 @@ class idata_repository {
   {
     {
       std::lock_guard<std::mutex> lock(_mutex);
-      // Ensure partition exists
-      if (batch) { batch->set_state_change_cv(&_cv); }
 
       if (static_cast<std::size_t>(partition_idx) >= _data_batches.size()) {
         _data_batches.resize(partition_idx + 1);
@@ -91,204 +89,89 @@ class idata_repository {
   }
 
   /**
-   * @brief Notify waiting threads that a batch state may have changed.
-   *
-   * Call this method when a batch's state changes outside the repository
-   * (e.g., after releasing a processing handle) to wake up threads blocked
-   * in pop_data_batch().
+   * @brief Notify waiting threads that a batch may be available.
    */
   void notify_state_change() { _cv.notify_all(); }
 
   /**
-   * @brief Remove and return a data batch that can transition to the target state.
+   * @brief Remove and return the next data batch from the repository.
    *
-   * Searches for a batch that can successfully transition to the specified target state.
-   * The specific batch returned depends on the implementation's eviction strategy:
-   * - FIFO: Searches from oldest to newest
-   * - LRU: Searches from least recently used
-   * - Priority: Searches from lowest priority
+   * Simple pop — returns the first batch in the partition with no state transition.
+   * If the partition is empty, returns a null pointer.
    *
-   * State transition behavior:
-   * - task_created: Calls try_to_create_task() on the batch. Succeeds for idle,
-   *   task_created, or processing batches. Processing batches stay in processing state.
-   * - processing: Not allowed here; an exception is thrown. Callers should pop with
-   *   task_created and then manually call try_to_lock_for_processing() on the returned batch.
-   * - in_transit: Calls try_to_lock_for_in_transit() on the batch. Succeeds only
-   *   for idle batches with no active processing.
-   *
-   * If no batch can transition to the target state, this method blocks until either:
-   * - A new batch is added to the repository
-   * - notify_state_change() is called
-   *
-   * @param target_state The state to transition the batch to (must not be processing)
    * @param partition_idx Index of the partition to pop from (default: 0)
-   * @return PtrType The data batch that was successfully transitioned, or nullptr
-   *         if the repository is empty after waiting.
+   * @return PtrType The data batch, or nullptr if the partition is empty.
    *
-   * @note Thread-safe operation protected by internal mutex and condition variable
-   * @throws std::runtime_error if target_state is batch_state::processing
+   * @note Thread-safe operation protected by internal mutex
    * @throws std::out_of_range if partition_idx is out of range
    */
-  virtual PtrType pop_data_batch(batch_state target_state, size_t partition_idx = 0)
+  virtual PtrType pop_data_batch(size_t partition_idx = 0)
   {
     std::unique_lock<std::mutex> lock(_mutex);
 
-    // Validate partition index
     if (partition_idx >= _data_batches.size()) {
       throw std::out_of_range("partition_idx out of range");
     }
 
-    while (true) {
-      if (_data_batches[partition_idx].empty()) { return PtrType{}; }
+    if (_data_batches[partition_idx].empty()) { return PtrType{}; }
 
-      // Search for a batch that can transition to the target state
-      for (auto it = _data_batches[partition_idx].begin(); it != _data_batches[partition_idx].end();
-           ++it) {
-        data_batch* batch_ptr = it->get();
-        bool can_transition   = try_transition_batch_for_pop(batch_ptr, target_state);
-
-        if (can_transition) {
-          auto batch = std::move(*it);
-          batch->set_state_change_cv(nullptr);  // No longer in this repo; avoid use-after-free
-          _data_batches[partition_idx].erase(it);
-          return batch;
-        }
-      }
-
-      // No batch could transition - wait for new batches or state changes
-      _cv.wait(lock);
-    }
+    auto batch = std::move(_data_batches[partition_idx].front());
+    _data_batches[partition_idx].erase(_data_batches[partition_idx].begin());
+    return batch;
   }
 
   /**
-   * @brief Remove and return a data batch by its batch ID, optionally with state transition.
+   * @brief Remove and return a data batch by its batch ID.
    *
    * Searches for a batch with the specified batch_id within the given partition.
-   *
-   * If target_state is std::nullopt:
-   * - Returns the batch immediately if found, without state transition
-   *
-   * If target_state has a value:
-   * - Attempts to transition the batch to the target state
-   * - If the batch exists but cannot transition, this method blocks until either:
-   *   - The batch can successfully transition to the target state
-   *   - notify_state_change() is called
-   *   - A new batch is added to the repository
-   *
-   * State transition behavior follows the same rules as pop_data_batch(batch_state):
-   * - task_created: Calls try_to_create_task() on the batch
-   * - processing: Not allowed; throws an exception
-   * - in_transit: Calls try_to_lock_for_in_transit() on the batch
+   * Returns the batch if found, nullptr otherwise.
    *
    * @param batch_id The unique identifier of the batch to retrieve
-   * @param target_state Optional state to transition the batch to (std::nullopt to skip state
-   * check)
    * @param partition_idx Index of the partition to search (default: 0)
    * @return PtrType The data batch with the matching batch_id, or nullptr if not found
    *
-   * @note Thread-safe operation protected by internal mutex and condition variable
-   * @throws std::runtime_error if target_state is batch_state::processing
+   * @note Thread-safe operation protected by internal mutex
    * @throws std::out_of_range if partition_idx is out of range
    */
-  virtual PtrType pop_data_batch_by_id(uint64_t batch_id,
-                                       std::optional<batch_state> target_state,
-                                       size_t partition_idx = 0)
+  virtual PtrType pop_data_batch_by_id(uint64_t batch_id, size_t partition_idx = 0)
   {
     std::unique_lock<std::mutex> lock(_mutex);
 
-    // Validate partition index
     if (partition_idx >= _data_batches.size()) {
       throw std::out_of_range("partition_idx out of range");
     }
 
-    // If no target_state specified, just find and return the batch
-    if (!target_state.has_value()) {
-      for (auto it = _data_batches[partition_idx].begin(); it != _data_batches[partition_idx].end();
-           ++it) {
-        if (it->get()->get_batch_id() == batch_id) {
-          auto batch = std::move(*it);
-          batch->set_state_change_cv(nullptr);
-          _data_batches[partition_idx].erase(it);
-          return batch;
-        }
+    for (auto it = _data_batches[partition_idx].begin(); it != _data_batches[partition_idx].end();
+         ++it) {
+      if (it->get()->get_batch_id() == batch_id) {
+        auto batch = std::move(*it);
+        _data_batches[partition_idx].erase(it);
+        return batch;
       }
-      // Batch not found
-      return PtrType{};
     }
 
-    // Target state specified - attempt state transition and wait if needed
-    while (true) {
-      // Search for the batch with the matching batch_id
-      bool batch_found = false;
-      for (auto it = _data_batches[partition_idx].begin(); it != _data_batches[partition_idx].end();
-           ++it) {
-        if (it->get()->get_batch_id() == batch_id) {
-          batch_found           = true;
-          data_batch* batch_ptr = it->get();
-          bool can_transition   = try_transition_batch_for_pop(batch_ptr, *target_state);
-
-          if (can_transition) {
-            auto batch = std::move(*it);
-            batch->set_state_change_cv(nullptr);
-            _data_batches[partition_idx].erase(it);
-            return batch;
-          }
-
-          // Batch found but cannot transition - wait for state change
-          break;
-        }
-      }
-
-      // If batch was not found, return nullptr
-      if (!batch_found) { return PtrType{}; }
-
-      // Batch exists but cannot transition - wait for state changes
-      _cv.wait(lock);
-    }
+    return PtrType{};
   }
 
   /**
-   * @brief Get a copy of a data batch by its batch ID, optionally with state transition.
+   * @brief Get a copy of a data batch by its batch ID (does not remove from repository).
    *
    * Searches for a batch with the specified batch_id within the given partition
-   * and returns a copy of the pointer (does not remove from repository).
-   *
-   * If target_state is std::nullopt:
-   * - Returns a copy of the batch pointer immediately if found, without state transition
-   *
-   * If target_state has a value:
-   * - Attempts to transition the batch to the target state
-   * - If the batch exists but cannot transition, this method blocks until either:
-   *   - The batch can successfully transition to the target state
-   *   - notify_state_change() is called
-   *   - A new batch is added to the repository
-   *
-   * State transition behavior follows the same rules as pop_data_batch(batch_state):
-   * - task_created: Calls try_to_create_task() on the batch
-   * - processing: Not allowed; throws an exception
-   * - in_transit: Calls try_to_lock_for_in_transit() on the batch
+   * and returns a copy of the pointer.
    *
    * @param batch_id The unique identifier of the batch to retrieve
-   * @param target_state Optional state to transition the batch to (std::nullopt to skip state
-   * check)
    * @param partition_idx Index of the partition to search (default: 0)
-   * @return PtrType A copy of the data batch pointer with the matching batch_id, or nullptr if not
-   * found
+   * @return PtrType A copy of the data batch pointer with the matching batch_id, or nullptr
    *
-   * @note Thread-safe operation protected by internal mutex and condition variable
+   * @note Thread-safe operation protected by internal mutex
    * @note Only supported for shared_ptr repositories. Will throw for unique_ptr repositories.
-   * @throws std::runtime_error if target_state is batch_state::processing or if called on
-   * unique_ptr repository
+   * @throws std::runtime_error if called on unique_ptr repository
    * @throws std::out_of_range if partition_idx is out of range
    */
-  virtual PtrType get_data_batch_by_id(uint64_t batch_id,
-                                       std::optional<batch_state> target_state,
-                                       size_t partition_idx = 0);
+  virtual PtrType get_data_batch_by_id(uint64_t batch_id, size_t partition_idx = 0);
 
   /**
    * @brief Get all batch IDs from a partition.
-   *
-   * Retrieves the batch IDs of all batches currently stored in the specified partition.
    *
    * @param partition_idx Index of the partition to query (default: 0)
    * @return std::vector<uint64_t> Vector containing all batch IDs in the partition
@@ -300,7 +183,6 @@ class idata_repository {
   {
     std::lock_guard<std::mutex> lock(_mutex);
 
-    // Validate partition index
     if (partition_idx >= _data_batches.size()) {
       throw std::out_of_range("partition_idx out of range");
     }
@@ -316,7 +198,7 @@ class idata_repository {
   }
 
   /**
-   * @brief Check if there are any data batches available in the repository.
+   * @brief Get the number of data batches in a partition.
    *
    * @param partition_idx Index of the partition to check (default: 0)
    * @return std::size_t The number of data batches currently stored in the specified partition.
@@ -388,31 +270,6 @@ class idata_repository {
   {
     std::lock_guard<std::mutex> lock(_mutex);
     return _data_batches.size();
-  }
-
- private:
-  /**
-   * @brief Helper function to attempt state transition on a batch when popping.
-   *
-   * @param batch_ptr Pointer to the batch to transition
-   * @param target_state The state to transition to
-   * @return bool True if the transition succeeded, false otherwise
-   * @throws std::runtime_error if target_state is batch_state::processing
-   */
-  bool try_transition_batch_for_pop(data_batch* batch_ptr, batch_state target_state) const
-  {
-    switch (target_state) {
-      case batch_state::task_created: return batch_ptr->try_to_create_task();
-      case batch_state::processing:
-        throw std::runtime_error(
-          "Pop operation cannot transition directly to processing; "
-          "Pop with task_created and call try_to_lock_for_processing() on the batch");
-      case batch_state::in_transit: return batch_ptr->try_to_lock_for_in_transit();
-      case batch_state::idle:
-        // Cannot transition to idle via pop - idle is a terminal state
-        return false;
-    }
-    return false;
   }
 
  protected:

--- a/include/cucascade/data/data_repository.hpp
+++ b/include/cucascade/data/data_repository.hpp
@@ -94,54 +94,30 @@ class idata_repository {
   void notify_state_change() { _cv.notify_all(); }
 
   /**
-   * @brief Remove and return the first idle data batch from the repository.
+   * @brief Remove and return the next data batch from the repository.
    *
-   * Scans the partition for the first batch with state == batch_state::idle.
-   * If no idle batch is found, returns a null pointer.
+   * Returns the first batch in the partition regardless of its state.
+   * If the partition is empty, returns a null pointer.
    *
    * @param partition_idx Index of the partition to pop from (default: 0)
-   * @return PtrType The data batch, or nullptr if no idle batch is found.
+   * @return PtrType The next data batch, or nullptr if the partition is empty.
    *
    * @note Thread-safe operation protected by internal mutex
    * @throws std::out_of_range if partition_idx is out of range
    */
-  virtual PtrType pop_idle_data_batch(size_t partition_idx = 0)
+  virtual PtrType pop_next_data_batch(size_t partition_idx = 0)
   {
-    return pop_data_batch_by_state(batch_state::idle, partition_idx);
-  }
+    std::unique_lock<std::mutex> lock(_mutex);
 
-  /**
-   * @brief Remove and return the first read-only data batch from the repository.
-   *
-   * Scans the partition for the first batch with state == batch_state::read_only.
-   * If no read-only batch is found, returns a null pointer.
-   *
-   * @param partition_idx Index of the partition to pop from (default: 0)
-   * @return PtrType The data batch, or nullptr if no read-only batch is found.
-   *
-   * @note Thread-safe operation protected by internal mutex
-   * @throws std::out_of_range if partition_idx is out of range
-   */
-  virtual PtrType pop_read_only_data_batch(size_t partition_idx = 0)
-  {
-    return pop_data_batch_by_state(batch_state::read_only, partition_idx);
-  }
+    if (partition_idx >= _data_batches.size()) {
+      throw std::out_of_range("partition_idx out of range");
+    }
 
-  /**
-   * @brief Remove and return the first mutable-locked data batch from the repository.
-   *
-   * Scans the partition for the first batch with state == batch_state::mutable_locked.
-   * If no mutable batch is found, returns a null pointer.
-   *
-   * @param partition_idx Index of the partition to pop from (default: 0)
-   * @return PtrType The data batch, or nullptr if no mutable batch is found.
-   *
-   * @note Thread-safe operation protected by internal mutex
-   * @throws std::out_of_range if partition_idx is out of range
-   */
-  virtual PtrType pop_mutable_data_batch(size_t partition_idx = 0)
-  {
-    return pop_data_batch_by_state(batch_state::mutable_locked, partition_idx);
+    if (_data_batches[partition_idx].empty()) { return PtrType{}; }
+
+    auto batch = std::move(_data_batches[partition_idx].front());
+    _data_batches[partition_idx].erase(_data_batches[partition_idx].begin());
+    return batch;
   }
 
   /**
@@ -297,33 +273,6 @@ class idata_repository {
   }
 
  protected:
-  /**
-   * @brief Pop the first batch matching the given state from a partition.
-   *
-   * @param target_state The batch_state to filter on.
-   * @param partition_idx Index of the partition to scan.
-   * @return PtrType The first matching batch, or nullptr if none found.
-   */
-  PtrType pop_data_batch_by_state(batch_state target_state, size_t partition_idx)
-  {
-    std::unique_lock<std::mutex> lock(_mutex);
-
-    if (partition_idx >= _data_batches.size()) {
-      throw std::out_of_range("partition_idx out of range");
-    }
-
-    for (auto it = _data_batches[partition_idx].begin(); it != _data_batches[partition_idx].end();
-         ++it) {
-      if (it->get()->get_state() == target_state) {
-        auto batch = std::move(*it);
-        _data_batches[partition_idx].erase(it);
-        return batch;
-      }
-    }
-
-    return PtrType{};
-  }
-
   mutable std::mutex _mutex;    ///< Mutex for thread-safe access to repository operations
   std::condition_variable _cv;  ///< Condition variable for blocking pop operations
   std::vector<std::vector<PtrType>>

--- a/include/cucascade/data/data_repository.hpp
+++ b/include/cucascade/data/data_repository.hpp
@@ -94,30 +94,54 @@ class idata_repository {
   void notify_state_change() { _cv.notify_all(); }
 
   /**
-   * @brief Remove and return the next data batch from the repository.
+   * @brief Remove and return the first idle data batch from the repository.
    *
-   * Simple pop — returns the first batch in the partition with no state transition.
-   * If the partition is empty, returns a null pointer.
+   * Scans the partition for the first batch with state == batch_state::idle.
+   * If no idle batch is found, returns a null pointer.
    *
    * @param partition_idx Index of the partition to pop from (default: 0)
-   * @return PtrType The data batch, or nullptr if the partition is empty.
+   * @return PtrType The data batch, or nullptr if no idle batch is found.
    *
    * @note Thread-safe operation protected by internal mutex
    * @throws std::out_of_range if partition_idx is out of range
    */
-  virtual PtrType pop_data_batch(size_t partition_idx = 0)
+  virtual PtrType pop_idle_data_batch(size_t partition_idx = 0)
   {
-    std::unique_lock<std::mutex> lock(_mutex);
+    return pop_data_batch_by_state(batch_state::idle, partition_idx);
+  }
 
-    if (partition_idx >= _data_batches.size()) {
-      throw std::out_of_range("partition_idx out of range");
-    }
+  /**
+   * @brief Remove and return the first read-only data batch from the repository.
+   *
+   * Scans the partition for the first batch with state == batch_state::read_only.
+   * If no read-only batch is found, returns a null pointer.
+   *
+   * @param partition_idx Index of the partition to pop from (default: 0)
+   * @return PtrType The data batch, or nullptr if no read-only batch is found.
+   *
+   * @note Thread-safe operation protected by internal mutex
+   * @throws std::out_of_range if partition_idx is out of range
+   */
+  virtual PtrType pop_read_only_data_batch(size_t partition_idx = 0)
+  {
+    return pop_data_batch_by_state(batch_state::read_only, partition_idx);
+  }
 
-    if (_data_batches[partition_idx].empty()) { return PtrType{}; }
-
-    auto batch = std::move(_data_batches[partition_idx].front());
-    _data_batches[partition_idx].erase(_data_batches[partition_idx].begin());
-    return batch;
+  /**
+   * @brief Remove and return the first mutable-locked data batch from the repository.
+   *
+   * Scans the partition for the first batch with state == batch_state::mutable_locked.
+   * If no mutable batch is found, returns a null pointer.
+   *
+   * @param partition_idx Index of the partition to pop from (default: 0)
+   * @return PtrType The data batch, or nullptr if no mutable batch is found.
+   *
+   * @note Thread-safe operation protected by internal mutex
+   * @throws std::out_of_range if partition_idx is out of range
+   */
+  virtual PtrType pop_mutable_data_batch(size_t partition_idx = 0)
+  {
+    return pop_data_batch_by_state(batch_state::mutable_locked, partition_idx);
   }
 
   /**
@@ -273,6 +297,33 @@ class idata_repository {
   }
 
  protected:
+  /**
+   * @brief Pop the first batch matching the given state from a partition.
+   *
+   * @param target_state The batch_state to filter on.
+   * @param partition_idx Index of the partition to scan.
+   * @return PtrType The first matching batch, or nullptr if none found.
+   */
+  PtrType pop_data_batch_by_state(batch_state target_state, size_t partition_idx)
+  {
+    std::unique_lock<std::mutex> lock(_mutex);
+
+    if (partition_idx >= _data_batches.size()) {
+      throw std::out_of_range("partition_idx out of range");
+    }
+
+    for (auto it = _data_batches[partition_idx].begin(); it != _data_batches[partition_idx].end();
+         ++it) {
+      if (it->get()->get_state() == target_state) {
+        auto batch = std::move(*it);
+        _data_batches[partition_idx].erase(it);
+        return batch;
+      }
+    }
+
+    return PtrType{};
+  }
+
   mutable std::mutex _mutex;    ///< Mutex for thread-safe access to repository operations
   std::condition_variable _cv;  ///< Condition variable for blocking pop operations
   std::vector<std::vector<PtrType>>

--- a/include/cucascade/data/data_repository_manager.hpp
+++ b/include/cucascade/data/data_repository_manager.hpp
@@ -210,6 +210,7 @@ class data_repository_manager {
    * @param amount_to_downgrade The amount of data in bytes to downgrade
    * @return std::vector<PtrType> A vector of data batches that are candidates for downgrade
    */
+   // WSM TODO: remove this?
   std::vector<PtrType> get_data_batches_for_downgrade(
     [[maybe_unused]] cucascade::memory::memory_space_id memory_space_id,
     [[maybe_unused]] size_t amount_to_downgrade)
@@ -235,6 +236,27 @@ class data_repository_manager {
     for (auto& [key, repo] : _repositories) {
       if (repo) { visitor(repo.get()); }
     }
+  }
+
+  /**
+   * @brief Get a snapshot of all current repository pointers.
+   *
+   * Returns a vector of raw pointers to each non-null repository. The vector
+   * is built under the manager mutex, so callers can iterate it externally
+   * without holding the lock (the repositories themselves remain thread-safe).
+   *
+   * @return std::vector<repository_type*> Snapshot of non-null repository pointers
+   * @note Thread-safe — holds the manager mutex for the duration of collection.
+   */
+  std::vector<repository_type*> get_repositories()
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    std::vector<repository_type*> result;
+    result.reserve(_repositories.size());
+    for (auto& [key, repo] : _repositories) {
+      if (repo) { result.push_back(repo.get()); }
+    }
+    return result;
   }
 
  private:

--- a/include/cucascade/data/data_repository_manager.hpp
+++ b/include/cucascade/data/data_repository_manager.hpp
@@ -203,24 +203,7 @@ class data_repository_manager {
     return leaked;
   }
 
-  /**
-   * @brief Get N batches from the specified repositories for downgrade.
-   *
-   * @param memory_space_id The memory space id to get the data batches from
-   * @param amount_to_downgrade The amount of data in bytes to downgrade
-   * @return std::vector<PtrType> A vector of data batches that are candidates for downgrade
-   */
-   // WSM TODO: remove this?
-  std::vector<PtrType> get_data_batches_for_downgrade(
-    [[maybe_unused]] cucascade::memory::memory_space_id memory_space_id,
-    [[maybe_unused]] size_t amount_to_downgrade)
-  {
-    std::vector<PtrType> data_batches;
-    // Note: Implementation would iterate through repositories and collect batches
-    // This is a placeholder - actual implementation depends on how batches are tracked
-    return data_batches;
-  }
-
+  
   /**
    * @brief Iterate over all repositories, calling the visitor for each one.
    *

--- a/include/cucascade/data/data_repository_manager.hpp
+++ b/include/cucascade/data/data_repository_manager.hpp
@@ -26,6 +26,7 @@
 #include <memory>
 #include <mutex>
 #include <string>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 
@@ -238,33 +239,25 @@ class data_repository_manager {
   }
 
  private:
-  // Implementation for shared_ptr - can copy to multiple repositories
-  template <typename T = PtrType>
-  typename std::enable_if<std::is_same<T, std::shared_ptr<data_batch>>::value>::type
-  add_data_batch_impl(T batch, std::vector<std::pair<size_t, std::string_view>>& ops)
+  void add_data_batch_impl(PtrType batch, std::vector<std::pair<size_t, std::string_view>>& ops)
   {
     std::lock_guard<std::mutex> lock(_mutex);
-    for (auto& op : ops) {
-      _repositories[{op.first, std::string(op.second)}]->add_data_batch(batch);
-    }
-  }
-
-  // Implementation for unique_ptr - can only add to one repository (moves the batch)
-  template <typename T = PtrType>
-  typename std::enable_if<std::is_same<T, std::unique_ptr<data_batch>>::value>::type
-  add_data_batch_impl(T batch, std::vector<std::pair<size_t, std::string_view>>& ops)
-  {
-    std::lock_guard<std::mutex> lock(_mutex);
-    if (ops.size() > 1) {
-      throw std::runtime_error(
-        "unique_ptr data_batch can only be added to one repository. "
-        "Use shared_ptr for multiple destinations.");
-    }
-    if (!ops.empty()) {
-      auto& op = ops[0];
-      _repositories[{op.first, std::string(op.second)}]->add_data_batch(std::move(batch));
+    if constexpr (std::is_copy_constructible_v<PtrType>) {
+      for (auto& op : ops) {
+        _repositories[{op.first, std::string(op.second)}]->add_data_batch(batch);
+      }
     } else {
-      throw std::runtime_error("No operator ports provided");
+      if (ops.size() > 1) {
+        throw std::runtime_error(
+          "unique_ptr data_batch can only be added to one repository. "
+          "Use shared_ptr for multiple destinations.");
+      }
+      if (!ops.empty()) {
+        auto& op = ops[0];
+        _repositories[{op.first, std::string(op.second)}]->add_data_batch(std::move(batch));
+      } else {
+        throw std::runtime_error("No operator ports provided");
+      }
     }
   }
 

--- a/src/data/data_batch.cpp
+++ b/src/data/data_batch.cpp
@@ -66,16 +66,24 @@ void data_batch::set_data(std::unique_ptr<idata_representation> data) { _data = 
 
 std::shared_ptr<data_batch> data_batch::to_idle(read_only_data_batch&& accessor)
 {
+  // Ownership-transfer pattern: steal _batch so the accessor's destructor becomes a no-op
+  // (nullptr check in destructor skips all cleanup). We then manually perform the cleanup
+  // that the destructor would have done: decrement read_only_count, set state, unlock.
+  // The lock is explicitly unlocked here because the accessor's shared_lock will NOT
+  // call unlock in its destructor after we call unlock() explicitly -- shared_lock tracks
+  // ownership and will skip the unlock if the lock is already released.
   auto ptr = std::move(accessor._batch);
-  ptr->_state.store(batch_state::idle, std::memory_order_relaxed);
+  ptr->_read_only_count.fetch_sub(1, std::memory_order_acq_rel);
+  ptr->_state.store(batch_state::idle, std::memory_order_release);
   accessor._lock.unlock();
   return ptr;
 }
 
 std::shared_ptr<data_batch> data_batch::to_idle(mutable_data_batch&& accessor)
 {
+  // Same ownership-transfer pattern as the read_only overload above.
   auto ptr = std::move(accessor._batch);
-  ptr->_state.store(batch_state::idle, std::memory_order_relaxed);
+  ptr->_state.store(batch_state::idle, std::memory_order_release);
   accessor._lock.unlock();
   return ptr;
 }
@@ -86,7 +94,8 @@ read_only_data_batch data_batch::to_read_only()
 {
   auto self = shared_from_this();
   std::shared_lock<std::shared_mutex> lock(_rw_mutex);
-  _state.store(batch_state::read_only, std::memory_order_relaxed);
+  _state.store(batch_state::read_only, std::memory_order_release);
+  // The read_only_data_batch constructor increments _read_only_count.
   return read_only_data_batch(std::move(self), std::move(lock));
 }
 
@@ -94,7 +103,7 @@ mutable_data_batch data_batch::to_mutable()
 {
   auto self = shared_from_this();
   std::unique_lock<std::shared_mutex> lock(_rw_mutex);
-  _state.store(batch_state::mutable_locked, std::memory_order_relaxed);
+  _state.store(batch_state::mutable_locked, std::memory_order_release);
   return mutable_data_batch(std::move(self), std::move(lock));
 }
 
@@ -102,8 +111,9 @@ std::optional<read_only_data_batch> data_batch::try_to_read_only()
 {
   std::shared_lock<std::shared_mutex> lock(_rw_mutex, std::try_to_lock);
   if (!lock.owns_lock()) { return std::nullopt; }
-  _state.store(batch_state::read_only, std::memory_order_relaxed);
+  _state.store(batch_state::read_only, std::memory_order_release);
   auto self = shared_from_this();
+  // The read_only_data_batch constructor increments _read_only_count.
   return read_only_data_batch(std::move(self), std::move(lock));
 }
 
@@ -111,7 +121,7 @@ std::optional<mutable_data_batch> data_batch::try_to_mutable()
 {
   std::unique_lock<std::shared_mutex> lock(_rw_mutex, std::try_to_lock);
   if (!lock.owns_lock()) { return std::nullopt; }
-  _state.store(batch_state::mutable_locked, std::memory_order_relaxed);
+  _state.store(batch_state::mutable_locked, std::memory_order_release);
   auto self = shared_from_this();
   return mutable_data_batch(std::move(self), std::move(lock));
 }
@@ -121,9 +131,11 @@ std::optional<mutable_data_batch> data_batch::try_to_mutable()
 mutable_data_batch data_batch::readonly_to_mutable(read_only_data_batch&& accessor)
 {
   auto ptr = std::move(accessor._batch);
+  // Decrement _read_only_count: we're removing a reader before re-locking as mutable.
+  ptr->_read_only_count.fetch_sub(1, std::memory_order_acq_rel);
   accessor._lock.unlock();
   std::unique_lock<std::shared_mutex> lock(ptr->_rw_mutex);
-  ptr->_state.store(batch_state::mutable_locked, std::memory_order_relaxed);
+  ptr->_state.store(batch_state::mutable_locked, std::memory_order_release);
   return mutable_data_batch(std::move(ptr), std::move(lock));
 }
 
@@ -132,7 +144,8 @@ read_only_data_batch data_batch::mutable_to_readonly(mutable_data_batch&& access
   auto ptr = std::move(accessor._batch);
   accessor._lock.unlock();
   std::shared_lock<std::shared_mutex> lock(ptr->_rw_mutex);
-  ptr->_state.store(batch_state::read_only, std::memory_order_relaxed);
+  ptr->_state.store(batch_state::read_only, std::memory_order_release);
+  // The read_only_data_batch constructor increments _read_only_count.
   return read_only_data_batch(std::move(ptr), std::move(lock));
 }
 
@@ -142,6 +155,45 @@ read_only_data_batch::read_only_data_batch(std::shared_ptr<data_batch> parent,
                                            std::shared_lock<std::shared_mutex> lock)
   : _batch(std::move(parent)), _lock(std::move(lock))
 {
+  _batch->_read_only_count.fetch_add(1, std::memory_order_acq_rel);
+}
+
+read_only_data_batch::read_only_data_batch(read_only_data_batch&& other) noexcept
+  : _batch(std::move(other._batch)), _lock(std::move(other._lock))
+{
+  // other._batch is now nullptr — other's destructor will be a no-op.
+  // The read_only_count does NOT change: ownership was transferred, not a new reader created.
+}
+
+read_only_data_batch& read_only_data_batch::operator=(read_only_data_batch&& other) noexcept
+{
+  if (this != &other) {
+    // Release the current state (same logic as destructor)
+    if (_batch) {
+      auto prev = _batch->_read_only_count.fetch_sub(1, std::memory_order_acq_rel);
+      if (prev == 1) { _batch->_state.store(batch_state::idle, std::memory_order_release); }
+      // _lock will be replaced below; its destructor fires when the old _lock is overwritten,
+      // releasing the shared lock. We release _lock explicitly here so the sequence is:
+      // decrement count -> set state (if last) -> release lock.
+      _lock.unlock();
+    }
+    _batch = std::move(other._batch);
+    _lock  = std::move(other._lock);
+  }
+  return *this;
+}
+
+read_only_data_batch::~read_only_data_batch()
+{
+  if (_batch) {
+    // Decrement the reader count. If we were the last reader, transition to idle.
+    // NOTE: Do NOT call _lock.unlock() here — the _lock member destructor handles that.
+    // The destructor body runs before member destructors, so _batch is still valid here.
+    // After this function returns, _lock destructor fires first (declared after _batch,
+    // destroyed in reverse order), releasing the shared lock. Then _batch destructor fires.
+    auto prev = _batch->_read_only_count.fetch_sub(1, std::memory_order_acq_rel);
+    if (prev == 1) { _batch->_state.store(batch_state::idle, std::memory_order_release); }
+  }
 }
 
 std::shared_ptr<data_batch> read_only_data_batch::clone(uint64_t new_batch_id,
@@ -158,6 +210,35 @@ mutable_data_batch::mutable_data_batch(std::shared_ptr<data_batch> parent,
                                        std::unique_lock<std::shared_mutex> lock)
   : _batch(std::move(parent)), _lock(std::move(lock))
 {
+}
+
+mutable_data_batch::mutable_data_batch(mutable_data_batch&& other) noexcept
+  : _batch(std::move(other._batch)), _lock(std::move(other._lock))
+{
+  // other._batch is now nullptr — other's destructor will be a no-op.
+}
+
+mutable_data_batch& mutable_data_batch::operator=(mutable_data_batch&& other) noexcept
+{
+  if (this != &other) {
+    // Release the current state (same logic as destructor)
+    if (_batch) {
+      _batch->_state.store(batch_state::idle, std::memory_order_release);
+      // Release the exclusive lock explicitly before taking ownership of the new one.
+      _lock.unlock();
+    }
+    _batch = std::move(other._batch);
+    _lock  = std::move(other._lock);
+  }
+  return *this;
+}
+
+mutable_data_batch::~mutable_data_batch()
+{
+  if (_batch) {
+    // Transition state to idle. The _lock member destructor handles releasing the exclusive lock.
+    _batch->_state.store(batch_state::idle, std::memory_order_release);
+  }
 }
 
 std::shared_ptr<data_batch> mutable_data_batch::clone(uint64_t new_batch_id,

--- a/src/data/data_batch.cpp
+++ b/src/data/data_batch.cpp
@@ -149,6 +149,14 @@ read_only_data_batch::read_only_data_batch(read_only_data_batch&& other) noexcep
   // The read_only_count does NOT change: ownership was transferred, not a new reader created.
 }
 
+read_only_data_batch::read_only_data_batch(const read_only_data_batch& other)
+  : _batch(other._batch)
+  , _lock(other._batch ? std::shared_lock<std::shared_mutex>(other._batch->_rw_mutex)
+                       : std::shared_lock<std::shared_mutex>())
+{
+  if (_batch) { _batch->_read_only_count.fetch_add(1); }
+}
+
 read_only_data_batch& read_only_data_batch::operator=(read_only_data_batch&& other) noexcept
 {
   if (this != &other) {
@@ -162,7 +170,27 @@ read_only_data_batch& read_only_data_batch::operator=(read_only_data_batch&& oth
       _lock.unlock();
     }
     _batch = std::move(other._batch);
-    _lock  = std::move(other._lock);
+    _lock  = std::move(other._lock);   
+  }
+  return *this;
+}
+
+read_only_data_batch& read_only_data_batch::operator=(const read_only_data_batch& other)
+{
+  if (this != &other) {
+    if (_batch) {
+      auto prev = _batch->_read_only_count.fetch_sub(1);
+      if (prev == 1) { _batch->_state.store(batch_state::idle); }
+      _lock.unlock();
+    }
+    _batch = other._batch;
+    if (_batch) {
+      _lock = std::shared_lock<std::shared_mutex>(_batch->_rw_mutex);
+      _batch->_read_only_count.fetch_add(1);
+      _batch->_state.store(batch_state::read_only);
+    } else {
+      _lock = std::shared_lock<std::shared_mutex>();
+    }
   }
   return *this;
 }

--- a/src/data/data_batch.cpp
+++ b/src/data/data_batch.cpp
@@ -62,47 +62,110 @@ memory::memory_space* data_batch::get_memory_space() const
 
 void data_batch::set_data(std::unique_ptr<idata_representation> data) { _data = std::move(data); }
 
-// ========== Non-static transition methods (shared_ptr only) ==========
+// ========== Static transition methods ==========
 
-read_only_data_batch<std::shared_ptr<data_batch>> data_batch::to_read_only()
+std::shared_ptr<data_batch> data_batch::to_idle(read_only_data_batch&& accessor)
+{
+  auto ptr = std::move(accessor._batch);
+  ptr->_state.store(batch_state::idle, std::memory_order_relaxed);
+  accessor._lock.unlock();
+  return ptr;
+}
+
+std::shared_ptr<data_batch> data_batch::to_idle(mutable_data_batch&& accessor)
+{
+  auto ptr = std::move(accessor._batch);
+  ptr->_state.store(batch_state::idle, std::memory_order_relaxed);
+  accessor._lock.unlock();
+  return ptr;
+}
+
+// ========== Non-static transition methods ==========
+
+read_only_data_batch data_batch::to_read_only()
 {
   auto self = shared_from_this();
   std::shared_lock<std::shared_mutex> lock(_rw_mutex);
   _state.store(batch_state::read_only, std::memory_order_relaxed);
-  return read_only_data_batch<std::shared_ptr<data_batch>>(std::move(self), std::move(lock));
+  return read_only_data_batch(std::move(self), std::move(lock));
 }
 
-mutable_data_batch<std::shared_ptr<data_batch>> data_batch::to_mutable()
+mutable_data_batch data_batch::to_mutable()
 {
   auto self = shared_from_this();
   std::unique_lock<std::shared_mutex> lock(_rw_mutex);
   _state.store(batch_state::mutable_locked, std::memory_order_relaxed);
-  return mutable_data_batch<std::shared_ptr<data_batch>>(std::move(self), std::move(lock));
+  return mutable_data_batch(std::move(self), std::move(lock));
 }
 
-std::optional<read_only_data_batch<std::shared_ptr<data_batch>>> data_batch::try_to_read_only()
+std::optional<read_only_data_batch> data_batch::try_to_read_only()
 {
   std::shared_lock<std::shared_mutex> lock(_rw_mutex, std::try_to_lock);
   if (!lock.owns_lock()) { return std::nullopt; }
   _state.store(batch_state::read_only, std::memory_order_relaxed);
   auto self = shared_from_this();
-  return read_only_data_batch<std::shared_ptr<data_batch>>(std::move(self), std::move(lock));
+  return read_only_data_batch(std::move(self), std::move(lock));
 }
 
-std::optional<mutable_data_batch<std::shared_ptr<data_batch>>> data_batch::try_to_mutable()
+std::optional<mutable_data_batch> data_batch::try_to_mutable()
 {
   std::unique_lock<std::shared_mutex> lock(_rw_mutex, std::try_to_lock);
   if (!lock.owns_lock()) { return std::nullopt; }
   _state.store(batch_state::mutable_locked, std::memory_order_relaxed);
   auto self = shared_from_this();
-  return mutable_data_batch<std::shared_ptr<data_batch>>(std::move(self), std::move(lock));
+  return mutable_data_batch(std::move(self), std::move(lock));
 }
 
-// ========== Explicit template instantiations ==========
+// ========== Locked-to-locked static transitions ==========
 
-template class read_only_data_batch<std::shared_ptr<data_batch>>;
-template class read_only_data_batch<std::unique_ptr<data_batch>>;
-template class mutable_data_batch<std::shared_ptr<data_batch>>;
-template class mutable_data_batch<std::unique_ptr<data_batch>>;
+mutable_data_batch data_batch::readonly_to_mutable(read_only_data_batch&& accessor)
+{
+  auto ptr = std::move(accessor._batch);
+  accessor._lock.unlock();
+  std::unique_lock<std::shared_mutex> lock(ptr->_rw_mutex);
+  ptr->_state.store(batch_state::mutable_locked, std::memory_order_relaxed);
+  return mutable_data_batch(std::move(ptr), std::move(lock));
+}
+
+read_only_data_batch data_batch::mutable_to_readonly(mutable_data_batch&& accessor)
+{
+  auto ptr = std::move(accessor._batch);
+  accessor._lock.unlock();
+  std::shared_lock<std::shared_mutex> lock(ptr->_rw_mutex);
+  ptr->_state.store(batch_state::read_only, std::memory_order_relaxed);
+  return read_only_data_batch(std::move(ptr), std::move(lock));
+}
+
+// ========== read_only_data_batch ==========
+
+read_only_data_batch::read_only_data_batch(std::shared_ptr<data_batch> parent,
+                                           std::shared_lock<std::shared_mutex> lock)
+  : _batch(std::move(parent)), _lock(std::move(lock))
+{
+}
+
+std::shared_ptr<data_batch> read_only_data_batch::clone(uint64_t new_batch_id,
+                                                        rmm::cuda_stream_view stream) const
+{
+  if (_batch->_data == nullptr) { throw std::runtime_error("Cannot clone: data is null"); }
+  auto cloned_data = _batch->_data->clone(stream);
+  return std::make_shared<data_batch>(new_batch_id, std::move(cloned_data));
+}
+
+// ========== mutable_data_batch ==========
+
+mutable_data_batch::mutable_data_batch(std::shared_ptr<data_batch> parent,
+                                       std::unique_lock<std::shared_mutex> lock)
+  : _batch(std::move(parent)), _lock(std::move(lock))
+{
+}
+
+std::shared_ptr<data_batch> mutable_data_batch::clone(uint64_t new_batch_id,
+                                                      rmm::cuda_stream_view stream) const
+{
+  if (_batch->_data == nullptr) { throw std::runtime_error("Cannot clone: data is null"); }
+  auto cloned_data = _batch->_data->clone(stream);
+  return std::make_shared<data_batch>(new_batch_id, std::move(cloned_data));
+}
 
 }  // namespace cucascade

--- a/src/data/data_batch.cpp
+++ b/src/data/data_batch.cpp
@@ -62,6 +62,42 @@ memory::memory_space* data_batch::get_memory_space() const
 
 void data_batch::set_data(std::unique_ptr<idata_representation> data) { _data = std::move(data); }
 
+// ========== Non-static transition methods (shared_ptr only) ==========
+
+read_only_data_batch<std::shared_ptr<data_batch>> data_batch::to_read_only()
+{
+  auto self = shared_from_this();
+  std::shared_lock<std::shared_mutex> lock(_rw_mutex);
+  _state.store(batch_state::read_only, std::memory_order_relaxed);
+  return read_only_data_batch<std::shared_ptr<data_batch>>(std::move(self), std::move(lock));
+}
+
+mutable_data_batch<std::shared_ptr<data_batch>> data_batch::to_mutable()
+{
+  auto self = shared_from_this();
+  std::unique_lock<std::shared_mutex> lock(_rw_mutex);
+  _state.store(batch_state::mutable_locked, std::memory_order_relaxed);
+  return mutable_data_batch<std::shared_ptr<data_batch>>(std::move(self), std::move(lock));
+}
+
+std::optional<read_only_data_batch<std::shared_ptr<data_batch>>> data_batch::try_to_read_only()
+{
+  std::shared_lock<std::shared_mutex> lock(_rw_mutex, std::try_to_lock);
+  if (!lock.owns_lock()) { return std::nullopt; }
+  _state.store(batch_state::read_only, std::memory_order_relaxed);
+  auto self = shared_from_this();
+  return read_only_data_batch<std::shared_ptr<data_batch>>(std::move(self), std::move(lock));
+}
+
+std::optional<mutable_data_batch<std::shared_ptr<data_batch>>> data_batch::try_to_mutable()
+{
+  std::unique_lock<std::shared_mutex> lock(_rw_mutex, std::try_to_lock);
+  if (!lock.owns_lock()) { return std::nullopt; }
+  _state.store(batch_state::mutable_locked, std::memory_order_relaxed);
+  auto self = shared_from_this();
+  return mutable_data_batch<std::shared_ptr<data_batch>>(std::move(self), std::move(lock));
+}
+
 // ========== Explicit template instantiations ==========
 
 template class read_only_data_batch<std::shared_ptr<data_batch>>;

--- a/src/data/data_batch.cpp
+++ b/src/data/data_batch.cpp
@@ -16,455 +16,57 @@
  */
 
 #include <cucascade/data/data_batch.hpp>
-#include <cucascade/data/gpu_data_representation.hpp>
-
-#include <optional>
 
 namespace cucascade {
 
-// data_batch_processing_handle implementation
+// ========== data_batch implementation ==========
 
-data_batch_processing_handle::~data_batch_processing_handle() { release(); }
-
-void data_batch_processing_handle::release()
+data_batch::data_batch(uint64_t batch_id, std::unique_ptr<idata_representation> data)
+  : _batch_id(batch_id), _data(std::move(data))
 {
-  if (_batch.has_value()) {
-    if (auto b = _batch->lock()) { b->decrement_processing_count(); }
-    _batch = std::nullopt;
-  }
 }
-
-// data_batch implementation
-
-data_batch::data_batch(uint64_t batch_id,
-                       std::unique_ptr<idata_representation> data,
-                       std::unique_ptr<idata_batch_probe> probe)
-  : _batch_id(batch_id), _data(std::move(data)), _probe(std::move(probe))
-{
-  std::unique_lock<std::mutex> lock(_mutex);
-  update_state_to(batch_state::idle, lock);
-}
-
-data_batch::data_batch(data_batch&& other)
-  : _batch_id(other._batch_id), _data(std::move(other._data))
-{
-  std::unique_lock<std::mutex> lock(other._mutex);
-  size_t other_processing_count = other._processing_count;
-  if (other_processing_count != 0) {
-    throw std::runtime_error(
-      "Cannot move data_batch with active processing (processing_count != 0)");
-  }
-  other._batch_id = 0;
-  other._data     = nullptr;
-}
-
-data_batch& data_batch::operator=(data_batch&& other)
-{
-  if (this != &other) {
-    std::unique_lock<std::mutex> lock(other._mutex);
-    size_t other_processing_count = other._processing_count;
-    if (other_processing_count != 0) {
-      throw std::runtime_error(
-        "Cannot move data_batch with active processing (processing_count != 0)");
-    }
-    _batch_id       = other._batch_id;
-    _data           = std::move(other._data);
-    other._batch_id = 0;
-    other._data     = nullptr;
-  }
-  return *this;
-}
-
-memory::Tier data_batch::get_current_tier() const { return _data->get_current_tier(); }
 
 uint64_t data_batch::get_batch_id() const { return _batch_id; }
 
-batch_state data_batch::get_state() const
+bool data_batch::subscribe()
 {
-  std::unique_lock<std::mutex> lock(_mutex);
-  return _state;
+  _subscriber_count.fetch_add(1, std::memory_order_relaxed);
+  return true;
 }
 
-size_t data_batch::get_processing_count() const
+void data_batch::unsubscribe()
 {
-  std::unique_lock<std::mutex> lock(_mutex);
-  return _processing_count;
+  size_t prev = _subscriber_count.fetch_sub(1, std::memory_order_relaxed);
+  if (prev == 0) {
+    _subscriber_count.fetch_add(1, std::memory_order_relaxed);
+    throw std::runtime_error("Cannot unsubscribe: subscriber count is already zero");
+  }
 }
+
+size_t data_batch::get_subscriber_count() const
+{
+  return _subscriber_count.load(std::memory_order_relaxed);
+}
+
+// ========== data_batch private data accessors ==========
+
+memory::Tier data_batch::get_current_tier() const { return _data->get_current_tier(); }
 
 idata_representation* data_batch::get_data() const { return _data.get(); }
 
-cucascade::memory::memory_space* data_batch::get_memory_space() const
+memory::memory_space* data_batch::get_memory_space() const
 {
   if (_data == nullptr) { return nullptr; }
   return &_data->get_memory_space();
 }
 
-void data_batch::set_state_change_cv(std::condition_variable* cv)
-{
-  std::unique_lock<std::mutex> lock(_mutex);
-  _state_change_cv = cv;
-}
+void data_batch::set_data(std::unique_ptr<idata_representation> data) { _data = std::move(data); }
 
-void data_batch::set_data(std::unique_ptr<idata_representation> data)
-{
-  std::unique_lock<std::mutex> lock(_mutex);
-  if (_processing_count != 0) {
-    throw std::runtime_error("Cannot set data while there is active processing");
-  }
-  _data = std::move(data);
-}
+// ========== Explicit template instantiations ==========
 
-bool data_batch::try_to_create_task()
-{
-  std::condition_variable* cv_to_notify = nullptr;
-  bool should_notify                    = false;
-  bool success                          = false;
-  {
-    std::unique_lock<std::mutex> lock(_mutex);
-    if (_state == batch_state::idle) {
-      ++_task_created_count;
-      update_state_to(batch_state::task_created, lock);
-      should_notify = true;
-      cv_to_notify  = _state_change_cv;
-      success       = true;
-    } else if (_state == batch_state::task_created) {
-      ++_task_created_count;
-      should_notify = true;
-      success       = true;
-    } else if (_state == batch_state::processing) {
-      // Batch is already processing, increment counter but stay in processing state
-      ++_task_created_count;
-      should_notify = true;
-      success       = true;
-    }
-  }
-  if (should_notify) { _internal_cv.notify_all(); }
-  if (should_notify && cv_to_notify) { cv_to_notify->notify_all(); }
-  return success;
-}
-
-void data_batch::wait_to_create_task()
-{
-  std::condition_variable* cv_to_notify = nullptr;
-  {
-    std::unique_lock<std::mutex> lock(_mutex);
-    _internal_cv.wait(lock, [&] { return _state != batch_state::in_transit; });
-    if (_state == batch_state::idle) {
-      update_state_to(batch_state::task_created, lock);
-      cv_to_notify = _state_change_cv;
-    }
-    // Always increment and always notify: wait_to_lock_for_processing waits on
-    // _internal_cv checking _task_created_count > 0, so it must be woken here.
-    ++_task_created_count;
-  }
-  _internal_cv.notify_all();
-  if (cv_to_notify) { cv_to_notify->notify_all(); }
-}
-
-size_t data_batch::get_task_created_count() const
-{
-  std::unique_lock<std::mutex> lock(_mutex);
-  return _task_created_count;
-}
-
-bool data_batch::try_to_cancel_task()
-{
-  std::condition_variable* cv_to_notify = nullptr;
-  bool should_notify                    = false;
-  bool success                          = false;
-  {
-    std::unique_lock<std::mutex> lock(_mutex);
-    if (_state == batch_state::task_created || _state == batch_state::processing) {
-      if (_task_created_count == 0) {
-        throw std::runtime_error(
-          "Cannot cancel task: task_created_count is zero. "
-          "try_to_create_task() must be called before try_to_cancel_task()");
-      }
-      --_task_created_count;
-      if (_task_created_count == 0 && _processing_count == 0) {
-        update_state_to(batch_state::idle, lock);
-        should_notify = true;
-        cv_to_notify  = _state_change_cv;
-      }
-      success = true;
-    }
-  }
-  if (should_notify) { _internal_cv.notify_all(); }
-  if (should_notify && cv_to_notify) { cv_to_notify->notify_all(); }
-  return success;
-}
-
-void data_batch::wait_to_cancel_task()
-{
-  std::condition_variable* cv_to_notify = nullptr;
-  bool should_notify                    = false;
-  {
-    std::unique_lock<std::mutex> lock(_mutex);
-    _internal_cv.wait(lock, [&] {
-      return _state == batch_state::task_created || _state == batch_state::processing;
-    });
-    if (_task_created_count == 0) {
-      throw std::runtime_error(
-        "Cannot cancel task: task_created_count is zero. "
-        "try_to_create_task() must be called before wait_to_cancel_task()");
-    }
-    --_task_created_count;
-    if (_task_created_count == 0 && _processing_count == 0) {
-      update_state_to(batch_state::idle, lock);
-      should_notify = true;
-      cv_to_notify  = _state_change_cv;
-    }
-  }
-  if (should_notify) { _internal_cv.notify_all(); }
-  if (should_notify && cv_to_notify) { cv_to_notify->notify_all(); }
-}
-
-lock_for_processing_result data_batch::try_to_lock_for_processing(
-  memory::memory_space_id requested_memory_space)
-{
-  std::condition_variable* cv_to_notify = nullptr;
-  bool should_notify                    = false;
-  lock_for_processing_result result{
-    false, data_batch_processing_handle{}, lock_for_processing_status::not_attempted};
-  {
-    std::unique_lock<std::mutex> lock(_mutex);
-
-    if (_data == nullptr) {
-      result.status = lock_for_processing_status::missing_data;
-      return result;
-    }
-
-    if (_data->get_memory_space().get_id() != requested_memory_space) {
-      result.status = lock_for_processing_status::memory_space_mismatch;
-      return result;
-    }
-
-    if (_task_created_count == 0) {
-      result.status = lock_for_processing_status::task_not_created;
-      return result;
-    }
-
-    if (!(_state == batch_state::task_created || _state == batch_state::processing)) {
-      result.status = lock_for_processing_status::invalid_state;
-      return result;
-    }
-    --_task_created_count;
-    ++_processing_count;
-    update_state_to(batch_state::processing, lock);
-    should_notify = true;
-    cv_to_notify  = _state_change_cv;
-    result        = {
-      true, data_batch_processing_handle{shared_from_this()}, lock_for_processing_status::success};
-  }
-  if (should_notify) { _internal_cv.notify_all(); }
-  if (should_notify && cv_to_notify) { cv_to_notify->notify_all(); }
-  return result;
-}
-
-lock_for_processing_result data_batch::wait_to_lock_for_processing(
-  memory::memory_space_id requested_memory_space)
-{
-  std::condition_variable* cv_to_notify = nullptr;
-  lock_for_processing_result result{
-    false, data_batch_processing_handle{}, lock_for_processing_status::not_attempted};
-  {
-    std::unique_lock<std::mutex> lock(_mutex);
-
-    // Return immediately for failures that cannot be resolved by waiting
-    if (_data == nullptr) {
-      result.status = lock_for_processing_status::missing_data;
-      return result;
-    }
-    if (_data->get_memory_space().get_id() != requested_memory_space) {
-      result.status = lock_for_processing_status::memory_space_mismatch;
-      return result;
-    }
-
-    // Wait until the state allows locking for processing
-    _internal_cv.wait(lock, [&] {
-      return (_state == batch_state::task_created || _state == batch_state::processing) &&
-             _task_created_count > 0;
-    });
-
-    // Re-check non-waitable conditions after waking (data may have changed)
-    if (_data == nullptr) {
-      result.status = lock_for_processing_status::missing_data;
-      return result;
-    }
-    if (_data->get_memory_space().get_id() != requested_memory_space) {
-      result.status = lock_for_processing_status::memory_space_mismatch;
-      return result;
-    }
-
-    --_task_created_count;
-    ++_processing_count;
-    update_state_to(batch_state::processing, lock);
-    cv_to_notify = _state_change_cv;
-    result       = {
-      true, data_batch_processing_handle{shared_from_this()}, lock_for_processing_status::success};
-  }
-  _internal_cv.notify_all();
-  if (cv_to_notify) { cv_to_notify->notify_all(); }
-  return result;
-}
-
-bool data_batch::try_to_lock_for_in_transit()
-{
-  std::condition_variable* cv_to_notify = nullptr;
-  bool should_notify                    = false;
-  bool success                          = false;
-  {
-    std::unique_lock<std::mutex> lock(_mutex);
-    if (_processing_count == 0 &&
-        ((_state == batch_state::idle) ||
-         (_state == batch_state::task_created && _task_created_count > 0))) {
-      update_state_to(batch_state::in_transit, lock);
-      should_notify = true;
-      cv_to_notify  = _state_change_cv;
-      success       = true;
-    }
-  }
-  if (should_notify) { _internal_cv.notify_all(); }
-  if (should_notify && cv_to_notify) { cv_to_notify->notify_all(); }
-  return success;
-}
-
-void data_batch::wait_to_lock_for_in_transit()
-{
-  std::condition_variable* cv_to_notify = nullptr;
-  {
-    std::unique_lock<std::mutex> lock(_mutex);
-    _internal_cv.wait(lock, [&] {
-      return _processing_count == 0 &&
-             ((_state == batch_state::idle) ||
-              (_state == batch_state::task_created && _task_created_count > 0));
-    });
-    update_state_to(batch_state::in_transit, lock);
-    cv_to_notify = _state_change_cv;
-  }
-  _internal_cv.notify_all();
-  if (cv_to_notify) { cv_to_notify->notify_all(); }
-}
-
-bool data_batch::try_to_release_in_transit(std::optional<batch_state> target_state)
-{
-  std::condition_variable* cv_to_notify = nullptr;
-  bool should_notify                    = false;
-  bool success                          = false;
-  {
-    std::unique_lock<std::mutex> lock(_mutex);
-    if (_state == batch_state::in_transit) {
-      // Caller can explicitly choose the state to return to; default is idle.
-      if (target_state.has_value()) {
-        if (*target_state == batch_state::idle) {
-          update_state_to(batch_state::idle, lock);
-        } else {
-          // first transition to idle
-          update_state_to(batch_state::idle, lock);
-          // then to the next state, maintaining FSM invariants
-          update_state_to(*target_state, lock);
-        }
-      } else {
-        update_state_to(batch_state::idle, lock);
-      }
-      should_notify = true;
-      cv_to_notify  = _state_change_cv;
-      success       = true;
-    }
-  }
-  if (should_notify) { _internal_cv.notify_all(); }
-  if (should_notify && cv_to_notify) { cv_to_notify->notify_all(); }
-  return success;
-}
-
-void data_batch::wait_to_release_in_transit(std::optional<batch_state> target_state)
-{
-  std::condition_variable* cv_to_notify = nullptr;
-  {
-    std::unique_lock<std::mutex> lock(_mutex);
-    _internal_cv.wait(lock, [&] { return _state == batch_state::in_transit; });
-    // Caller can explicitly choose the state to return to; default is idle.
-    if (target_state.has_value()) {
-      if (*target_state == batch_state::idle) {
-        update_state_to(batch_state::idle, lock);
-      } else {
-        // first transition to idle
-        update_state_to(batch_state::idle, lock);
-        // then to the next state, maintaining FSM invariants
-        update_state_to(*target_state, lock);
-      }
-    } else {
-      update_state_to(batch_state::idle, lock);
-    }
-    cv_to_notify = _state_change_cv;
-  }
-  _internal_cv.notify_all();
-  if (cv_to_notify) { cv_to_notify->notify_all(); }
-}
-
-void data_batch::decrement_processing_count()
-{
-  std::condition_variable* cv_to_notify = nullptr;
-  bool should_notify                    = false;
-  {
-    std::unique_lock<std::mutex> lock(_mutex);
-    if (_state != batch_state::processing) {
-      throw std::runtime_error(
-        "Cannot decrement processing count: batch is not in processing state. state: " +
-        std::to_string((int)_state));
-    }
-    if (_processing_count == 0) {
-      throw std::runtime_error(
-        "Cannot decrement processing count: processing count is already zero");
-    }
-    _processing_count -= 1;
-    if (_processing_count == 0) {
-      // Preserve pending task_created intent if any remain
-      update_state_to((_task_created_count > 0) ? batch_state::task_created : batch_state::idle,
-                      lock);
-      should_notify = true;
-      cv_to_notify  = _state_change_cv;
-    }
-  }
-  if (should_notify) { _internal_cv.notify_all(); }
-  if (should_notify && cv_to_notify) { cv_to_notify->notify_all(); }
-}
-
-std::shared_ptr<data_batch> data_batch::clone(
-  uint64_t new_batch_id,
-  rmm::cuda_stream_view stream,
-  std::optional<std::unique_ptr<idata_batch_probe>> probe)
-{
-  // Create a task and lock for processing to protect data during clone
-  if (!try_to_create_task()) {
-    throw std::runtime_error(
-      "Cannot clone data_batch: failed to create task (batch may be in transit)");
-  }
-
-  auto space_id = _data->get_memory_space().get_id();
-  std::unique_ptr<idata_representation> cloned_data;
-  {
-    auto result = try_to_lock_for_processing(space_id);
-    if (!result.success) {
-      throw std::runtime_error("Cannot clone data_batch: failed to lock for processing");
-    }
-
-    // Clone the data while holding the processing lock
-    cloned_data = _data->clone(stream);
-  }
-  // Handle destructor will decrement processing count when result goes out of scope
-  return std::make_shared<data_batch>(
-    new_batch_id,
-    std::move(cloned_data),
-    probe ? std::move(*probe) : std::make_unique<idata_batch_probe>());
-}
-
-void data_batch::update_state_to(batch_state new_state,
-                                 const std::unique_lock<std::mutex>& /*lock*/)
-{
-  _state = new_state;
-  _probe->state_transitioned_to(
-    _state, _batch_id, *(this->get_data()), _processing_count, _task_created_count);
-}
+template class read_only_data_batch<std::shared_ptr<data_batch>>;
+template class read_only_data_batch<std::unique_ptr<data_batch>>;
+template class mutable_data_batch<std::shared_ptr<data_batch>>;
+template class mutable_data_batch<std::unique_ptr<data_batch>>;
 
 }  // namespace cucascade

--- a/src/data/data_batch.cpp
+++ b/src/data/data_batch.cpp
@@ -66,25 +66,13 @@ void data_batch::set_data(std::unique_ptr<idata_representation> data) { _data = 
 
 std::shared_ptr<data_batch> data_batch::to_idle(read_only_data_batch&& accessor)
 {
-  // Ownership-transfer pattern: steal _batch so the accessor's destructor becomes a no-op
-  // (nullptr check in destructor skips all cleanup). We then manually perform the cleanup
-  // that the destructor would have done: decrement read_only_count, set state, unlock.
-  // The lock is explicitly unlocked here because the accessor's shared_lock will NOT
-  // call unlock in its destructor after we call unlock() explicitly -- shared_lock tracks
-  // ownership and will skip the unlock if the lock is already released.
-  auto ptr = std::move(accessor._batch);
-  ptr->_read_only_count.fetch_sub(1, std::memory_order_acq_rel);
-  ptr->_state.store(batch_state::idle, std::memory_order_release);
-  accessor._lock.unlock();
+  auto ptr = accessor._batch;
   return ptr;
 }
 
 std::shared_ptr<data_batch> data_batch::to_idle(mutable_data_batch&& accessor)
 {
-  // Same ownership-transfer pattern as the read_only overload above.
-  auto ptr = std::move(accessor._batch);
-  ptr->_state.store(batch_state::idle, std::memory_order_release);
-  accessor._lock.unlock();
+  auto ptr = accessor._batch;
   return ptr;
 }
 
@@ -94,8 +82,6 @@ read_only_data_batch data_batch::to_read_only()
 {
   auto self = shared_from_this();
   std::shared_lock<std::shared_mutex> lock(_rw_mutex);
-  _state.store(batch_state::read_only, std::memory_order_release);
-  // The read_only_data_batch constructor increments _read_only_count.
   return read_only_data_batch(std::move(self), std::move(lock));
 }
 
@@ -103,7 +89,6 @@ mutable_data_batch data_batch::to_mutable()
 {
   auto self = shared_from_this();
   std::unique_lock<std::shared_mutex> lock(_rw_mutex);
-  _state.store(batch_state::mutable_locked, std::memory_order_release);
   return mutable_data_batch(std::move(self), std::move(lock));
 }
 
@@ -111,9 +96,7 @@ std::optional<read_only_data_batch> data_batch::try_to_read_only()
 {
   std::shared_lock<std::shared_mutex> lock(_rw_mutex, std::try_to_lock);
   if (!lock.owns_lock()) { return std::nullopt; }
-  _state.store(batch_state::read_only, std::memory_order_release);
   auto self = shared_from_this();
-  // The read_only_data_batch constructor increments _read_only_count.
   return read_only_data_batch(std::move(self), std::move(lock));
 }
 
@@ -121,7 +104,6 @@ std::optional<mutable_data_batch> data_batch::try_to_mutable()
 {
   std::unique_lock<std::shared_mutex> lock(_rw_mutex, std::try_to_lock);
   if (!lock.owns_lock()) { return std::nullopt; }
-  _state.store(batch_state::mutable_locked, std::memory_order_release);
   auto self = shared_from_this();
   return mutable_data_batch(std::move(self), std::move(lock));
 }
@@ -130,22 +112,23 @@ std::optional<mutable_data_batch> data_batch::try_to_mutable()
 
 mutable_data_batch data_batch::readonly_to_mutable(read_only_data_batch&& accessor)
 {
-  auto ptr = std::move(accessor._batch);
-  // Decrement _read_only_count: we're removing a reader before re-locking as mutable.
-  ptr->_read_only_count.fetch_sub(1, std::memory_order_acq_rel);
-  accessor._lock.unlock();
+  auto ptr = accessor._batch;
+  {
+    // destructor decrements _read_only_count, releases the shared lock and sets state to idle                                                             
+    auto _ = std::move(accessor);  // move into temporary, destroyed at }
+  }   
   std::unique_lock<std::shared_mutex> lock(ptr->_rw_mutex);
-  ptr->_state.store(batch_state::mutable_locked, std::memory_order_release);
   return mutable_data_batch(std::move(ptr), std::move(lock));
 }
 
 read_only_data_batch data_batch::mutable_to_readonly(mutable_data_batch&& accessor)
 {
-  auto ptr = std::move(accessor._batch);
-  accessor._lock.unlock();
+  auto ptr = accessor._batch;
+  {
+    // destructor frees the exclusive lock and sets state to idle                                                             
+    auto _ = std::move(accessor);  // move into temporary, destroyed at }
+  }   
   std::shared_lock<std::shared_mutex> lock(ptr->_rw_mutex);
-  ptr->_state.store(batch_state::read_only, std::memory_order_release);
-  // The read_only_data_batch constructor increments _read_only_count.
   return read_only_data_batch(std::move(ptr), std::move(lock));
 }
 
@@ -155,7 +138,8 @@ read_only_data_batch::read_only_data_batch(std::shared_ptr<data_batch> parent,
                                            std::shared_lock<std::shared_mutex> lock)
   : _batch(std::move(parent)), _lock(std::move(lock))
 {
-  _batch->_read_only_count.fetch_add(1, std::memory_order_acq_rel);
+  _batch->_read_only_count.fetch_add(1);
+  _batch->_state.store(batch_state::read_only);
 }
 
 read_only_data_batch::read_only_data_batch(read_only_data_batch&& other) noexcept
@@ -170,8 +154,8 @@ read_only_data_batch& read_only_data_batch::operator=(read_only_data_batch&& oth
   if (this != &other) {
     // Release the current state (same logic as destructor)
     if (_batch) {
-      auto prev = _batch->_read_only_count.fetch_sub(1, std::memory_order_acq_rel);
-      if (prev == 1) { _batch->_state.store(batch_state::idle, std::memory_order_release); }
+      auto prev = _batch->_read_only_count.fetch_sub(1);
+      if (prev == 1) { _batch->_state.store(batch_state::idle); }
       // _lock will be replaced below; its destructor fires when the old _lock is overwritten,
       // releasing the shared lock. We release _lock explicitly here so the sequence is:
       // decrement count -> set state (if last) -> release lock.
@@ -191,8 +175,8 @@ read_only_data_batch::~read_only_data_batch()
     // The destructor body runs before member destructors, so _batch is still valid here.
     // After this function returns, _lock destructor fires first (declared after _batch,
     // destroyed in reverse order), releasing the shared lock. Then _batch destructor fires.
-    auto prev = _batch->_read_only_count.fetch_sub(1, std::memory_order_acq_rel);
-    if (prev == 1) { _batch->_state.store(batch_state::idle, std::memory_order_release); }
+    auto prev = _batch->_read_only_count.fetch_sub(1);
+    if (prev == 1) { _batch->_state.store(batch_state::idle); }
   }
 }
 
@@ -210,6 +194,7 @@ mutable_data_batch::mutable_data_batch(std::shared_ptr<data_batch> parent,
                                        std::unique_lock<std::shared_mutex> lock)
   : _batch(std::move(parent)), _lock(std::move(lock))
 {
+  _batch->_state.store(batch_state::mutable_locked);
 }
 
 mutable_data_batch::mutable_data_batch(mutable_data_batch&& other) noexcept
@@ -223,7 +208,7 @@ mutable_data_batch& mutable_data_batch::operator=(mutable_data_batch&& other) no
   if (this != &other) {
     // Release the current state (same logic as destructor)
     if (_batch) {
-      _batch->_state.store(batch_state::idle, std::memory_order_release);
+      _batch->_state.store(batch_state::idle);
       // Release the exclusive lock explicitly before taking ownership of the new one.
       _lock.unlock();
     }
@@ -237,7 +222,7 @@ mutable_data_batch::~mutable_data_batch()
 {
   if (_batch) {
     // Transition state to idle. The _lock member destructor handles releasing the exclusive lock.
-    _batch->_state.store(batch_state::idle, std::memory_order_release);
+    _batch->_state.store(batch_state::idle);
   }
 }
 

--- a/src/data/data_repository.cpp
+++ b/src/data/data_repository.cpp
@@ -26,75 +26,28 @@ template class idata_repository<std::unique_ptr<data_batch>>;
 // Explicit specialization of get_data_batch_by_id for shared_ptr (copies the pointer)
 template <>
 std::shared_ptr<data_batch> idata_repository<std::shared_ptr<data_batch>>::get_data_batch_by_id(
-  uint64_t batch_id, std::optional<batch_state> target_state, size_t partition_idx)
+  uint64_t batch_id, size_t partition_idx)
 {
   std::unique_lock<std::mutex> lock(_mutex);
 
-  // Validate partition index
   if (partition_idx >= _data_batches.size()) {
     throw std::out_of_range("partition_idx out of range");
   }
 
-  // If no target_state specified, just find and return a copy of the batch pointer
-  if (!target_state.has_value()) {
-    for (auto it = _data_batches[partition_idx].begin(); it != _data_batches[partition_idx].end();
-         ++it) {
-      if ((*it)->get_batch_id() == batch_id) {
-        return *it;  // Return a copy of the shared_ptr
-      }
+  for (auto it = _data_batches[partition_idx].begin(); it != _data_batches[partition_idx].end();
+       ++it) {
+    if ((*it)->get_batch_id() == batch_id) {
+      return *it;  // Return a copy of the shared_ptr
     }
-    // Batch not found
-    return nullptr;
   }
 
-  // Target state specified - attempt state transition and wait if needed
-  while (true) {
-    // Search for the batch with the matching batch_id
-    bool batch_found = false;
-    for (auto it = _data_batches[partition_idx].begin(); it != _data_batches[partition_idx].end();
-         ++it) {
-      if ((*it)->get_batch_id() == batch_id) {
-        batch_found           = true;
-        data_batch* batch_ptr = it->get();
-        bool can_transition   = false;
-
-        switch (*target_state) {
-          case batch_state::task_created: can_transition = batch_ptr->try_to_create_task(); break;
-          case batch_state::processing:
-            throw std::runtime_error(
-              "get_data_batch_by_id cannot transition directly to processing; "
-              "use pop_data_batch with task_created and call try_to_lock_for_processing() on the "
-              "batch");
-          case batch_state::in_transit:
-            can_transition = batch_ptr->try_to_lock_for_in_transit();
-            break;
-          case batch_state::idle:
-            // Cannot transition to idle via get - idle is a terminal state
-            can_transition = false;
-            break;
-        }
-
-        if (can_transition) {
-          return *it;  // Return a copy of the shared_ptr
-        }
-
-        // Batch found but cannot transition - wait for state change
-        break;
-      }
-    }
-
-    // If batch was not found, return nullptr
-    if (!batch_found) { return nullptr; }
-
-    // Batch exists but cannot transition - wait for state changes
-    _cv.wait(lock);
-  }
+  return nullptr;
 }
 
 // Explicit specialization of get_data_batch_by_id for unique_ptr (not supported)
 template <>
 std::unique_ptr<data_batch> idata_repository<std::unique_ptr<data_batch>>::get_data_batch_by_id(
-  uint64_t /*batch_id*/, std::optional<batch_state> /*target_state*/, size_t /*partition_idx*/)
+  uint64_t /*batch_id*/, size_t /*partition_idx*/)
 {
   throw std::runtime_error(
     "get_data_batch_by_id is not supported for unique_ptr repositories. "

--- a/src/memory/fixed_size_host_memory_resource.cpp
+++ b/src/memory/fixed_size_host_memory_resource.cpp
@@ -171,7 +171,7 @@ std::vector<std::byte*> fixed_size_host_memory_resource::allocate_multiple_block
         if (tracker) tracker->allocated_bytes.fetch_sub(static_cast<int64_t>(total_bytes));
         throw rmm::out_of_memory(
           "Not enough free blocks available in fixed_size_host_memory_resource and pool expansion "
-          "failed.");
+          "failed. total_bytes: " + std::to_string(total_bytes) + ", upstream_tracked_bytes: " + std::to_string(upstream_tracked_bytes) + ", only " + std::to_string(_free_blocks.size()) + " free blocks available from " + std::to_string(num_blocks) + " requested blocks" + ".");
       }
 
       std::byte* ptr = static_cast<std::byte*>(_free_blocks.back());
@@ -183,7 +183,8 @@ std::vector<std::byte*> fixed_size_host_memory_resource::allocate_multiple_block
   } else {
     if (tracker) tracker->allocated_bytes.fetch_sub(static_cast<int64_t>(total_bytes));
     throw rmm::out_of_memory(
-      "Not enough free blocks available in fixed_size_host_memory_resource.");
+      "Not enough free blocks available in fixed_size_host_memory_resource. " 
+      "total_bytes: " + std::to_string(total_bytes) + ", upstream_tracked_bytes: " + std::to_string(upstream_tracked_bytes) + ", only " + std::to_string(_free_blocks.size()) + " free blocks available from " + std::to_string(num_blocks) + " requested blocks" + ".");
   }
   return {};
 }

--- a/test/data/test_data_batch.cpp
+++ b/test/data/test_data_batch.cpp
@@ -32,7 +32,9 @@
 #include <chrono>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <optional>
+#include <string>
 #include <thread>
 #include <type_traits>
 #include <vector>
@@ -852,4 +854,206 @@ TEST_CASE("data_batch full cycle: idle -> ro -> mutable -> ro -> idle", "[data_b
 
   REQUIRE(idle->get_state() == batch_state::idle);
   REQUIRE(idle->get_batch_id() == 1);
+}
+
+// =============================================================================
+// RAII lifecycle tests: _read_only_count tracking and destructor state transitions
+// =============================================================================
+
+TEST_CASE("data_batch read_only_count tracks concurrent readers", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  REQUIRE(batch->get_read_only_count() == 0);
+
+  // Create first reader
+  auto ro1 = batch->to_read_only();
+  REQUIRE(batch->get_read_only_count() == 1);
+
+  // Create second reader
+  auto ro2 = batch->to_read_only();
+  REQUIRE(batch->get_read_only_count() == 2);
+
+  // Create third reader
+  auto ro3 = batch->to_read_only();
+  REQUIRE(batch->get_read_only_count() == 3);
+
+  // Drop one reader via to_idle
+  auto idle = data_batch::to_idle(std::move(ro1));
+  REQUIRE(batch->get_read_only_count() == 2);
+
+  // Drop remaining readers via destructor (scope exit)
+  {
+    auto temp = std::move(ro2);
+    // temp destructor fires at end of scope
+  }
+  REQUIRE(batch->get_read_only_count() == 1);
+
+  // Last reader — should transition to idle
+  {
+    auto temp = std::move(ro3);
+  }
+  REQUIRE(batch->get_read_only_count() == 0);
+  REQUIRE(batch->get_state() == batch_state::idle);
+}
+
+TEST_CASE("data_batch destructor transitions state to idle for read_only", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  {
+    auto ro = batch->to_read_only();
+    REQUIRE(batch->get_state() == batch_state::read_only);
+    // ro destructor fires here
+  }
+  REQUIRE(batch->get_state() == batch_state::idle);
+}
+
+TEST_CASE("data_batch destructor transitions state to idle for mutable", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  {
+    auto mut = batch->to_mutable();
+    REQUIRE(batch->get_state() == batch_state::mutable_locked);
+    // mut destructor fires here
+  }
+  REQUIRE(batch->get_state() == batch_state::idle);
+}
+
+TEST_CASE("data_batch concurrent lifecycle: readers then mutable then readers", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  // Track event ordering
+  std::vector<std::string> events;
+  std::mutex events_mutex;
+  auto log_event = [&](const std::string& event) {
+    std::lock_guard<std::mutex> guard(events_mutex);
+    events.push_back(event);
+  };
+
+  // Phase 1: Create initial read_only on main thread
+  auto ro_initial = batch->to_read_only();
+  REQUIRE(batch->get_read_only_count() == 1);
+
+  std::atomic<bool> thread1_readers_created{false};
+  std::atomic<bool> thread1_readers_released{false};
+  std::atomic<bool> thread2_mutable_acquired{false};
+  std::atomic<bool> thread2_mutable_released{false};
+
+  // Thread 1: create 2 more read_only, then release all 3, then create 2 more after mutable done
+  std::thread t1([&]() {
+    // Create 2 more readers
+    auto ro_t1_a = batch->to_read_only();
+    auto ro_t1_b = batch->to_read_only();
+    log_event("t1: 3 readers active");
+    REQUIRE(batch->get_read_only_count() == 3);
+    thread1_readers_created.store(true);
+
+    // Wait a bit to let thread 2 try to acquire mutable (it will block)
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // Move the initial reader into this scope and release all 3
+    auto ro_main = std::move(ro_initial);
+    {
+      auto temp1 = std::move(ro_main);
+      auto temp2 = std::move(ro_t1_a);
+      auto temp3 = std::move(ro_t1_b);
+      // All 3 destructors fire here
+    }
+    log_event("t1: all readers released");
+    thread1_readers_released.store(true);
+    REQUIRE(batch->get_read_only_count() == 0);
+
+    // Wait for thread 2 to acquire and release mutable
+    while (!thread2_mutable_released.load()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+
+    // Create 2 new readers after mutable is done
+    auto ro_new_a = batch->to_read_only();
+    auto ro_new_b = batch->to_read_only();
+    log_event("t1: 2 new readers after mutable");
+    REQUIRE(batch->get_read_only_count() == 2);
+    REQUIRE(ro_new_a.get_batch_id() == 1);
+    REQUIRE(ro_new_b.get_batch_id() == 1);
+    // Let them go out of scope — destructors clean up
+  });
+
+  // Thread 2: wait for readers to be created, then acquire mutable (blocks until readers release)
+  std::thread t2([&]() {
+    // Wait for thread 1 to create its readers
+    while (!thread1_readers_created.load()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+
+    // This will block until all read_only locks are released
+    log_event("t2: requesting mutable");
+    auto mut = batch->to_mutable();
+    log_event("t2: mutable acquired");
+    thread2_mutable_acquired.store(true);
+
+    REQUIRE(batch->get_state() == batch_state::mutable_locked);
+    REQUIRE(batch->get_read_only_count() == 0);
+    REQUIRE(mut.get_batch_id() == 1);
+
+    // Hold mutable briefly
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    // Release via destructor
+    {
+      auto temp = std::move(mut);
+    }
+    log_event("t2: mutable released");
+    thread2_mutable_released.store(true);
+    REQUIRE(batch->get_state() == batch_state::idle);
+  });
+
+  t1.join();
+  t2.join();
+
+  // Validate ordering: readers released before mutable acquired, mutable released before new readers
+  {
+    std::lock_guard<std::mutex> guard(events_mutex);
+    auto find_idx = [&](const std::string& prefix) -> size_t {
+      for (size_t i = 0; i < events.size(); ++i) {
+        if (events[i].find(prefix) != std::string::npos) return i;
+      }
+      return events.size();  // not found
+    };
+
+    size_t idx_readers_released = find_idx("t1: all readers released");
+    size_t idx_mutable_acquired = find_idx("t2: mutable acquired");
+    size_t idx_mutable_released = find_idx("t2: mutable released");
+    size_t idx_new_readers      = find_idx("t1: 2 new readers after mutable");
+
+    REQUIRE(idx_readers_released < idx_mutable_acquired);
+    REQUIRE(idx_mutable_acquired < idx_mutable_released);
+    REQUIRE(idx_mutable_released < idx_new_readers);
+  }
+
+  // Final state: batch should be idle after everything
+  REQUIRE(batch->get_state() == batch_state::idle);
+  REQUIRE(batch->get_read_only_count() == 0);
+}
+
+TEST_CASE("data_batch move does not change read_only_count", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto ro1 = batch->to_read_only();
+  REQUIRE(batch->get_read_only_count() == 1);
+
+  // Move should not change count — ownership transferred, not a new reader
+  auto ro2 = std::move(ro1);
+  REQUIRE(batch->get_read_only_count() == 1);
+
+  // ro1 is now in moved-from state — its destructor fires at end of scope harmlessly
+  // ro2 destructor fires here and decrements count
 }

--- a/test/data/test_data_batch.cpp
+++ b/test/data/test_data_batch.cpp
@@ -32,10 +32,10 @@
 
 #include <atomic>
 #include <chrono>
-#include <map>
 #include <memory>
-#include <mutex>
+#include <optional>
 #include <thread>
+#include <type_traits>
 #include <vector>
 
 using namespace cucascade;
@@ -44,654 +44,458 @@ using cucascade::test::expect_cudf_tables_equal_on_stream;
 using cucascade::test::make_mock_memory_space;
 using cucascade::test::mock_data_representation;
 
-// Test basic construction
-TEST_CASE("data_batch Construction", "[data_batch]")
-{
-  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 2048);
-  data_batch batch(1, std::move(data));
+// =============================================================================
+// Construction tests (TEST-01)
+// =============================================================================
 
-  REQUIRE(batch.get_batch_id() == 1);
-  REQUIRE(batch.get_current_tier() == memory::Tier::GPU);
-  REQUIRE(batch.get_processing_count() == 0);
-  REQUIRE(batch.get_state() == batch_state::idle);
+TEST_CASE("data_batch construction via shared_ptr", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 2048);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  REQUIRE(batch->get_batch_id() == 1);
+  REQUIRE(batch->get_subscriber_count() == 0);
 }
 
-// Test move constructor
-TEST_CASE("data_batch Move Constructor", "[data_batch]")
+TEST_CASE("data_batch construction via unique_ptr", "[data_batch]")
 {
-  auto data = std::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
-  data_batch batch1(42, std::move(data));
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 2048);
+  auto batch = std::make_unique<data_batch>(1, std::move(data));
 
-  REQUIRE(batch1.get_batch_id() == 42);
-  REQUIRE(batch1.get_current_tier() == memory::Tier::HOST);
-
-  // Move construct
-  data_batch batch2(std::move(batch1));
-
-  REQUIRE(batch2.get_batch_id() == 42);
-  REQUIRE(batch2.get_current_tier() == memory::Tier::HOST);
-  REQUIRE(batch1.get_batch_id() == 0);  // Moved-from state
+  REQUIRE(batch->get_batch_id() == 1);
+  REQUIRE(batch->get_subscriber_count() == 0);
 }
 
-// Test move assignment
-TEST_CASE("data_batch Move Assignment", "[data_batch]")
+// =============================================================================
+// Deleted copy/move tests (TEST-03)
+// =============================================================================
+
+TEST_CASE("data_batch is non-copyable and non-movable", "[data_batch]")
 {
-  auto data1 = std::make_unique<mock_data_representation>(memory::Tier::GPU, 512);
-  auto data2 = std::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
-
-  data_batch batch1(10, std::move(data1));
-  data_batch batch2(20, std::move(data2));
-
-  REQUIRE(batch1.get_batch_id() == 10);
-  REQUIRE(batch2.get_batch_id() == 20);
-
-  // Move assign
-  batch1 = std::move(batch2);
-
-  REQUIRE(batch1.get_batch_id() == 20);
-  REQUIRE(batch1.get_current_tier() == memory::Tier::HOST);
-  REQUIRE(batch2.get_batch_id() == 0);  // Moved-from state
+  static_assert(!std::is_copy_constructible_v<data_batch>);
+  static_assert(!std::is_move_constructible_v<data_batch>);
+  static_assert(!std::is_copy_assignable_v<data_batch>);
+  static_assert(!std::is_move_assignable_v<data_batch>);
 }
 
-// Test self-assignment (move)
-TEST_CASE("data_batch Self Move Assignment", "[data_batch]")
+// =============================================================================
+// Lock-free get_batch_id (TEST-01)
+// =============================================================================
+
+TEST_CASE("data_batch get_batch_id is lock-free via shared_ptr", "[data_batch]")
 {
-  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  data_batch batch(100, std::move(data));
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(99, std::move(data));
 
-  // Self-assignment should not crash
-  batch = std::move(batch);
+  // get_batch_id works without acquiring any lock
+  REQUIRE(batch->get_batch_id() == 99);
 
-  REQUIRE(batch.get_batch_id() == 100);
-  REQUIRE(batch.get_current_tier() == memory::Tier::GPU);
+  // Also works through the mutable accessor
+  auto data2  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch2 = std::make_shared<data_batch>(99, std::move(data2));
+  auto rw     = data_batch::to_mutable(std::move(batch2));
+  REQUIRE(rw.get_batch_id() == 99);
 }
 
-// Test processing state management with try_to_lock_for_processing
-TEST_CASE("data_batch Processing State Management", "[data_batch]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  REQUIRE(batch->get_processing_count() == 0);
-  REQUIRE(batch->get_state() == batch_state::idle);
-
-  // Cannot lock for processing directly from idle - must create task first
-  auto bad_idle = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(bad_idle.success == false);
-  REQUIRE(bad_idle.status == lock_for_processing_status::task_not_created);
-  REQUIRE(batch->get_processing_count() == 0);
-  REQUIRE(batch->get_state() == batch_state::idle);
-
-  // Create task first
-  REQUIRE(batch->try_to_create_task() == true);
-  REQUIRE(batch->get_state() == batch_state::task_created);
-
-  // Now lock for processing
-  auto r1 = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(r1.success == true);
-  auto h1 = std::move(r1.handle);
-  REQUIRE(h1.valid() == true);
-  REQUIRE(batch->get_processing_count() == 1);
-  REQUIRE(batch->get_state() == batch_state::processing);
-
-  // Lock again while already processing
-  REQUIRE(batch->try_to_create_task() == true);
-  auto r2 = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(r2.success == true);
-  auto h2 = std::move(r2.handle);
-  REQUIRE(h2.valid() == true);
-  REQUIRE(batch->get_processing_count() == 2);
-  REQUIRE(batch->get_state() == batch_state::processing);
-
-  REQUIRE(batch->try_to_create_task() == true);
-  auto r3 = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(r3.success == true);
-  auto h3 = std::move(r3.handle);
-  REQUIRE(h3.valid() == true);
-  REQUIRE(batch->get_processing_count() == 3);
-}
-
-TEST_CASE("data_batch Lock For Processing Requires Matching Memory Space", "[data_batch]")
-{
-  auto data          = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch         = std::make_shared<data_batch>(1, std::move(data));
-  auto correct_space = batch->get_memory_space()->get_id();
-  auto wrong_space   = memory::memory_space_id{memory::Tier::HOST, correct_space.device_id};
-
-  REQUIRE(batch->try_to_create_task() == true);
-
-  auto wrong = batch->try_to_lock_for_processing(wrong_space);
-  REQUIRE(wrong.success == false);
-  REQUIRE(wrong.status == lock_for_processing_status::memory_space_mismatch);
-  REQUIRE(batch->get_processing_count() == 0);
-  REQUIRE(batch->get_state() == batch_state::task_created);
-
-  auto right = batch->try_to_lock_for_processing(correct_space);
-  REQUIRE(right.success == true);
-  REQUIRE(right.status == lock_for_processing_status::success);
-  auto handle = std::move(right.handle);
-  REQUIRE(handle.valid());
-  REQUIRE(batch->get_processing_count() == 1);
-}
-
-// Test data_batch_processing_handle RAII behavior
-TEST_CASE("data_batch_processing_handle RAII", "[data_batch]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  REQUIRE(batch->get_processing_count() == 0);
-  REQUIRE(batch->get_state() == batch_state::idle);
-
-  {
-    // Create task first, then lock for processing
-    REQUIRE(batch->try_to_create_task() == true);
-    auto r = batch->try_to_lock_for_processing(space_id);
-    REQUIRE(r.success == true);
-    auto handle = std::move(r.handle);
-
-    REQUIRE(batch->get_processing_count() == 1);
-    REQUIRE(batch->get_state() == batch_state::processing);
-
-    {
-      // Create another handle (can lock while already processing)
-      REQUIRE(batch->try_to_create_task() == true);
-      auto r2 = batch->try_to_lock_for_processing(space_id);
-      REQUIRE(r2.success == true);
-      auto handle2 = std::move(r2.handle);
-
-      REQUIRE(batch->get_processing_count() == 2);
-    }  // handle2 goes out of scope
-
-    REQUIRE(batch->get_processing_count() == 1);
-    REQUIRE(batch->get_state() == batch_state::processing);
-  }  // handle goes out of scope
-
-  REQUIRE(batch->get_processing_count() == 0);
-  REQUIRE(batch->get_state() == batch_state::idle);
-}
-
-// Test try_to_lock_for_in_transit blocks processing
-TEST_CASE("data_batch In Transit Blocks Processing", "[data_batch]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  REQUIRE(batch->get_state() == batch_state::idle);
-
-  // Lock for in_transit
-  REQUIRE(batch->try_to_lock_for_in_transit() == true);
-  REQUIRE(batch->get_state() == batch_state::in_transit);
-
-  // Try to create task should fail while in_transit
-  REQUIRE(batch->try_to_create_task() == false);
-  REQUIRE(batch->get_state() == batch_state::in_transit);
-
-  // Try to lock for processing should fail while in_transit
-  auto in_transit = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(in_transit.success == false);
-  REQUIRE(in_transit.status == lock_for_processing_status::task_not_created);
-  REQUIRE(batch->get_processing_count() == 0);
-
-  // Release the in_transit lock
-  REQUIRE(batch->try_to_release_in_transit() == true);
-  REQUIRE(batch->get_state() == batch_state::idle);
-}
-
-// Test try_to_lock_for_in_transit fails when processing
-TEST_CASE("data_batch Cannot Go In Transit While Processing", "[data_batch]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  // Create task and start processing
-  REQUIRE(batch->try_to_create_task() == true);
-  auto r = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(r.success == true);
-  auto handle = std::move(r.handle);
-
-  REQUIRE(batch->get_state() == batch_state::processing);
-
-  // Try to lock for in_transit should fail
-  REQUIRE(batch->try_to_lock_for_in_transit() == false);
-  REQUIRE(batch->get_state() == batch_state::processing);
-}
-
-// Test multiple batches with different IDs
-TEST_CASE("Multiple data_batch Instances", "[data_batch]")
-{
-  std::vector<data_batch> batches;
-
-  for (uint64_t i = 0; i < 10; ++i) {
-    auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024 * (i + 1));
-    batches.emplace_back(i, std::move(data));
-  }
-
-  // Verify all batches have correct IDs and tiers
-  for (uint64_t i = 0; i < 10; ++i) {
-    REQUIRE(batches[i].get_batch_id() == i);
-    REQUIRE(batches[i].get_current_tier() == memory::Tier::GPU);
-    REQUIRE(batches[i].get_processing_count() == 0);
-    REQUIRE(batches[i].get_state() == batch_state::idle);
-  }
-}
-
-// Test get_current_tier delegates to idata_representation
-TEST_CASE("data_batch get_current_tier Delegation", "[data_batch]")
-{
-  // Test GPU memory::Tier
-  {
-    auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-    data_batch batch(1, std::move(data));
-    REQUIRE(batch.get_current_tier() == memory::Tier::GPU);
-  }
-
-  // Test HOST memory::Tier
-  {
-    auto data = std::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
-    data_batch batch(2, std::move(data));
-    REQUIRE(batch.get_current_tier() == memory::Tier::HOST);
-  }
-
-  // Test DISK memory::Tier
-  {
-    auto data = std::make_unique<mock_data_representation>(memory::Tier::DISK, 1024);
-    data_batch batch(3, std::move(data));
-    REQUIRE(batch.get_current_tier() == memory::Tier::DISK);
-  }
-}
-
-// Test thread-safe processing count
-TEST_CASE("data_batch Thread-Safe Processing Count", "[data_batch]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  constexpr int num_threads      = 10;
-  constexpr int locks_per_thread = 100;
-
-  std::vector<std::thread> threads;
-  std::vector<std::vector<data_batch_processing_handle>> thread_handles(num_threads);
-
-  // Launch threads to lock for processing
-  for (int i = 0; i < num_threads; ++i) {
-    threads.emplace_back([batch, &thread_handles, i, space_id]() {
-      for (int j = 0; j < locks_per_thread; ++j) {
-        // Create task first so threads can lock for processing
-        REQUIRE(batch->try_to_create_task() == true);
-        auto r = batch->try_to_lock_for_processing(space_id);
-        REQUIRE(r.success == true);
-        thread_handles[i].push_back(std::move(r.handle));
-      }
-    });
-  }
-
-  // Wait for all threads to complete
-  for (auto& thread : threads) {
-    thread.join();
-  }
-
-  // Verify final count
-  REQUIRE(batch->get_processing_count() == num_threads * locks_per_thread);
-
-  // Clear all handles to release processing locks
-  for (auto& handles : thread_handles) {
-    handles.clear();
-  }
-
-  // Verify final count is back to zero
-  REQUIRE(batch->get_processing_count() == 0);
-  REQUIRE(batch->get_state() == batch_state::idle);
-}
-
-// Test batch ID uniqueness in practice
-TEST_CASE("data_batch Unique IDs", "[data_batch]")
-{
-  std::vector<uint64_t> batch_ids = {0, 1, 100, 999, 1000, 9999, UINT64_MAX - 1, UINT64_MAX};
-
-  std::vector<data_batch> batches;
-
-  for (auto id : batch_ids) {
-    auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-    batches.emplace_back(id, std::move(data));
-  }
-
-  // Verify each batch has the correct ID
-  for (size_t i = 0; i < batch_ids.size(); ++i) {
-    REQUIRE(batches[i].get_batch_id() == batch_ids[i]);
-  }
-}
-
-// Test edge case: zero processing count operations
-TEST_CASE("data_batch Zero Processing Count", "[data_batch]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  // Starting processing count should be zero
-  REQUIRE(batch->get_processing_count() == 0);
-  REQUIRE(batch->get_state() == batch_state::idle);
-
-  // Create task and lock for processing
-  REQUIRE(batch->try_to_create_task() == true);
-  {
-    auto r = batch->try_to_lock_for_processing(space_id);
-    REQUIRE(r.success == true);
-    auto handle = std::move(r.handle);
-    REQUIRE(handle.valid());
-    REQUIRE(batch->get_processing_count() == 1);
-    REQUIRE(batch->get_state() == batch_state::processing);
-  }  // Handle goes out of scope
-
-  // Should be back to idle
-  REQUIRE(batch->get_processing_count() == 0);
-  REQUIRE(batch->get_state() == batch_state::idle);
-
-  // Can create task and lock again from idle
-  REQUIRE(batch->try_to_create_task() == true);
-  auto r2 = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(r2.success == true);
-  auto handle2 = std::move(r2.handle);
-  REQUIRE(handle2.valid());
-  REQUIRE(batch->get_processing_count() == 1);
-}
-
-// Test with different data sizes
-TEST_CASE("data_batch With Different Data Sizes", "[data_batch]")
-{
-  std::vector<size_t> sizes = {0, 1, 1024, 1024 * 1024, 1024 * 1024 * 100};
-
-  for (size_t size : sizes) {
-    auto data      = std::make_unique<mock_data_representation>(memory::Tier::GPU, size);
-    auto* data_ptr = data.get();
-    data_batch batch(1, std::move(data));
-
-    // Verify the data representation is accessible through the batch
-    REQUIRE(batch.get_current_tier() == memory::Tier::GPU);
-    REQUIRE(data_ptr->get_size_in_bytes() == size);
-  }
-}
-
-// Test that move operations require zero processing count
-TEST_CASE("data_batch Move Requires Zero Processing Count", "[data_batch]")
-{
-  // Test that moving with active processing throws
-  {
-    auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-    auto batch1   = std::make_shared<data_batch>(1, std::move(data));
-    auto space_id = batch1->get_memory_space()->get_id();
-    batch1->try_to_create_task();
-    auto r = batch1->try_to_lock_for_processing(space_id);
-    REQUIRE(r.success == true);
-    auto handle = std::move(r.handle);
-
-    REQUIRE_THROWS_AS([&]() { data_batch batch2(std::move(*batch1)); }(), std::runtime_error);
-  }
-
-  // Test that moving with zero counts succeeds
-  {
-    auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-    data_batch batch1(1, std::move(data));
-
-    REQUIRE(batch1.get_processing_count() == 0);
-
-    data_batch batch2(std::move(batch1));
-
-    REQUIRE(batch2.get_processing_count() == 0);
-    REQUIRE(batch2.get_batch_id() == 1);
-  }
-}
-
-// Test multiple rapid processing lock/unlock cycles
-TEST_CASE("data_batch Rapid Processing Cycles", "[data_batch]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  // Perform many cycles of lock and unlock via handles
-  for (int cycle = 0; cycle < 100; ++cycle) {
-    // Create task first
-
-    std::vector<data_batch_processing_handle> handles;
-    for (int i = 0; i < 10; ++i) {
-      REQUIRE(batch->try_to_create_task() == true);
-      auto r = batch->try_to_lock_for_processing(space_id);
-      REQUIRE(r.success == true);
-      handles.push_back(std::move(r.handle));
-    }
-    REQUIRE(batch->get_processing_count() == 10);
-    REQUIRE(batch->get_state() == batch_state::processing);
-
-    handles.clear();  // Release all handles
-
-    REQUIRE(batch->get_processing_count() == 0);
-    REQUIRE(batch->get_state() == batch_state::idle);
-  }
-
-  // Final state should be idle with zero count
-  REQUIRE(batch->get_processing_count() == 0);
-  REQUIRE(batch->get_state() == batch_state::idle);
-}
-
-// Test smart pointer lifecycle management
-TEST_CASE("data_batch Smart Pointer Lifecycle", "[data_batch]")
-{
-  // Test with shared_ptr
-  {
-    auto batch = std::make_shared<data_batch>(
-      1, std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024));
-
-    REQUIRE(batch->get_batch_id() == 1);
-    REQUIRE(batch->get_processing_count() == 0);
-
-    // Copy the shared_ptr
-    auto batch_copy = batch;
-    REQUIRE(batch_copy->get_batch_id() == 1);
-
-    // Both point to the same batch
-    batch->try_to_create_task();
-    auto space_id = batch->get_memory_space()->get_id();
-    auto r        = batch->try_to_lock_for_processing(space_id);
-    REQUIRE(r.success == true);
-    REQUIRE(batch_copy->get_processing_count() == 1);
-
-    REQUIRE(batch->get_processing_count() == 1);
-  }
-
-  // Test with unique_ptr
-  {
-    auto batch = std::make_unique<data_batch>(
-      2, std::make_unique<mock_data_representation>(memory::Tier::GPU, 2048));
-
-    REQUIRE(batch->get_batch_id() == 2);
-    REQUIRE(batch->get_processing_count() == 0);
-
-    // Move the unique_ptr
-    auto batch_moved = std::move(batch);
-    REQUIRE(batch_moved->get_batch_id() == 2);
-    REQUIRE(batch == nullptr);
-  }
-}
-
-// Test data_batch_processing_handle move semantics
-TEST_CASE("data_batch_processing_handle Move Semantics", "[data_batch]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  REQUIRE(batch->try_to_create_task() == true);
-  auto r = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(r.success == true);
-  auto h = std::move(r.handle);
-  REQUIRE(h.valid());
-  REQUIRE(batch->get_processing_count() == 1);
-
-  {
-    REQUIRE(batch->try_to_create_task() == true);
-    auto r1 = batch->try_to_lock_for_processing(space_id);
-    REQUIRE(r1.success == true);
-    auto handle1 = std::move(r1.handle);
-
-    // Move construct
-    data_batch_processing_handle handle2(std::move(handle1));
-
-    REQUIRE(handle1.valid() == false);
-    REQUIRE(handle2.valid() == true);
-    REQUIRE(batch->get_processing_count() == 2);  // Two active handles (outer h + handle2)
-
-  }  // handle2 goes out of scope, should decrement
-
-  REQUIRE(batch->get_processing_count() == 1);
-  REQUIRE(batch->get_state() == batch_state::processing);
-
-  // Explicitly release the original handle to return to idle
-  h.release();
-  REQUIRE(batch->get_processing_count() == 0);
-  REQUIRE(batch->get_state() == batch_state::idle);
-}
-
-// Test data_batch_processing_handle explicit release
-TEST_CASE("data_batch_processing_handle Explicit Release", "[data_batch]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  REQUIRE(batch->try_to_create_task() == true);
-  auto r = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(r.success == true);
-  auto handle = std::move(r.handle);
-
-  REQUIRE(batch->get_processing_count() == 1);
-
-  // Explicitly release
-  handle.release();
-
-  REQUIRE(batch->get_processing_count() == 0);
-  REQUIRE(handle.valid() == false);
-
-  // Double release should be safe (no-op)
-  handle.release();
-  REQUIRE(batch->get_processing_count() == 0);
-}
-
-// Test empty handle
-TEST_CASE("data_batch_processing_handle Empty Handle", "[data_batch]")
-{
-  // Default constructed handle
-  data_batch_processing_handle handle;
-
-  REQUIRE(handle.valid() == false);
-
-  // Release on empty handle should be safe
-  handle.release();
-  REQUIRE(handle.valid() == false);
-}
-
-// Test task_created state transitions
-TEST_CASE("data_batch Task Created State Transitions", "[data_batch]")
+// =============================================================================
+// read_only_data_batch tests (TEST-01)
+// =============================================================================
+
+TEST_CASE("data_batch to_read_only acquires shared access", "[data_batch]")
 {
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  REQUIRE(batch->get_state() == batch_state::idle);
-
-  // Create task
-  REQUIRE(batch->try_to_create_task() == true);
-  REQUIRE(batch->get_state() == batch_state::task_created);
-
-  // Can call try_to_create_task again while already in task_created state (idempotent)
-  REQUIRE(batch->try_to_create_task() == true);
-  REQUIRE(batch->get_state() == batch_state::task_created);
-
-  // Can lock for in_transit while in task_created state (to move data)
-  REQUIRE(batch->try_to_lock_for_in_transit() == true);
-  REQUIRE(batch->get_state() == batch_state::in_transit);
-
-  // Release in_transit returns to task_created since the task is still pending
-  REQUIRE(batch->try_to_release_in_transit(batch_state::task_created) == true);
-  REQUIRE(batch->get_state() == batch_state::task_created);
-
-  // Can cancel task and go back to idle
-  REQUIRE(batch->try_to_cancel_task() == true);
-  REQUIRE(batch->try_to_cancel_task() == true);
-  REQUIRE(batch->get_state() == batch_state::idle);
-
-  // Create task again
-  REQUIRE(batch->try_to_create_task() == true);
-  REQUIRE(batch->get_state() == batch_state::task_created);
-
-  auto space_id = batch->get_memory_space()->get_id();
-  // Go to processing
-  auto r = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(r.success == true);
-  auto handle = std::move(r.handle);
-  REQUIRE(handle.valid());
-  REQUIRE(batch->get_state() == batch_state::processing);
-
-  // Can call try_to_create_task while processing (idempotent)
-  REQUIRE(batch->try_to_create_task() == true);
-  REQUIRE(batch->get_state() == batch_state::processing);
+  auto ro = data_batch::to_read_only(std::move(batch));
+  REQUIRE(ro.get_batch_id() == 1);
+  REQUIRE(ro.get_current_tier() == memory::Tier::GPU);
 }
 
-// Test in_transit state transitions
-TEST_CASE("data_batch In Transit State Transitions", "[data_batch]")
+TEST_CASE("data_batch multiple concurrent read_only via shared_ptr copies", "[data_batch]")
 {
-  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  data_batch batch(1, std::move(data));
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+  auto b2    = batch;
+  auto b3    = batch;
 
-  REQUIRE(batch.get_state() == batch_state::idle);
+  auto ro1 = data_batch::to_read_only(std::move(batch));
+  auto ro2 = data_batch::to_read_only(std::move(b2));
+  auto ro3 = data_batch::to_read_only(std::move(b3));
 
-  // Lock for in_transit
-  REQUIRE(batch.try_to_lock_for_in_transit() == true);
-  REQUIRE(batch.get_state() == batch_state::in_transit);
-
-  // Cannot lock for in_transit again
-  REQUIRE(batch.try_to_lock_for_in_transit() == false);
-  REQUIRE(batch.get_state() == batch_state::in_transit);
-
-  // Cannot create task while in_transit
-  REQUIRE(batch.try_to_create_task() == false);
-  REQUIRE(batch.get_state() == batch_state::in_transit);
-
-  // Cannot cancel task (not in task_created state)
-  REQUIRE(batch.try_to_cancel_task() == false);
-
-  // Release in_transit lock (defaults to idle)
-  REQUIRE(batch.try_to_release_in_transit() == true);
-  REQUIRE(batch.get_state() == batch_state::idle);
-
-  // Cannot release in_transit again (already idle)
-  REQUIRE(batch.try_to_release_in_transit() == false);
-  REQUIRE(batch.get_state() == batch_state::idle);
-}
-
-TEST_CASE("data_batch In Transit From Task Created Returns To Task Created", "[data_batch]")
-{
-  auto data = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  data_batch batch(1, std::move(data));
-
-  REQUIRE(batch.try_to_create_task() == true);
-  REQUIRE(batch.get_state() == batch_state::task_created);
-
-  REQUIRE(batch.try_to_lock_for_in_transit() == true);
-  REQUIRE(batch.get_state() == batch_state::in_transit);
-
-  // Release should go back to task_created because a task is pending
-  REQUIRE(batch.try_to_release_in_transit(batch_state::task_created) == true);
-  REQUIRE(batch.get_state() == batch_state::task_created);
+  REQUIRE(ro1.get_batch_id() == 1);
+  REQUIRE(ro2.get_batch_id() == 1);
+  REQUIRE(ro3.get_batch_id() == 1);
 }
 
 // =============================================================================
-// Clone Tests
+// Try variants (TEST-04)
+// =============================================================================
+
+TEST_CASE("data_batch try_to_read_only succeeds when unlocked", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto result = data_batch::try_to_read_only(batch);
+  REQUIRE(result.has_value());
+  REQUIRE(batch == nullptr);
+  REQUIRE(result->get_batch_id() == 1);
+}
+
+TEST_CASE("data_batch try_to_read_only fails when mutable lock held", "[data_batch]")
+{
+  auto data       = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch      = std::make_shared<data_batch>(1, std::move(data));
+  auto batch_copy = batch;
+
+  auto rw = data_batch::to_mutable(std::move(batch));
+
+  std::atomic<bool> got_lock{false};
+  std::thread t([&batch_copy, &got_lock]() {
+    auto result = data_batch::try_to_read_only(batch_copy);
+    got_lock.store(result.has_value());
+  });
+  t.join();
+  REQUIRE(got_lock.load() == false);
+}
+
+TEST_CASE("data_batch try_to_mutable succeeds when unlocked", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto result = data_batch::try_to_mutable(batch);
+  REQUIRE(result.has_value());
+  REQUIRE(batch == nullptr);
+  REQUIRE(result->get_batch_id() == 1);
+}
+
+TEST_CASE("data_batch try_to_mutable fails when readonly lock held", "[data_batch]")
+{
+  auto data       = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch      = std::make_shared<data_batch>(1, std::move(data));
+  auto batch_copy = batch;
+
+  auto ro = data_batch::to_read_only(std::move(batch));
+
+  std::atomic<bool> got_lock{false};
+  std::thread t([&batch_copy, &got_lock]() {
+    auto result = data_batch::try_to_mutable(batch_copy);
+    got_lock.store(result.has_value());
+  });
+  t.join();
+  REQUIRE(got_lock.load() == false);
+}
+
+TEST_CASE("data_batch try_to_mutable fails when mutable lock held", "[data_batch]")
+{
+  auto data       = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch      = std::make_shared<data_batch>(1, std::move(data));
+  auto batch_copy = batch;
+
+  auto rw = data_batch::to_mutable(std::move(batch));
+
+  std::atomic<bool> got_lock{false};
+  std::thread t([&batch_copy, &got_lock]() {
+    auto result = data_batch::try_to_mutable(batch_copy);
+    got_lock.store(result.has_value());
+  });
+  t.join();
+  REQUIRE(got_lock.load() == false);
+}
+
+// =============================================================================
+// mutable_data_batch tests (TEST-01)
+// =============================================================================
+
+TEST_CASE("data_batch to_mutable acquires exclusive access", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto rw = data_batch::to_mutable(std::move(batch));
+  REQUIRE(rw.get_batch_id() == 1);
+}
+
+TEST_CASE("data_batch mutable blocks until readonly released", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  // Copy the shared_ptr: one for the reader, one for the writer
+  auto writer_copy = batch;
+
+  // Acquire read-only on a heap-allocated accessor so we can control its lifetime
+  auto ro = std::make_unique<read_only_data_batch<std::shared_ptr<data_batch>>>(
+    data_batch::to_read_only(std::move(batch)));
+
+  std::atomic<bool> got_mutable{false};
+
+  std::thread writer([&writer_copy, &got_mutable]() {
+    auto rw = data_batch::to_mutable(std::move(writer_copy));
+    got_mutable.store(true);
+  });
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(20));
+  REQUIRE(got_mutable.load() == false);
+
+  ro.reset();
+  writer.join();
+  REQUIRE(got_mutable.load() == true);
+}
+
+// =============================================================================
+// Locked-to-locked conversions through idle (TEST-01)
+// =============================================================================
+
+TEST_CASE("data_batch mutable to readonly through idle", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto rw   = data_batch::to_mutable(std::move(batch));
+  auto idle = data_batch::to_idle(std::move(rw));
+  auto ro   = data_batch::to_read_only(std::move(idle));
+  REQUIRE(ro.get_batch_id() == 1);
+}
+
+TEST_CASE("data_batch readonly to mutable through idle", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto ro   = data_batch::to_read_only(std::move(batch));
+  auto idle = data_batch::to_idle(std::move(ro));
+  auto rw   = data_batch::to_mutable(std::move(idle));
+  REQUIRE(rw.get_batch_id() == 1);
+}
+
+// =============================================================================
+// Destruction order safety (TEST-02)
+// =============================================================================
+
+TEST_CASE("data_batch destruction order safety", "[data_batch]")
+{
+  // Verifies member declaration order in read_only_data_batch: PtrType (_batch)
+  // is declared before the lock guard (_lock). When the accessor is destroyed,
+  // C++ destroys members in reverse declaration order:
+  //   1. _lock (shared_lock) releases the shared lock on the mutex
+  //   2. _batch (shared_ptr) drops the last reference, destroys data_batch + mutex
+  // If the order were reversed, the mutex would be destroyed before the lock
+  // releases, causing undefined behavior detectable by TSan/ASan.
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  // Create accessor -- this is now the ONLY shared_ptr holding the batch alive.
+  auto ro = data_batch::to_read_only(std::move(batch));
+  // batch is null now. The only reference to the data_batch is inside ro._batch.
+
+  // When ro goes out of scope here, the destruction order above should NOT crash.
+}
+
+// =============================================================================
+// Subscriber count tests (TEST-01)
+// =============================================================================
+
+TEST_CASE("data_batch subscribe always succeeds", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  REQUIRE(batch->get_subscriber_count() == 0);
+  REQUIRE(batch->subscribe() == true);
+  REQUIRE(batch->get_subscriber_count() == 1);
+  REQUIRE(batch->subscribe() == true);
+  REQUIRE(batch->get_subscriber_count() == 2);
+}
+
+TEST_CASE("data_batch unsubscribe decrements count", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  batch->subscribe();
+  batch->subscribe();
+  REQUIRE(batch->get_subscriber_count() == 2);
+
+  batch->unsubscribe();
+  REQUIRE(batch->get_subscriber_count() == 1);
+  batch->unsubscribe();
+  REQUIRE(batch->get_subscriber_count() == 0);
+}
+
+TEST_CASE("data_batch unsubscribe throws at zero", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  REQUIRE_THROWS_AS(batch->unsubscribe(), std::runtime_error);
+  REQUIRE(batch->get_subscriber_count() == 0);
+}
+
+TEST_CASE("data_batch subscriber count thread safety", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  constexpr int num_threads     = 10;
+  constexpr int subs_per_thread = 100;
+
+  std::vector<std::thread> threads;
+  for (int i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&batch]() {
+      for (int j = 0; j < subs_per_thread; ++j) {
+        batch->subscribe();
+      }
+    });
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  REQUIRE(batch->get_subscriber_count() ==
+          static_cast<size_t>(num_threads) * static_cast<size_t>(subs_per_thread));
+
+  threads.clear();
+  for (int i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&batch]() {
+      for (int j = 0; j < subs_per_thread; ++j) {
+        batch->unsubscribe();
+      }
+    });
+  }
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  REQUIRE(batch->get_subscriber_count() == 0);
+}
+
+// =============================================================================
+// set_data via mutable accessor (TEST-01)
+// =============================================================================
+
+TEST_CASE("data_batch set_data via mutable accessor", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto rw = data_batch::to_mutable(std::move(batch));
+  REQUIRE(rw.get_current_tier() == memory::Tier::GPU);
+  rw.set_data(std::make_unique<mock_data_representation>(memory::Tier::HOST, 2048));
+  batch = data_batch::to_idle(std::move(rw));
+
+  auto ro = data_batch::to_read_only(std::move(batch));
+  REQUIRE(ro.get_current_tier() == memory::Tier::HOST);
+}
+
+// =============================================================================
+// Accessor delegation tests (TEST-01)
+// =============================================================================
+
+TEST_CASE("data_batch accessor get_current_tier", "[data_batch]")
+{
+  {
+    auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto batch = std::make_shared<data_batch>(1, std::move(data));
+    auto ro    = data_batch::to_read_only(std::move(batch));
+    REQUIRE(ro.get_current_tier() == memory::Tier::GPU);
+  }
+  {
+    auto data  = std::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
+    auto batch = std::make_shared<data_batch>(2, std::move(data));
+    auto ro    = data_batch::to_read_only(std::move(batch));
+    REQUIRE(ro.get_current_tier() == memory::Tier::HOST);
+  }
+  {
+    auto data  = std::make_unique<mock_data_representation>(memory::Tier::DISK, 1024);
+    auto batch = std::make_shared<data_batch>(3, std::move(data));
+    auto ro    = data_batch::to_read_only(std::move(batch));
+    REQUIRE(ro.get_current_tier() == memory::Tier::DISK);
+  }
+}
+
+// =============================================================================
+// Unique IDs (TEST-01)
+// =============================================================================
+
+TEST_CASE("data_batch unique IDs", "[data_batch]")
+{
+  std::vector<uint64_t> batch_ids = {0, 1, 100, 999, 1000, 9999, UINT64_MAX - 1, UINT64_MAX};
+
+  for (auto id : batch_ids) {
+    auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+    auto batch = std::make_shared<data_batch>(id, std::move(data));
+    REQUIRE(batch->get_batch_id() == id);
+  }
+}
+
+// =============================================================================
+// Concurrent access tests (TEST-08)
+// =============================================================================
+
+TEST_CASE("data_batch thread-safe concurrent readonly", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  constexpr int num_threads      = 10;
+  constexpr int reads_per_thread = 100;
+
+  std::vector<std::thread> threads;
+  for (int i = 0; i < num_threads; ++i) {
+    // Each thread gets its own shared_ptr copy
+    auto thread_batch = batch;
+    threads.emplace_back([thread_batch = std::move(thread_batch)]() mutable {
+      for (int j = 0; j < reads_per_thread; ++j) {
+        auto copy = thread_batch;
+        auto ro   = data_batch::to_read_only(std::move(copy));
+        REQUIRE(ro.get_batch_id() == 1);
+        thread_batch = data_batch::to_idle(std::move(ro));
+      }
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+}
+
+TEST_CASE("data_batch thread-safe mutable access serialized", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  constexpr int num_threads = 10;
+  std::atomic<int> concurrent_writers{0};
+  std::atomic<bool> saw_concurrent{false};
+
+  std::vector<std::thread> threads;
+  for (int i = 0; i < num_threads; ++i) {
+    auto thread_batch = batch;
+    threads.emplace_back(
+      [thread_batch = std::move(thread_batch), &concurrent_writers, &saw_concurrent]() mutable {
+        for (int j = 0; j < 10; ++j) {
+          auto copy = thread_batch;
+          auto rw   = data_batch::to_mutable(std::move(copy));
+          int count = concurrent_writers.fetch_add(1);
+          if (count > 0) { saw_concurrent.store(true); }
+          std::this_thread::sleep_for(std::chrono::microseconds(1));
+          concurrent_writers.fetch_sub(1);
+          thread_batch = data_batch::to_idle(std::move(rw));
+        }
+      });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  REQUIRE(saw_concurrent.load() == false);
+}
+
+// =============================================================================
+// Clone tests (TEST-05)
 // =============================================================================
 
 TEST_CASE("data_batch clone creates independent copy", "[data_batch]")
@@ -699,26 +503,17 @@ TEST_CASE("data_batch clone creates independent copy", "[data_batch]")
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 2048);
   auto batch = std::make_shared<data_batch>(42, std::move(data));
 
-  // Clone the batch with a new ID
-  auto cloned = batch->clone(100, rmm::cuda_stream_view{});
+  auto ro     = data_batch::to_read_only(std::move(batch));
+  auto cloned = ro.clone(100, rmm::cuda_stream_view{});
 
   REQUIRE(cloned != nullptr);
   REQUIRE(cloned->get_batch_id() == 100);
-  REQUIRE(cloned->get_current_tier() == memory::Tier::GPU);
-  REQUIRE(cloned->get_processing_count() == 0);
-  REQUIRE(cloned->get_state() == batch_state::idle);
+  REQUIRE(cloned->get_subscriber_count() == 0);
+  REQUIRE(ro.get_batch_id() == 42);
 
-  // Original batch should be unchanged
-  REQUIRE(batch->get_batch_id() == 42);
-  REQUIRE(batch->get_current_tier() == memory::Tier::GPU);
-  REQUIRE(batch->get_processing_count() == 0);
-  REQUIRE(batch->get_state() == batch_state::idle);
-
-  // Verify data size matches
-  REQUIRE(cloned->get_data()->get_size_in_bytes() == batch->get_data()->get_size_in_bytes());
-
-  // Verify the data representations are different objects
-  REQUIRE(cloned->get_data() != batch->get_data());
+  auto ro_clone = data_batch::to_read_only(std::move(cloned));
+  REQUIRE(ro_clone.get_data()->get_size_in_bytes() == ro.get_data()->get_size_in_bytes());
+  REQUIRE(ro_clone.get_data() != ro.get_data());
 }
 
 TEST_CASE("data_batch clone with different batch IDs", "[data_batch]")
@@ -726,15 +521,15 @@ TEST_CASE("data_batch clone with different batch IDs", "[data_batch]")
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  // Clone with same ID as original (allowed)
-  auto clone1 = batch->clone(1, rmm::cuda_stream_view{});
+  auto ro = data_batch::to_read_only(std::move(batch));
+
+  auto clone1 = ro.clone(1, rmm::cuda_stream_view{});
   REQUIRE(clone1->get_batch_id() == 1);
 
-  // Clone with different IDs
-  auto clone2 = batch->clone(0, rmm::cuda_stream_view{});
+  auto clone2 = ro.clone(0, rmm::cuda_stream_view{});
   REQUIRE(clone2->get_batch_id() == 0);
 
-  auto clone3 = batch->clone(UINT64_MAX, rmm::cuda_stream_view{});
+  auto clone3 = ro.clone(UINT64_MAX, rmm::cuda_stream_view{});
   REQUIRE(clone3->get_batch_id() == UINT64_MAX);
 }
 
@@ -744,138 +539,33 @@ TEST_CASE("data_batch clone preserves tier information", "[data_batch]")
   {
     auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto batch  = std::make_shared<data_batch>(1, std::move(data));
-    auto cloned = batch->clone(2, rmm::cuda_stream_view{});
-
-    REQUIRE(cloned->get_current_tier() == memory::Tier::GPU);
+    auto ro     = data_batch::to_read_only(std::move(batch));
+    auto cloned = ro.clone(2, rmm::cuda_stream_view{});
+    auto ro_cl  = data_batch::to_read_only(std::move(cloned));
+    REQUIRE(ro_cl.get_current_tier() == memory::Tier::GPU);
   }
-
   SECTION("HOST tier")
   {
     auto data   = std::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
     auto batch  = std::make_shared<data_batch>(1, std::move(data));
-    auto cloned = batch->clone(2, rmm::cuda_stream_view{});
-
-    REQUIRE(cloned->get_current_tier() == memory::Tier::HOST);
+    auto ro     = data_batch::to_read_only(std::move(batch));
+    auto cloned = ro.clone(2, rmm::cuda_stream_view{});
+    auto ro_cl  = data_batch::to_read_only(std::move(cloned));
+    REQUIRE(ro_cl.get_current_tier() == memory::Tier::HOST);
   }
-
   SECTION("DISK tier")
   {
     auto data   = std::make_unique<mock_data_representation>(memory::Tier::DISK, 1024);
     auto batch  = std::make_shared<data_batch>(1, std::move(data));
-    auto cloned = batch->clone(2, rmm::cuda_stream_view{});
-
-    REQUIRE(cloned->get_current_tier() == memory::Tier::DISK);
+    auto ro     = data_batch::to_read_only(std::move(batch));
+    auto cloned = ro.clone(2, rmm::cuda_stream_view{});
+    auto ro_cl  = data_batch::to_read_only(std::move(cloned));
+    REQUIRE(ro_cl.get_current_tier() == memory::Tier::DISK);
   }
 }
 
-TEST_CASE("data_batch clone succeeds with active processing", "[data_batch]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  // Start processing
-  REQUIRE(batch->try_to_create_task() == true);
-  auto r = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(r.success == true);
-  auto handle = std::move(r.handle);
-
-  REQUIRE(batch->get_processing_count() == 1);
-  REQUIRE(batch->get_state() == batch_state::processing);
-
-  // Clone should succeed even while processing
-  auto cloned = batch->clone(2, rmm::cuda_stream_view{});
-  REQUIRE(cloned != nullptr);
-  REQUIRE(cloned->get_batch_id() == 2);
-
-  // Original batch should still be processing with original count
-  REQUIRE(batch->get_processing_count() == 1);
-  REQUIRE(batch->get_state() == batch_state::processing);
-
-  // Release processing handle
-  handle.release();
-  REQUIRE(batch->get_processing_count() == 0);
-  REQUIRE(batch->get_state() == batch_state::idle);
-}
-
-TEST_CASE("data_batch clone fails when in_transit", "[data_batch]")
-{
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-
-  // Lock for in-transit
-  REQUIRE(batch->try_to_lock_for_in_transit() == true);
-  REQUIRE(batch->get_state() == batch_state::in_transit);
-
-  // Clone should fail while in_transit
-  REQUIRE_THROWS_AS(batch->clone(2, rmm::cuda_stream_view{}), std::runtime_error);
-
-  // Release in-transit lock
-  REQUIRE(batch->try_to_release_in_transit() == true);
-  REQUIRE(batch->get_state() == batch_state::idle);
-
-  // Now clone should succeed
-  auto cloned = batch->clone(2, rmm::cuda_stream_view{});
-  REQUIRE(cloned != nullptr);
-  REQUIRE(cloned->get_batch_id() == 2);
-}
-
-TEST_CASE("data_batch clone returns shared_ptr", "[data_batch]")
-{
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-
-  std::shared_ptr<data_batch> cloned = batch->clone(2, rmm::cuda_stream_view{});
-
-  REQUIRE(cloned.use_count() == 1);
-
-  // Make a copy of the shared_ptr
-  std::shared_ptr<data_batch> cloned_copy = cloned;
-  REQUIRE(cloned.use_count() == 2);
-  REQUIRE(cloned_copy.use_count() == 2);
-
-  // Both point to the same batch
-  REQUIRE(cloned->get_batch_id() == cloned_copy->get_batch_id());
-  REQUIRE(cloned.get() == cloned_copy.get());
-}
-
-TEST_CASE("data_batch clone can be independently processed", "[data_batch]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  auto cloned          = batch->clone(2, rmm::cuda_stream_view{});
-  auto cloned_space_id = cloned->get_memory_space()->get_id();
-
-  // Process original batch
-  REQUIRE(batch->try_to_create_task() == true);
-  auto r1 = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(r1.success == true);
-  auto handle1 = std::move(r1.handle);
-
-  REQUIRE(batch->get_processing_count() == 1);
-  REQUIRE(cloned->get_processing_count() == 0);
-
-  // Process cloned batch independently
-  REQUIRE(cloned->try_to_create_task() == true);
-  auto r2 = cloned->try_to_lock_for_processing(cloned_space_id);
-  REQUIRE(r2.success == true);
-  auto handle2 = std::move(r2.handle);
-
-  REQUIRE(batch->get_processing_count() == 1);
-  REQUIRE(cloned->get_processing_count() == 1);
-
-  // Release handles
-  handle1.release();
-  handle2.release();
-
-  REQUIRE(batch->get_processing_count() == 0);
-  REQUIRE(cloned->get_processing_count() == 0);
-}
-
 // =============================================================================
-// Real GPU Data Clone Tests
+// Real GPU data clone tests (TEST-05)
 // =============================================================================
 
 TEST_CASE("data_batch clone with real GPU data verifies data integrity", "[data_batch][gpu]")
@@ -883,32 +573,29 @@ TEST_CASE("data_batch clone with real GPU data verifies data integrity", "[data_
   auto gpu_space = make_mock_memory_space(memory::Tier::GPU, 0);
   rmm::cuda_stream stream;
 
-  // Create a real cudf table with known data
   auto table = create_simple_cudf_table(100, 2, gpu_space->get_default_allocator(), stream.view());
   auto original_rows    = table.num_rows();
   auto original_columns = table.num_columns();
 
-  // Create gpu_table_representation and wrap in data_batch
   auto gpu_repr = std::make_unique<gpu_table_representation>(
     std::make_unique<cudf::table>(std::move(table)), *gpu_space);
   auto batch = std::make_shared<data_batch>(1, std::move(gpu_repr));
 
-  // Clone the batch
-  auto cloned = batch->clone(2, stream.view());
+  auto ro     = data_batch::to_read_only(std::move(batch));
+  auto cloned = ro.clone(2, stream.view());
   REQUIRE(cloned != nullptr);
   REQUIRE(cloned->get_batch_id() == 2);
 
-  // Verify the cloned data has correct structure
-  auto* original_repr = dynamic_cast<gpu_table_representation*>(batch->get_data());
-  auto* cloned_repr   = dynamic_cast<gpu_table_representation*>(cloned->get_data());
+  auto ro_clone = data_batch::to_read_only(std::move(cloned));
+
+  auto* original_repr = dynamic_cast<gpu_table_representation*>(ro.get_data());
+  auto* cloned_repr   = dynamic_cast<gpu_table_representation*>(ro_clone.get_data());
   REQUIRE(original_repr != nullptr);
   REQUIRE(cloned_repr != nullptr);
 
-  // Verify table shape matches
   REQUIRE(cloned_repr->get_table().num_rows() == original_rows);
   REQUIRE(cloned_repr->get_table().num_columns() == original_columns);
 
-  // Verify actual data content matches
   stream.synchronize();
   expect_cudf_tables_equal_on_stream(
     original_repr->get_table(), cloned_repr->get_table(), stream.view());
@@ -924,61 +611,21 @@ TEST_CASE("data_batch clone creates independent memory copies", "[data_batch][gp
     std::make_unique<cudf::table>(std::move(table)), *gpu_space);
   auto batch = std::make_shared<data_batch>(1, std::move(gpu_repr));
 
-  auto cloned = batch->clone(2, stream.view());
+  auto ro     = data_batch::to_read_only(std::move(batch));
+  auto cloned = ro.clone(2, stream.view());
 
-  auto* original_repr = dynamic_cast<gpu_table_representation*>(batch->get_data());
-  auto* cloned_repr   = dynamic_cast<gpu_table_representation*>(cloned->get_data());
+  auto ro_clone = data_batch::to_read_only(std::move(cloned));
 
-  // Verify the data representations are different objects
-  REQUIRE(batch->get_data() != cloned->get_data());
+  auto* original_repr = dynamic_cast<gpu_table_representation*>(ro.get_data());
+  auto* cloned_repr   = dynamic_cast<gpu_table_representation*>(ro_clone.get_data());
 
-  // Verify the underlying cudf tables are different objects
+  REQUIRE(ro.get_data() != ro_clone.get_data());
   REQUIRE(&original_repr->get_table() != &cloned_repr->get_table());
 
-  // Verify each column points to different memory
   for (cudf::size_type i = 0; i < original_repr->get_table().num_columns(); ++i) {
     REQUIRE(original_repr->get_table().view().column(i).head() !=
             cloned_repr->get_table().view().column(i).head());
   }
-}
-
-TEST_CASE("data_batch clone with real GPU data while processing", "[data_batch][gpu]")
-{
-  auto gpu_space = make_mock_memory_space(memory::Tier::GPU, 0);
-  rmm::cuda_stream stream;
-
-  auto table = create_simple_cudf_table(75, 2, gpu_space->get_default_allocator(), stream.view());
-  auto gpu_repr = std::make_unique<gpu_table_representation>(
-    std::make_unique<cudf::table>(std::move(table)), *gpu_space);
-  auto batch    = std::make_shared<data_batch>(1, std::move(gpu_repr));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  // Start processing on the original batch
-  REQUIRE(batch->try_to_create_task() == true);
-  auto r = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(r.success == true);
-  auto handle = std::move(r.handle);
-  REQUIRE(batch->get_processing_count() == 1);
-
-  // Clone while processing - should succeed and data should be valid
-  auto cloned = batch->clone(2, stream.view());
-  REQUIRE(cloned != nullptr);
-
-  // Verify data integrity after clone during processing
-  auto* original_repr = dynamic_cast<gpu_table_representation*>(batch->get_data());
-  auto* cloned_repr   = dynamic_cast<gpu_table_representation*>(cloned->get_data());
-
-  stream.synchronize();
-  expect_cudf_tables_equal_on_stream(
-    original_repr->get_table(), cloned_repr->get_table(), stream.view());
-
-  // Original should still be processing
-  REQUIRE(batch->get_processing_count() == 1);
-  REQUIRE(batch->get_state() == batch_state::processing);
-
-  // Release handle
-  handle.release();
-  REQUIRE(batch->get_processing_count() == 0);
 }
 
 TEST_CASE("data_batch multiple clones are all independent", "[data_batch][gpu]")
@@ -991,29 +638,24 @@ TEST_CASE("data_batch multiple clones are all independent", "[data_batch][gpu]")
     std::make_unique<cudf::table>(std::move(table)), *gpu_space);
   auto batch = std::make_shared<data_batch>(1, std::move(gpu_repr));
 
-  // Create multiple clones
-  auto clone1 = batch->clone(10, stream.view());
-  auto clone2 = batch->clone(20, stream.view());
-  auto clone3 = batch->clone(30, stream.view());
+  // Clone 3 times from the same read_only accessor (clone does not consume the accessor)
+  auto ro     = data_batch::to_read_only(std::move(batch));
+  auto clone1 = ro.clone(10, stream.view());
+  auto clone2 = ro.clone(20, stream.view());
+  auto clone3 = ro.clone(30, stream.view());
 
-  // Verify all have correct batch IDs
   REQUIRE(clone1->get_batch_id() == 10);
   REQUIRE(clone2->get_batch_id() == 20);
   REQUIRE(clone3->get_batch_id() == 30);
 
-  // Verify all have independent data
-  REQUIRE(batch->get_data() != clone1->get_data());
-  REQUIRE(batch->get_data() != clone2->get_data());
-  REQUIRE(batch->get_data() != clone3->get_data());
-  REQUIRE(clone1->get_data() != clone2->get_data());
-  REQUIRE(clone1->get_data() != clone3->get_data());
-  REQUIRE(clone2->get_data() != clone3->get_data());
+  auto ro_c1 = data_batch::to_read_only(std::move(clone1));
+  auto ro_c2 = data_batch::to_read_only(std::move(clone2));
+  auto ro_c3 = data_batch::to_read_only(std::move(clone3));
 
-  // Verify all data content matches original
-  auto* original_repr = dynamic_cast<gpu_table_representation*>(batch->get_data());
-  auto* clone1_repr   = dynamic_cast<gpu_table_representation*>(clone1->get_data());
-  auto* clone2_repr   = dynamic_cast<gpu_table_representation*>(clone2->get_data());
-  auto* clone3_repr   = dynamic_cast<gpu_table_representation*>(clone3->get_data());
+  auto* original_repr = dynamic_cast<gpu_table_representation*>(ro.get_data());
+  auto* clone1_repr   = dynamic_cast<gpu_table_representation*>(ro_c1.get_data());
+  auto* clone2_repr   = dynamic_cast<gpu_table_representation*>(ro_c2.get_data());
+  auto* clone3_repr   = dynamic_cast<gpu_table_representation*>(ro_c3.get_data());
 
   stream.synchronize();
   expect_cudf_tables_equal_on_stream(
@@ -1029,16 +671,17 @@ TEST_CASE("data_batch clone with empty table", "[data_batch][gpu]")
   auto gpu_space = make_mock_memory_space(memory::Tier::GPU, 0);
   rmm::cuda_stream stream;
 
-  // Create an empty table
   auto table    = create_simple_cudf_table(0, 2, gpu_space->get_default_allocator(), stream.view());
   auto gpu_repr = std::make_unique<gpu_table_representation>(
     std::make_unique<cudf::table>(std::move(table)), *gpu_space);
   auto batch = std::make_shared<data_batch>(1, std::move(gpu_repr));
 
-  auto cloned = batch->clone(2, stream.view());
+  auto ro     = data_batch::to_read_only(std::move(batch));
+  auto cloned = ro.clone(2, stream.view());
   REQUIRE(cloned != nullptr);
 
-  auto* cloned_repr = dynamic_cast<gpu_table_representation*>(cloned->get_data());
+  auto ro_clone     = data_batch::to_read_only(std::move(cloned));
+  auto* cloned_repr = dynamic_cast<gpu_table_representation*>(ro_clone.get_data());
   REQUIRE(cloned_repr != nullptr);
   REQUIRE(cloned_repr->get_table().num_rows() == 0);
   REQUIRE(cloned_repr->get_table().num_columns() == 2);
@@ -1049,888 +692,30 @@ TEST_CASE("data_batch clone with large table", "[data_batch][gpu]")
   auto gpu_space = make_mock_memory_space(memory::Tier::GPU, 0);
   rmm::cuda_stream stream;
 
-  // Create a larger table
   auto table =
     create_simple_cudf_table(10000, 2, gpu_space->get_default_allocator(), stream.view());
   auto gpu_repr = std::make_unique<gpu_table_representation>(
     std::make_unique<cudf::table>(std::move(table)), *gpu_space);
   auto batch = std::make_shared<data_batch>(1, std::move(gpu_repr));
 
-  auto cloned = batch->clone(2, stream.view());
+  auto ro     = data_batch::to_read_only(std::move(batch));
+  auto cloned = ro.clone(2, stream.view());
   REQUIRE(cloned != nullptr);
 
-  auto* original_repr = dynamic_cast<gpu_table_representation*>(batch->get_data());
-  auto* cloned_repr   = dynamic_cast<gpu_table_representation*>(cloned->get_data());
+  auto ro_clone = data_batch::to_read_only(std::move(cloned));
 
-  // Verify structure
+  auto* original_repr = dynamic_cast<gpu_table_representation*>(ro.get_data());
+  auto* cloned_repr   = dynamic_cast<gpu_table_representation*>(ro_clone.get_data());
+
   REQUIRE(cloned_repr->get_table().num_rows() == 10000);
   REQUIRE(cloned_repr->get_table().num_columns() == 2);
 
-  // Verify data integrity
   stream.synchronize();
   expect_cudf_tables_equal_on_stream(
     original_repr->get_table(), cloned_repr->get_table(), stream.view());
 
-  // Verify independence
   for (cudf::size_type i = 0; i < original_repr->get_table().num_columns(); ++i) {
     REQUIRE(original_repr->get_table().view().column(i).head() !=
             cloned_repr->get_table().view().column(i).head());
   }
-}
-
-TEST_CASE("data_batch clone state transitions correctly", "[data_batch][gpu]")
-{
-  auto gpu_space = make_mock_memory_space(memory::Tier::GPU, 0);
-  rmm::cuda_stream stream;
-
-  auto table = create_simple_cudf_table(50, 2, gpu_space->get_default_allocator(), stream.view());
-  auto gpu_repr = std::make_unique<gpu_table_representation>(
-    std::make_unique<cudf::table>(std::move(table)), *gpu_space);
-  auto batch = std::make_shared<data_batch>(1, std::move(gpu_repr));
-
-  SECTION("Clone from idle state returns to idle")
-  {
-    REQUIRE(batch->get_state() == batch_state::idle);
-    auto cloned = batch->clone(2, stream.view());
-    REQUIRE(cloned != nullptr);
-    REQUIRE(batch->get_state() == batch_state::idle);
-    REQUIRE(cloned->get_state() == batch_state::idle);
-  }
-
-  SECTION("Clone from task_created state returns to task_created")
-  {
-    REQUIRE(batch->try_to_create_task() == true);
-    REQUIRE(batch->get_state() == batch_state::task_created);
-
-    auto cloned = batch->clone(2, stream.view());
-    REQUIRE(cloned != nullptr);
-
-    // Original should return to task_created (has pending task)
-    REQUIRE(batch->get_state() == batch_state::task_created);
-    REQUIRE(cloned->get_state() == batch_state::idle);
-  }
-}
-
-// =============================================================================
-// Blocking wait_to_* method tests
-// =============================================================================
-
-// Helper: wait for a flag with a short timeout, used to confirm blocking
-static void wait_for_flag(const std::atomic<bool>& flag)
-{
-  for (int i = 0; i < 200; ++i) {
-    if (flag.load()) return;
-    std::this_thread::sleep_for(std::chrono::milliseconds(1));
-  }
-}
-
-// --- wait_to_create_task ---
-
-TEST_CASE("data_batch wait_to_create_task from idle succeeds immediately", "[data_batch][blocking]")
-{
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-
-  REQUIRE(batch->get_state() == batch_state::idle);
-  batch->wait_to_create_task();
-  REQUIRE(batch->get_state() == batch_state::task_created);
-  REQUIRE(batch->get_task_created_count() == 1);
-}
-
-TEST_CASE("data_batch wait_to_create_task from task_created increments counter",
-          "[data_batch][blocking]")
-{
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-
-  REQUIRE(batch->try_to_create_task() == true);
-  REQUIRE(batch->get_task_created_count() == 1);
-
-  batch->wait_to_create_task();
-  REQUIRE(batch->get_state() == batch_state::task_created);
-  REQUIRE(batch->get_task_created_count() == 2);
-}
-
-TEST_CASE("data_batch wait_to_create_task from processing increments counter",
-          "[data_batch][blocking]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  REQUIRE(batch->try_to_create_task() == true);
-  auto r = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(r.success == true);
-  auto handle = std::move(r.handle);
-  REQUIRE(batch->get_state() == batch_state::processing);
-
-  batch->wait_to_create_task();
-  REQUIRE(batch->get_state() == batch_state::processing);
-  REQUIRE(batch->get_task_created_count() == 1);
-}
-
-TEST_CASE("data_batch wait_to_create_task blocks while in_transit then succeeds",
-          "[data_batch][blocking]")
-{
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-
-  REQUIRE(batch->try_to_lock_for_in_transit() == true);
-  REQUIRE(batch->get_state() == batch_state::in_transit);
-
-  std::atomic<bool> wait_started{false};
-  std::atomic<bool> wait_done{false};
-
-  std::thread waiter([batch, &wait_started, &wait_done]() {
-    wait_started.store(true);
-    batch->wait_to_create_task();
-    wait_done.store(true);
-  });
-
-  wait_for_flag(wait_started);
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  REQUIRE(wait_done.load() == false);  // still blocked
-
-  REQUIRE(batch->try_to_release_in_transit() == true);
-  waiter.join();
-
-  REQUIRE(wait_done.load() == true);
-  REQUIRE(batch->get_state() == batch_state::task_created);
-  REQUIRE(batch->get_task_created_count() == 1);
-}
-
-// --- wait_to_cancel_task ---
-
-TEST_CASE("data_batch wait_to_cancel_task from task_created returns to idle",
-          "[data_batch][blocking]")
-{
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-
-  REQUIRE(batch->try_to_create_task() == true);
-  REQUIRE(batch->get_state() == batch_state::task_created);
-
-  batch->wait_to_cancel_task();
-  REQUIRE(batch->get_state() == batch_state::idle);
-  REQUIRE(batch->get_task_created_count() == 0);
-}
-
-TEST_CASE("data_batch wait_to_cancel_task with multiple tasks only decrements by one",
-          "[data_batch][blocking]")
-{
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-
-  REQUIRE(batch->try_to_create_task() == true);
-  REQUIRE(batch->try_to_create_task() == true);
-  REQUIRE(batch->get_task_created_count() == 2);
-
-  batch->wait_to_cancel_task();
-  REQUIRE(batch->get_state() == batch_state::task_created);
-  REQUIRE(batch->get_task_created_count() == 1);
-}
-
-TEST_CASE("data_batch wait_to_cancel_task from processing decrements counter",
-          "[data_batch][blocking]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  REQUIRE(batch->try_to_create_task() == true);
-  REQUIRE(batch->try_to_create_task() == true);
-  auto r = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(r.success == true);
-  auto handle = std::move(r.handle);
-  REQUIRE(batch->get_state() == batch_state::processing);
-  REQUIRE(batch->get_task_created_count() == 1);
-
-  batch->wait_to_cancel_task();
-  REQUIRE(batch->get_state() == batch_state::processing);
-  REQUIRE(batch->get_task_created_count() == 0);
-}
-
-TEST_CASE("data_batch wait_to_cancel_task blocks in idle until task is created",
-          "[data_batch][blocking]")
-{
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-
-  // Pre-create a task so cancel has something to cancel (count > 0 after unblocking)
-  REQUIRE(batch->try_to_create_task() == true);
-  // Force it back to in_transit so wait_to_cancel_task has to wait
-  REQUIRE(batch->try_to_lock_for_in_transit() == true);
-  REQUIRE(batch->get_state() == batch_state::in_transit);
-
-  std::atomic<bool> wait_started{false};
-  std::atomic<bool> wait_done{false};
-
-  std::thread waiter([batch, &wait_started, &wait_done]() {
-    wait_started.store(true);
-    batch->wait_to_cancel_task();
-    wait_done.store(true);
-  });
-
-  wait_for_flag(wait_started);
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  REQUIRE(wait_done.load() == false);  // still blocked
-
-  // Release in_transit back to task_created so the cancel can proceed
-  REQUIRE(batch->try_to_release_in_transit(batch_state::task_created) == true);
-  waiter.join();
-
-  REQUIRE(wait_done.load() == true);
-  REQUIRE(batch->get_state() == batch_state::idle);
-  REQUIRE(batch->get_task_created_count() == 0);
-}
-
-// --- wait_to_lock_for_processing ---
-
-TEST_CASE("data_batch wait_to_lock_for_processing from task_created succeeds immediately",
-          "[data_batch][blocking]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  REQUIRE(batch->try_to_create_task() == true);
-
-  auto result = batch->wait_to_lock_for_processing(space_id);
-  REQUIRE(result.success == true);
-  REQUIRE(result.status == lock_for_processing_status::success);
-  REQUIRE(result.handle.valid() == true);
-  REQUIRE(batch->get_state() == batch_state::processing);
-  REQUIRE(batch->get_processing_count() == 1);
-  REQUIRE(batch->get_task_created_count() == 0);
-}
-
-TEST_CASE("data_batch wait_to_lock_for_processing returns immediately for missing_data",
-          "[data_batch][blocking]")
-{
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-  batch->set_data(nullptr);
-
-  // Fabricate a space_id; doesn't matter since it should fail before checking state
-  auto dummy_space = make_mock_memory_space(memory::Tier::GPU, 0);
-  auto dummy_id    = dummy_space->get_id();
-
-  auto result = batch->wait_to_lock_for_processing(dummy_id);
-  REQUIRE(result.success == false);
-  REQUIRE(result.status == lock_for_processing_status::missing_data);
-}
-
-TEST_CASE("data_batch wait_to_lock_for_processing returns immediately for memory_space_mismatch",
-          "[data_batch][blocking]")
-{
-  auto data        = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch       = std::make_shared<data_batch>(1, std::move(data));
-  auto wrong_space = make_mock_memory_space(memory::Tier::HOST, 0);
-
-  auto result = batch->wait_to_lock_for_processing(wrong_space->get_id());
-  REQUIRE(result.success == false);
-  REQUIRE(result.status == lock_for_processing_status::memory_space_mismatch);
-}
-
-TEST_CASE("data_batch wait_to_lock_for_processing blocks in idle until task is created",
-          "[data_batch][blocking]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  REQUIRE(batch->get_state() == batch_state::idle);
-
-  std::atomic<bool> wait_started{false};
-  std::atomic<bool> wait_done{false};
-  lock_for_processing_result result;
-
-  std::thread waiter([batch, space_id, &wait_started, &wait_done, &result]() {
-    wait_started.store(true);
-    result = batch->wait_to_lock_for_processing(space_id);
-    wait_done.store(true);
-  });
-
-  wait_for_flag(wait_started);
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  REQUIRE(wait_done.load() == false);  // still blocked
-
-  REQUIRE(batch->try_to_create_task() == true);
-  waiter.join();
-
-  REQUIRE(wait_done.load() == true);
-  REQUIRE(result.success == true);
-  REQUIRE(result.status == lock_for_processing_status::success);
-  REQUIRE(batch->get_state() == batch_state::processing);
-  REQUIRE(batch->get_processing_count() == 1);
-}
-
-TEST_CASE("data_batch wait_to_lock_for_processing blocks in in_transit until released",
-          "[data_batch][blocking]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  REQUIRE(batch->try_to_create_task() == true);
-  REQUIRE(batch->try_to_lock_for_in_transit() == true);
-  REQUIRE(batch->get_state() == batch_state::in_transit);
-
-  std::atomic<bool> wait_started{false};
-  std::atomic<bool> wait_done{false};
-  lock_for_processing_result result;
-
-  std::thread waiter([batch, space_id, &wait_started, &wait_done, &result]() {
-    wait_started.store(true);
-    result = batch->wait_to_lock_for_processing(space_id);
-    wait_done.store(true);
-  });
-
-  wait_for_flag(wait_started);
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  REQUIRE(wait_done.load() == false);  // still blocked
-
-  // Release transit back to task_created (count is still 1)
-  REQUIRE(batch->try_to_release_in_transit(batch_state::task_created) == true);
-  waiter.join();
-
-  REQUIRE(wait_done.load() == true);
-  REQUIRE(result.success == true);
-  REQUIRE(batch->get_state() == batch_state::processing);
-}
-
-// --- wait_to_lock_for_in_transit ---
-
-TEST_CASE("data_batch wait_to_lock_for_in_transit from idle succeeds immediately",
-          "[data_batch][blocking]")
-{
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-
-  REQUIRE(batch->get_state() == batch_state::idle);
-  batch->wait_to_lock_for_in_transit();
-  REQUIRE(batch->get_state() == batch_state::in_transit);
-}
-
-TEST_CASE("data_batch wait_to_lock_for_in_transit from task_created succeeds immediately",
-          "[data_batch][blocking]")
-{
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-
-  REQUIRE(batch->try_to_create_task() == true);
-  REQUIRE(batch->get_state() == batch_state::task_created);
-  REQUIRE(batch->get_task_created_count() == 1);
-
-  batch->wait_to_lock_for_in_transit();
-  REQUIRE(batch->get_state() == batch_state::in_transit);
-}
-
-TEST_CASE("data_batch wait_to_lock_for_in_transit blocks while processing then succeeds",
-          "[data_batch][blocking]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  REQUIRE(batch->try_to_create_task() == true);
-  auto r = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(r.success == true);
-  auto handle = std::move(r.handle);
-  REQUIRE(batch->get_state() == batch_state::processing);
-  REQUIRE(batch->get_processing_count() == 1);
-
-  std::atomic<bool> wait_started{false};
-  std::atomic<bool> wait_done{false};
-
-  std::thread waiter([batch, &wait_started, &wait_done]() {
-    wait_started.store(true);
-    batch->wait_to_lock_for_in_transit();
-    wait_done.store(true);
-  });
-
-  wait_for_flag(wait_started);
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  REQUIRE(wait_done.load() == false);  // still blocked
-
-  handle.release();  // decrement processing count → idle
-  waiter.join();
-
-  REQUIRE(wait_done.load() == true);
-  REQUIRE(batch->get_state() == batch_state::in_transit);
-  REQUIRE(batch->get_processing_count() == 0);
-}
-
-TEST_CASE("data_batch wait_to_lock_for_in_transit blocks with multiple processing handles",
-          "[data_batch][blocking]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  // Acquire two processing handles
-  REQUIRE(batch->try_to_create_task() == true);
-  REQUIRE(batch->try_to_create_task() == true);
-  auto r1 = batch->try_to_lock_for_processing(space_id);
-  auto r2 = batch->try_to_lock_for_processing(space_id);
-  REQUIRE(r1.success == true);
-  REQUIRE(r2.success == true);
-  auto h1 = std::move(r1.handle);
-  auto h2 = std::move(r2.handle);
-  REQUIRE(batch->get_processing_count() == 2);
-
-  std::atomic<bool> wait_started{false};
-  std::atomic<bool> wait_done{false};
-
-  std::thread waiter([batch, &wait_started, &wait_done]() {
-    wait_started.store(true);
-    batch->wait_to_lock_for_in_transit();
-    wait_done.store(true);
-  });
-
-  wait_for_flag(wait_started);
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  REQUIRE(wait_done.load() == false);
-
-  h1.release();  // count → 1, still blocked
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  REQUIRE(wait_done.load() == false);
-
-  h2.release();  // count → 0, unblocks
-  waiter.join();
-
-  REQUIRE(wait_done.load() == true);
-  REQUIRE(batch->get_state() == batch_state::in_transit);
-}
-
-// --- wait_to_release_in_transit ---
-
-TEST_CASE("data_batch wait_to_release_in_transit from in_transit returns to idle",
-          "[data_batch][blocking]")
-{
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-
-  REQUIRE(batch->try_to_lock_for_in_transit() == true);
-  REQUIRE(batch->get_state() == batch_state::in_transit);
-
-  batch->wait_to_release_in_transit();
-  REQUIRE(batch->get_state() == batch_state::idle);
-}
-
-TEST_CASE("data_batch wait_to_release_in_transit with explicit target_state",
-          "[data_batch][blocking]")
-{
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-
-  REQUIRE(batch->try_to_create_task() == true);
-  REQUIRE(batch->try_to_lock_for_in_transit() == true);
-  REQUIRE(batch->get_state() == batch_state::in_transit);
-
-  batch->wait_to_release_in_transit(batch_state::task_created);
-  REQUIRE(batch->get_state() == batch_state::task_created);
-}
-
-TEST_CASE("data_batch wait_to_release_in_transit blocks until in_transit", "[data_batch][blocking]")
-{
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-
-  REQUIRE(batch->get_state() == batch_state::idle);
-
-  std::atomic<bool> wait_started{false};
-  std::atomic<bool> wait_done{false};
-
-  std::thread waiter([batch, &wait_started, &wait_done]() {
-    wait_started.store(true);
-    batch->wait_to_release_in_transit();
-    wait_done.store(true);
-  });
-
-  wait_for_flag(wait_started);
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  REQUIRE(wait_done.load() == false);  // still blocked
-
-  REQUIRE(batch->try_to_lock_for_in_transit() == true);
-  waiter.join();
-
-  REQUIRE(wait_done.load() == true);
-  REQUIRE(batch->get_state() == batch_state::idle);
-}
-
-TEST_CASE("data_batch wait_to_release_in_transit blocks until in_transit with target_state",
-          "[data_batch][blocking]")
-{
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-
-  std::atomic<bool> wait_done{false};
-
-  std::thread waiter([batch, &wait_done]() {
-    batch->wait_to_release_in_transit(batch_state::task_created);
-    wait_done.store(true);
-  });
-
-  std::this_thread::sleep_for(std::chrono::milliseconds(20));
-  REQUIRE(wait_done.load() == false);
-
-  REQUIRE(batch->try_to_lock_for_in_transit() == true);
-  waiter.join();
-
-  REQUIRE(wait_done.load() == true);
-  REQUIRE(batch->get_state() == batch_state::task_created);
-}
-
-// --- Full state-machine round trips using blocking calls ---
-
-TEST_CASE("data_batch blocking calls full round trip idle->task_created->processing->idle",
-          "[data_batch][blocking]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  REQUIRE(batch->get_state() == batch_state::idle);
-
-  batch->wait_to_create_task();
-  REQUIRE(batch->get_state() == batch_state::task_created);
-
-  auto result = batch->wait_to_lock_for_processing(space_id);
-  REQUIRE(result.success == true);
-  REQUIRE(batch->get_state() == batch_state::processing);
-
-  result.handle.release();
-  REQUIRE(batch->get_state() == batch_state::idle);
-}
-
-TEST_CASE("data_batch blocking calls full round trip idle->in_transit->idle",
-          "[data_batch][blocking]")
-{
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-
-  REQUIRE(batch->get_state() == batch_state::idle);
-
-  batch->wait_to_lock_for_in_transit();
-  REQUIRE(batch->get_state() == batch_state::in_transit);
-
-  batch->wait_to_release_in_transit();
-  REQUIRE(batch->get_state() == batch_state::idle);
-}
-
-TEST_CASE("data_batch concurrent wait_to_create_task and wait_to_lock_for_processing",
-          "[data_batch][blocking]")
-{
-  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch    = std::make_shared<data_batch>(1, std::move(data));
-  auto space_id = batch->get_memory_space()->get_id();
-
-  constexpr int num_rounds = 50;
-  std::vector<data_batch_processing_handle> handles;
-  handles.reserve(num_rounds);
-
-  for (int i = 0; i < num_rounds; ++i) {
-    std::atomic<bool> creator_done{false};
-
-    std::thread creator([batch, &creator_done]() {
-      batch->wait_to_create_task();
-      creator_done.store(true);
-    });
-
-    auto result = batch->wait_to_lock_for_processing(space_id);
-    creator.join();
-
-    REQUIRE(result.success == true);
-    handles.push_back(std::move(result.handle));
-  }
-
-  REQUIRE(batch->get_processing_count() == num_rounds);
-  handles.clear();
-  REQUIRE(batch->get_processing_count() == 0);
-  REQUIRE(batch->get_state() == batch_state::idle);
-}
-
-// =============================================================================
-// convert_to stream synchronization tests
-// =============================================================================
-
-// Tracks whether a CUDA event recorded after async work was complete at the
-// time the source representation was destroyed.
-struct conversion_sync_observer {
-  cudaEvent_t event{};
-  bool synced_before_destroy = false;
-
-  conversion_sync_observer()
-  {
-    CUCASCADE_CUDA_TRY(cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
-  }
-  ~conversion_sync_observer() { cudaEventDestroy(event); }
-
-  conversion_sync_observer(const conversion_sync_observer&)            = delete;
-  conversion_sync_observer& operator=(const conversion_sync_observer&) = delete;
-};
-
-// GPU representation that checks whether pending stream work completed before
-// this object is destroyed.  The destructor queries the observer's CUDA event:
-// if the event is complete, the stream was synchronized first.
-class observed_gpu_representation : private cucascade::test::mock_memory_space_holder,
-                                    public idata_representation {
- public:
-  observed_gpu_representation(rmm::device_buffer buf, conversion_sync_observer& observer)
-    : mock_memory_space_holder(memory::Tier::GPU, 0)
-    , idata_representation(*space)
-    , _buf(std::move(buf))
-    , _observer(observer)
-  {
-  }
-
-  ~observed_gpu_representation() override
-  {
-    _observer.synced_before_destroy = (cudaEventQuery(_observer.event) == cudaSuccess);
-  }
-
-  void const* data() const { return _buf.data(); }
-  std::size_t get_size_in_bytes() const override { return _buf.size(); }
-  std::size_t get_uncompressed_data_size_in_bytes() const override { return _buf.size(); }
-  std::unique_ptr<idata_representation> clone(
-    [[maybe_unused]] rmm::cuda_stream_view stream) override
-  {
-    return nullptr;
-  }
-
- private:
-  rmm::device_buffer _buf;
-  conversion_sync_observer& _observer;
-};
-
-TEST_CASE(
-  "convert_to synchronizes stream before destroying GPU source",
-  "[data_batch][convert_to]")
-{
-  rmm::cuda_stream stream;
-
-  // Use a buffer large enough that the async copy is still in-flight when
-  // the old representation would be destroyed without synchronization.
-  constexpr std::size_t buf_size = 4 * 1024 * 1024;  // 4 MB
-  rmm::device_buffer gpu_buf(buf_size, stream.view());
-  CUCASCADE_CUDA_TRY(cudaMemsetAsync(gpu_buf.data(), 0xAB, buf_size, stream.value()));
-  stream.synchronize();
-
-  // Pinned host memory so cudaMemcpyAsync is truly asynchronous
-  void* pinned_host = nullptr;
-  CUCASCADE_CUDA_TRY(cudaMallocHost(&pinned_host, buf_size));
-
-  conversion_sync_observer observer;
-  auto host_space = make_mock_memory_space(memory::Tier::HOST, 0);
-
-  // Register a converter that enqueues async work reading from the source GPU
-  // buffer WITHOUT synchronizing.  convert_to must sync before destroying the
-  // source.
-  representation_converter_registry registry;
-  registry.register_converter<observed_gpu_representation, mock_data_representation>(
-    [&](idata_representation& source,
-        const memory::memory_space* /*target_space*/,
-        rmm::cuda_stream_view s) -> std::unique_ptr<idata_representation> {
-      auto& gpu_src = source.cast<observed_gpu_representation>();
-      CUCASCADE_CUDA_TRY(cudaMemcpyAsync(
-        pinned_host, gpu_src.data(), buf_size, cudaMemcpyDeviceToHost, s.value()));
-      // Record event after the async copy so we can check completion order
-      CUCASCADE_CUDA_TRY(cudaEventRecord(observer.event, s.value()));
-      // Deliberately NO stream.synchronize() — convert_to must handle this
-      return std::make_unique<mock_data_representation>(memory::Tier::HOST, buf_size);
-    });
-
-  auto gpu_data = std::make_unique<observed_gpu_representation>(std::move(gpu_buf), observer);
-  data_batch batch(1, std::move(gpu_data));
-
-  batch.convert_to<mock_data_representation>(registry, host_space.get(), stream.view());
-
-  // With the fix: convert_to synchronizes the stream before the old GPU
-  // representation is destroyed, so the CUDA event was already complete when
-  // the destructor queried it.
-  // Without the fix: the old representation is destroyed during the move-
-  // assignment to _data, before any sync, so the event is still pending.
-  REQUIRE(observer.synced_before_destroy);
-
-  // Verify the async copy captured correct data (would be unreliable without
-  // the sync since the source GPU memory could have been freed mid-copy).
-  auto* host_bytes = static_cast<uint8_t*>(pinned_host);
-  for (std::size_t i = 0; i < buf_size; ++i) {
-    if (host_bytes[i] != 0xAB) {
-      FAIL("Data mismatch at byte " << i << ": expected 0xAB, got 0x" << std::hex
-                                     << static_cast<int>(host_bytes[i]));
-    }
-  }
-
-  CUCASCADE_CUDA_TRY(cudaFreeHost(pinned_host));
-}
-
-// Host representation that checks whether pending stream work completed before
-// this object is destroyed, mirroring observed_gpu_representation for the
-// HOST→GPU conversion direction.
-class observed_host_representation : private cucascade::test::mock_memory_space_holder,
-                                     public idata_representation {
- public:
-  observed_host_representation(void* pinned_ptr, std::size_t size, conversion_sync_observer& observer)
-    : mock_memory_space_holder(memory::Tier::HOST, 0)
-    , idata_representation(*space)
-    , _pinned_ptr(pinned_ptr)
-    , _size(size)
-    , _observer(observer)
-  {
-  }
-
-  ~observed_host_representation() override
-  {
-    _observer.synced_before_destroy = (cudaEventQuery(_observer.event) == cudaSuccess);
-  }
-
-  void const* data() const { return _pinned_ptr; }
-  std::size_t get_size_in_bytes() const override { return _size; }
-  std::size_t get_uncompressed_data_size_in_bytes() const override { return _size; }
-  std::unique_ptr<idata_representation> clone(
-    [[maybe_unused]] rmm::cuda_stream_view stream) override
-  {
-    return nullptr;
-  }
-
- private:
-  void* _pinned_ptr;
-  std::size_t _size;
-  conversion_sync_observer& _observer;
-};
-
-TEST_CASE(
-  "convert_to synchronizes stream before destroying HOST source when target is GPU",
-  "[data_batch][convert_to]")
-{
-  rmm::cuda_stream stream;
-
-  constexpr std::size_t buf_size = 4 * 1024 * 1024;  // 4 MB
-
-  // Pinned host memory so cudaMemcpyAsync is truly asynchronous
-  void* pinned_host = nullptr;
-  CUCASCADE_CUDA_TRY(cudaMallocHost(&pinned_host, buf_size));
-  std::memset(pinned_host, 0xCD, buf_size);
-
-  conversion_sync_observer observer;
-
-  // Register a converter that enqueues an async H2D copy reading from the
-  // source HOST buffer WITHOUT synchronizing.  convert_to must sync before
-  // destroying the source.
-  representation_converter_registry registry;
-  registry.register_converter<observed_host_representation, mock_data_representation>(
-    [&](idata_representation& source,
-        const memory::memory_space* /*target_space*/,
-        rmm::cuda_stream_view s) -> std::unique_ptr<idata_representation> {
-      auto& host_src = source.cast<observed_host_representation>();
-      rmm::device_buffer gpu_buf(buf_size, s);
-      CUCASCADE_CUDA_TRY(cudaMemcpyAsync(
-        gpu_buf.data(), host_src.data(), buf_size, cudaMemcpyHostToDevice, s.value()));
-      // Record event after the async copy so we can check completion order
-      CUCASCADE_CUDA_TRY(cudaEventRecord(observer.event, s.value()));
-      // Deliberately NO stream.synchronize() — convert_to must handle this
-      return std::make_unique<mock_data_representation>(memory::Tier::GPU, buf_size);
-    });
-
-  auto host_data =
-    std::make_unique<observed_host_representation>(pinned_host, buf_size, observer);
-  auto gpu_space = make_mock_memory_space(memory::Tier::GPU, 0);
-  data_batch batch(1, std::move(host_data));
-
-  batch.convert_to<mock_data_representation>(registry, gpu_space.get(), stream.view());
-
-  // With the fix: convert_to synchronizes the stream before the old HOST
-  // representation is destroyed, so the CUDA event was already complete when
-  // the destructor queried it.
-  REQUIRE(observer.synced_before_destroy);
-
-  CUCASCADE_CUDA_TRY(cudaFreeHost(pinned_host));
-}
-
-// Host callback that blocks the CUDA stream for a fixed duration, used to
-// create a deterministic window during which stream.synchronize() is blocked.
-static void CUDART_CB stream_delay_callback(void* /*userData*/)
-{
-  std::this_thread::sleep_for(std::chrono::milliseconds(50));
-}
-
-TEST_CASE(
-  "convert_to releases mutex before stream sync allowing concurrent access",
-  "[data_batch][convert_to]")
-{
-  rmm::cuda_stream stream;
-
-  constexpr std::size_t buf_size = 4 * 1024 * 1024;  // 4 MB
-  rmm::device_buffer gpu_buf(buf_size, stream.view());
-  CUCASCADE_CUDA_TRY(cudaMemsetAsync(gpu_buf.data(), 0xAB, buf_size, stream.value()));
-  stream.synchronize();
-
-  void* pinned_host = nullptr;
-  CUCASCADE_CUDA_TRY(cudaMallocHost(&pinned_host, buf_size));
-
-  conversion_sync_observer observer;
-  auto host_space = make_mock_memory_space(memory::Tier::HOST, 0);
-
-  // The converter signals when it returns so we know convert_to is about to
-  // unlock the mutex and enter the stream sync phase.
-  std::atomic<bool> converter_returned{false};
-
-  representation_converter_registry registry;
-  registry.register_converter<observed_gpu_representation, mock_data_representation>(
-    [&](idata_representation& source,
-        const memory::memory_space* /*target_space*/,
-        rmm::cuda_stream_view s) -> std::unique_ptr<idata_representation> {
-      auto& gpu_src = source.cast<observed_gpu_representation>();
-      CUCASCADE_CUDA_TRY(cudaMemcpyAsync(
-        pinned_host, gpu_src.data(), buf_size, cudaMemcpyDeviceToHost, s.value()));
-      // Enqueue a host callback that sleeps for 50 ms, creating a large
-      // deterministic window during which stream.synchronize() blocks.
-      CUCASCADE_CUDA_TRY(cudaLaunchHostFunc(s.value(), stream_delay_callback, nullptr));
-      // Record event AFTER the delay — it won't be complete until the
-      // callback finishes, regardless of GPU speed.
-      CUCASCADE_CUDA_TRY(cudaEventRecord(observer.event, s.value()));
-      converter_returned.store(true, std::memory_order_release);
-      return std::make_unique<mock_data_representation>(memory::Tier::HOST, buf_size);
-    });
-
-  auto gpu_data = std::make_unique<observed_gpu_representation>(std::move(gpu_buf), observer);
-  auto batch    = std::make_shared<data_batch>(1, std::move(gpu_data));
-
-  std::thread convert_thread([&]() {
-    batch->convert_to<mock_data_representation>(registry, host_space.get(), stream.view());
-  });
-
-  // Spin until the converter function has returned — convert_to is about to
-  // unlock the mutex and enter the stream.synchronize() phase.
-  while (!converter_returned.load(std::memory_order_acquire)) {
-    std::this_thread::yield();
-  }
-
-  // Brief pause to let convert_to move past the unlock into the sync phase.
-  std::this_thread::sleep_for(std::chrono::microseconds(500));
-
-  // get_state() takes the mutex.  With the early-unlock optimisation it
-  // returns immediately while the stream sync is still running (the host
-  // callback sleeps for 50 ms).  If the mutex were held during the sync,
-  // we would be blocked for the full 50 ms.
-  auto state = batch->get_state();
-
-  // Check whether the stream work was still in progress when we read the
-  // batch state.  cudaErrorNotReady means the event (recorded after the 50 ms
-  // host callback) hasn't been reached yet, proving we got the mutex DURING
-  // the sync.
-  bool accessed_during_sync = (cudaEventQuery(observer.event) == cudaErrorNotReady);
-
-  convert_thread.join();
-
-  // With early unlock: the mutex is free while the stream syncs, so we
-  //   accessed the batch while stream work was still in-flight.
-  // With sync inside lock: the mutex is held until the sync finishes, so by
-  //   the time get_state() returns the event is already complete.
-  REQUIRE(accessed_during_sync);
-  REQUIRE(state == batch_state::idle);
-
-  CUCASCADE_CUDA_TRY(cudaFreeHost(pinned_host));
 }

--- a/test/data/test_data_batch.cpp
+++ b/test/data/test_data_batch.cpp
@@ -719,3 +719,158 @@ TEST_CASE("data_batch clone with large table", "[data_batch][gpu]")
             cloned_repr->get_table().view().column(i).head());
   }
 }
+
+// =============================================================================
+// Observable state tests (batch_state)
+// =============================================================================
+
+TEST_CASE("data_batch initial state is idle", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+  REQUIRE(batch->get_state() == batch_state::idle);
+}
+
+TEST_CASE("data_batch state transitions via static methods", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  SECTION("idle -> read_only -> idle")
+  {
+    auto ro   = data_batch::to_read_only(std::move(batch));
+    auto idle = data_batch::to_idle(std::move(ro));
+    REQUIRE(idle->get_state() == batch_state::idle);
+  }
+
+  SECTION("idle -> mutable_locked -> idle")
+  {
+    auto mut  = data_batch::to_mutable(std::move(batch));
+    auto idle = data_batch::to_idle(std::move(mut));
+    REQUIRE(idle->get_state() == batch_state::idle);
+  }
+
+  SECTION("try_to_read_only updates state on success")
+  {
+    auto result = data_batch::try_to_read_only(batch);
+    REQUIRE(result.has_value());
+    REQUIRE(batch == nullptr);
+
+    auto idle = data_batch::to_idle(std::move(*result));
+    REQUIRE(idle->get_state() == batch_state::idle);
+  }
+
+  SECTION("try_to_mutable updates state on success")
+  {
+    auto result = data_batch::try_to_mutable(batch);
+    REQUIRE(result.has_value());
+    REQUIRE(batch == nullptr);
+
+    auto idle = data_batch::to_idle(std::move(*result));
+    REQUIRE(idle->get_state() == batch_state::idle);
+  }
+}
+
+// =============================================================================
+// Non-static transition tests (shared_from_this)
+// =============================================================================
+
+TEST_CASE("data_batch non-static to_read_only does not consume caller pointer", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto accessor = batch->to_read_only();
+  REQUIRE(batch != nullptr);
+  REQUIRE(batch->get_batch_id() == 1);
+  REQUIRE(batch->get_state() == batch_state::read_only);
+  REQUIRE(accessor.get_batch_id() == 1);
+}
+
+TEST_CASE("data_batch non-static to_mutable does not consume caller pointer", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto accessor = batch->to_mutable();
+  REQUIRE(batch != nullptr);
+  REQUIRE(batch->get_batch_id() == 1);
+  REQUIRE(batch->get_state() == batch_state::mutable_locked);
+  REQUIRE(accessor.get_batch_id() == 1);
+}
+
+TEST_CASE("data_batch non-static try_to_read_only", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto result = batch->try_to_read_only();
+  REQUIRE(result.has_value());
+  REQUIRE(batch != nullptr);
+  REQUIRE(batch->get_state() == batch_state::read_only);
+}
+
+TEST_CASE("data_batch non-static try_to_mutable", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto result = batch->try_to_mutable();
+  REQUIRE(result.has_value());
+  REQUIRE(batch != nullptr);
+  REQUIRE(batch->get_state() == batch_state::mutable_locked);
+}
+
+TEST_CASE("data_batch non-static try_to_mutable fails when read-locked", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto ro     = batch->to_read_only();
+  auto result = batch->try_to_mutable();
+  REQUIRE_FALSE(result.has_value());
+}
+
+// =============================================================================
+// Locked-to-locked transition tests
+// =============================================================================
+
+TEST_CASE("data_batch readonly_to_mutable", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto ro  = data_batch::to_read_only(std::move(batch));
+  auto mut = data_batch::readonly_to_mutable(std::move(ro));
+  REQUIRE(mut.get_batch_id() == 1);
+
+  auto idle = data_batch::to_idle(std::move(mut));
+  REQUIRE(idle->get_state() == batch_state::idle);
+}
+
+TEST_CASE("data_batch mutable_to_readonly", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto mut = data_batch::to_mutable(std::move(batch));
+  auto ro  = data_batch::mutable_to_readonly(std::move(mut));
+  REQUIRE(ro.get_batch_id() == 1);
+
+  auto idle = data_batch::to_idle(std::move(ro));
+  REQUIRE(idle->get_state() == batch_state::idle);
+}
+
+TEST_CASE("data_batch full cycle: idle -> ro -> mutable -> ro -> idle", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto ro1  = data_batch::to_read_only(std::move(batch));
+  auto mut  = data_batch::readonly_to_mutable(std::move(ro1));
+  auto ro2  = data_batch::mutable_to_readonly(std::move(mut));
+  auto idle = data_batch::to_idle(std::move(ro2));
+
+  REQUIRE(idle->get_state() == batch_state::idle);
+  REQUIRE(idle->get_batch_id() == 1);
+}

--- a/test/data/test_data_batch.cpp
+++ b/test/data/test_data_batch.cpp
@@ -1059,6 +1059,216 @@ TEST_CASE("data_batch move does not change read_only_count", "[data_batch]")
 }
 
 // =============================================================================
+// read_only_data_batch copy semantics tests
+// =============================================================================
+
+TEST_CASE("read_only_data_batch is copyable", "[data_batch]")
+{
+  static_assert(std::is_copy_constructible_v<read_only_data_batch>);
+  static_assert(std::is_copy_assignable_v<read_only_data_batch>);
+}
+
+TEST_CASE("read_only_data_batch copy constructor acquires new shared lock", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto ro1 = batch->to_read_only();
+  REQUIRE(batch->get_read_only_count() == 1);
+
+  auto ro2 = ro1;  // NOLINT(performance-unnecessary-copy-initialization)
+  REQUIRE(batch->get_read_only_count() == 2);
+  REQUIRE(ro1.get_batch_id() == 1);
+  REQUIRE(ro2.get_batch_id() == 1);
+  REQUIRE(ro1.get_current_tier() == memory::Tier::GPU);
+  REQUIRE(ro2.get_current_tier() == memory::Tier::GPU);
+  REQUIRE(ro1.get_data() == ro2.get_data());
+}
+
+TEST_CASE("read_only_data_batch copy destructor decrements count", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto ro1 = batch->to_read_only();
+  REQUIRE(batch->get_read_only_count() == 1);
+
+  {
+    auto ro2 = ro1;  // NOLINT(performance-unnecessary-copy-initialization)
+    REQUIRE(batch->get_read_only_count() == 2);
+  }
+  REQUIRE(batch->get_read_only_count() == 1);
+  REQUIRE(batch->get_state() == batch_state::read_only);
+}
+
+TEST_CASE("read_only_data_batch copy outlives original", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  std::optional<read_only_data_batch> copy;
+  {
+    auto ro = batch->to_read_only();
+    copy.emplace(ro);
+    REQUIRE(batch->get_read_only_count() == 2);
+  }
+  REQUIRE(batch->get_read_only_count() == 1);
+  REQUIRE(batch->get_state() == batch_state::read_only);
+  REQUIRE(copy->get_batch_id() == 1);
+  REQUIRE(copy->get_current_tier() == memory::Tier::GPU);
+
+  copy.reset();
+  REQUIRE(batch->get_read_only_count() == 0);
+  REQUIRE(batch->get_state() == batch_state::idle);
+}
+
+TEST_CASE("read_only_data_batch multiple copies all independent", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto ro1 = batch->to_read_only();
+  auto ro2 = ro1;  // NOLINT(performance-unnecessary-copy-initialization)
+  auto ro3 = ro2;  // NOLINT(performance-unnecessary-copy-initialization)
+  auto ro4 = ro1;  // NOLINT(performance-unnecessary-copy-initialization)
+  REQUIRE(batch->get_read_only_count() == 4);
+
+  {
+    auto temp = std::move(ro2);
+  }
+  REQUIRE(batch->get_read_only_count() == 3);
+
+  {
+    auto temp = std::move(ro3);
+  }
+  REQUIRE(batch->get_read_only_count() == 2);
+
+  REQUIRE(ro1.get_batch_id() == 1);
+  REQUIRE(ro4.get_batch_id() == 1);
+}
+
+TEST_CASE("read_only_data_batch copy assignment replaces existing lock", "[data_batch]")
+{
+  auto data1  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch1 = std::make_shared<data_batch>(1, std::move(data1));
+
+  auto data2  = std::make_unique<mock_data_representation>(memory::Tier::HOST, 2048);
+  auto batch2 = std::make_shared<data_batch>(2, std::move(data2));
+
+  auto ro1 = batch1->to_read_only();
+  auto ro2 = batch2->to_read_only();
+  REQUIRE(batch1->get_read_only_count() == 1);
+  REQUIRE(batch2->get_read_only_count() == 1);
+
+  ro1 = ro2;
+  REQUIRE(batch1->get_read_only_count() == 0);
+  REQUIRE(batch1->get_state() == batch_state::idle);
+  REQUIRE(batch2->get_read_only_count() == 2);
+  REQUIRE(ro1.get_batch_id() == 2);
+  REQUIRE(ro1.get_current_tier() == memory::Tier::HOST);
+}
+
+TEST_CASE("read_only_data_batch copy self-assignment is safe", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto ro = batch->to_read_only();
+  REQUIRE(batch->get_read_only_count() == 1);
+
+  ro = ro;
+  REQUIRE(batch->get_read_only_count() == 1);
+  REQUIRE(batch->get_state() == batch_state::read_only);
+  REQUIRE(ro.get_batch_id() == 1);
+}
+
+TEST_CASE("read_only_data_batch copy blocks mutable access", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto ro   = batch->to_read_only();
+  auto copy = ro;  // NOLINT(performance-unnecessary-copy-initialization)
+
+  // Destroy original — copy still holds shared lock
+  {
+    auto temp = std::move(ro);
+  }
+  REQUIRE(batch->get_read_only_count() == 1);
+
+  // Mutable should still be blocked by the copy's shared lock
+  std::atomic<bool> got_lock{false};
+  std::thread t([&batch, &got_lock]() {
+    auto result = batch->try_to_mutable();
+    got_lock.store(result.has_value());
+  });
+  t.join();
+  REQUIRE(got_lock.load() == false);
+}
+
+TEST_CASE("read_only_data_batch last copy destruction transitions to idle", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  {
+    auto ro1 = batch->to_read_only();
+    auto ro2 = ro1;  // NOLINT(performance-unnecessary-copy-initialization)
+    auto ro3 = ro2;  // NOLINT(performance-unnecessary-copy-initialization)
+    REQUIRE(batch->get_read_only_count() == 3);
+    REQUIRE(batch->get_state() == batch_state::read_only);
+  }
+  REQUIRE(batch->get_read_only_count() == 0);
+  REQUIRE(batch->get_state() == batch_state::idle);
+}
+
+TEST_CASE("read_only_data_batch concurrent copies thread safety", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  auto ro = batch->to_read_only();
+
+  constexpr int num_threads      = 10;
+  constexpr int copies_per_thread = 50;
+
+  std::vector<std::thread> threads;
+  for (int i = 0; i < num_threads; ++i) {
+    threads.emplace_back([&ro]() {
+      for (int j = 0; j < copies_per_thread; ++j) {
+        auto copy = ro;  // NOLINT(performance-unnecessary-copy-initialization)
+        REQUIRE(copy.get_batch_id() == 1);
+      }
+    });
+  }
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  // Only the original should remain
+  REQUIRE(batch->get_read_only_count() == 1);
+}
+
+TEST_CASE("read_only_data_batch copy then mutable after all copies released", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  {
+    auto ro1 = batch->to_read_only();
+    auto ro2 = ro1;  // NOLINT(performance-unnecessary-copy-initialization)
+    auto ro3 = ro1;  // NOLINT(performance-unnecessary-copy-initialization)
+    REQUIRE(batch->get_read_only_count() == 3);
+  }
+
+  // All copies destroyed — mutable should succeed
+  auto mut = batch->to_mutable();
+  REQUIRE(batch->get_state() == batch_state::mutable_locked);
+  REQUIRE(mut.get_batch_id() == 1);
+}
+
+// =============================================================================
 // task_created_count preserved across in_transit round-trip (STATE-01, STATE-02)
 // =============================================================================
 

--- a/test/data/test_data_batch.cpp
+++ b/test/data/test_data_batch.cpp
@@ -215,8 +215,7 @@ TEST_CASE("data_batch mutable blocks until readonly released", "[data_batch]")
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
   // Acquire read-only on a heap-allocated accessor so we can control its lifetime
-  auto ro =
-    std::make_unique<read_only_data_batch<std::shared_ptr<data_batch>>>(batch->to_read_only());
+  auto ro = std::make_unique<read_only_data_batch>(batch->to_read_only());
 
   std::atomic<bool> got_mutable{false};
 

--- a/test/data/test_data_batch.cpp
+++ b/test/data/test_data_batch.cpp
@@ -26,12 +26,11 @@
 
 #include <cuda_runtime_api.h>
 
-#include <cstring>
-
 #include <catch2/catch.hpp>
 
 #include <atomic>
 #include <chrono>
+#include <cstring>
 #include <memory>
 #include <optional>
 #include <thread>
@@ -93,7 +92,7 @@ TEST_CASE("data_batch get_batch_id is lock-free via shared_ptr", "[data_batch]")
   // Also works through the mutable accessor
   auto data2  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch2 = std::make_shared<data_batch>(99, std::move(data2));
-  auto rw     = data_batch::to_mutable(std::move(batch2));
+  auto rw     = batch2->to_mutable();
   REQUIRE(rw.get_batch_id() == 99);
 }
 
@@ -106,7 +105,7 @@ TEST_CASE("data_batch to_read_only acquires shared access", "[data_batch]")
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  auto ro = data_batch::to_read_only(std::move(batch));
+  auto ro = batch->to_read_only();
   REQUIRE(ro.get_batch_id() == 1);
   REQUIRE(ro.get_current_tier() == memory::Tier::GPU);
 }
@@ -115,12 +114,10 @@ TEST_CASE("data_batch multiple concurrent read_only via shared_ptr copies", "[da
 {
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
-  auto b2    = batch;
-  auto b3    = batch;
 
-  auto ro1 = data_batch::to_read_only(std::move(batch));
-  auto ro2 = data_batch::to_read_only(std::move(b2));
-  auto ro3 = data_batch::to_read_only(std::move(b3));
+  auto ro1 = batch->to_read_only();
+  auto ro2 = batch->to_read_only();
+  auto ro3 = batch->to_read_only();
 
   REQUIRE(ro1.get_batch_id() == 1);
   REQUIRE(ro2.get_batch_id() == 1);
@@ -136,23 +133,21 @@ TEST_CASE("data_batch try_to_read_only succeeds when unlocked", "[data_batch]")
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  auto result = data_batch::try_to_read_only(batch);
+  auto result = batch->try_to_read_only();
   REQUIRE(result.has_value());
-  REQUIRE(batch == nullptr);
   REQUIRE(result->get_batch_id() == 1);
 }
 
 TEST_CASE("data_batch try_to_read_only fails when mutable lock held", "[data_batch]")
 {
-  auto data       = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch      = std::make_shared<data_batch>(1, std::move(data));
-  auto batch_copy = batch;
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  auto rw = data_batch::to_mutable(std::move(batch));
+  auto rw = batch->to_mutable();
 
   std::atomic<bool> got_lock{false};
-  std::thread t([&batch_copy, &got_lock]() {
-    auto result = data_batch::try_to_read_only(batch_copy);
+  std::thread t([&batch, &got_lock]() {
+    auto result = batch->try_to_read_only();
     got_lock.store(result.has_value());
   });
   t.join();
@@ -164,23 +159,21 @@ TEST_CASE("data_batch try_to_mutable succeeds when unlocked", "[data_batch]")
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  auto result = data_batch::try_to_mutable(batch);
+  auto result = batch->try_to_mutable();
   REQUIRE(result.has_value());
-  REQUIRE(batch == nullptr);
   REQUIRE(result->get_batch_id() == 1);
 }
 
 TEST_CASE("data_batch try_to_mutable fails when readonly lock held", "[data_batch]")
 {
-  auto data       = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch      = std::make_shared<data_batch>(1, std::move(data));
-  auto batch_copy = batch;
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  auto ro = data_batch::to_read_only(std::move(batch));
+  auto ro = batch->to_read_only();
 
   std::atomic<bool> got_lock{false};
-  std::thread t([&batch_copy, &got_lock]() {
-    auto result = data_batch::try_to_mutable(batch_copy);
+  std::thread t([&batch, &got_lock]() {
+    auto result = batch->try_to_mutable();
     got_lock.store(result.has_value());
   });
   t.join();
@@ -189,15 +182,14 @@ TEST_CASE("data_batch try_to_mutable fails when readonly lock held", "[data_batc
 
 TEST_CASE("data_batch try_to_mutable fails when mutable lock held", "[data_batch]")
 {
-  auto data       = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch      = std::make_shared<data_batch>(1, std::move(data));
-  auto batch_copy = batch;
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  auto rw = data_batch::to_mutable(std::move(batch));
+  auto rw = batch->to_mutable();
 
   std::atomic<bool> got_lock{false};
-  std::thread t([&batch_copy, &got_lock]() {
-    auto result = data_batch::try_to_mutable(batch_copy);
+  std::thread t([&batch, &got_lock]() {
+    auto result = batch->try_to_mutable();
     got_lock.store(result.has_value());
   });
   t.join();
@@ -213,7 +205,7 @@ TEST_CASE("data_batch to_mutable acquires exclusive access", "[data_batch]")
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  auto rw = data_batch::to_mutable(std::move(batch));
+  auto rw = batch->to_mutable();
   REQUIRE(rw.get_batch_id() == 1);
 }
 
@@ -222,17 +214,14 @@ TEST_CASE("data_batch mutable blocks until readonly released", "[data_batch]")
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  // Copy the shared_ptr: one for the reader, one for the writer
-  auto writer_copy = batch;
-
   // Acquire read-only on a heap-allocated accessor so we can control its lifetime
-  auto ro = std::make_unique<read_only_data_batch<std::shared_ptr<data_batch>>>(
-    data_batch::to_read_only(std::move(batch)));
+  auto ro =
+    std::make_unique<read_only_data_batch<std::shared_ptr<data_batch>>>(batch->to_read_only());
 
   std::atomic<bool> got_mutable{false};
 
-  std::thread writer([&writer_copy, &got_mutable]() {
-    auto rw = data_batch::to_mutable(std::move(writer_copy));
+  std::thread writer([&batch, &got_mutable]() {
+    auto rw = batch->to_mutable();
     got_mutable.store(true);
   });
 
@@ -253,9 +242,9 @@ TEST_CASE("data_batch mutable to readonly through idle", "[data_batch]")
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  auto rw   = data_batch::to_mutable(std::move(batch));
+  auto rw   = batch->to_mutable();
   auto idle = data_batch::to_idle(std::move(rw));
-  auto ro   = data_batch::to_read_only(std::move(idle));
+  auto ro   = idle->to_read_only();
   REQUIRE(ro.get_batch_id() == 1);
 }
 
@@ -264,9 +253,9 @@ TEST_CASE("data_batch readonly to mutable through idle", "[data_batch]")
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  auto ro   = data_batch::to_read_only(std::move(batch));
+  auto ro   = batch->to_read_only();
   auto idle = data_batch::to_idle(std::move(ro));
-  auto rw   = data_batch::to_mutable(std::move(idle));
+  auto rw   = idle->to_mutable();
   REQUIRE(rw.get_batch_id() == 1);
 }
 
@@ -287,7 +276,8 @@ TEST_CASE("data_batch destruction order safety", "[data_batch]")
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
   // Create accessor -- this is now the ONLY shared_ptr holding the batch alive.
-  auto ro = data_batch::to_read_only(std::move(batch));
+  auto ro = batch->to_read_only();
+  batch.reset();
   // batch is null now. The only reference to the data_batch is inside ro._batch.
 
   // When ro goes out of scope here, the destruction order above should NOT crash.
@@ -380,12 +370,12 @@ TEST_CASE("data_batch set_data via mutable accessor", "[data_batch]")
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  auto rw = data_batch::to_mutable(std::move(batch));
+  auto rw = batch->to_mutable();
   REQUIRE(rw.get_current_tier() == memory::Tier::GPU);
   rw.set_data(std::make_unique<mock_data_representation>(memory::Tier::HOST, 2048));
   batch = data_batch::to_idle(std::move(rw));
 
-  auto ro = data_batch::to_read_only(std::move(batch));
+  auto ro = batch->to_read_only();
   REQUIRE(ro.get_current_tier() == memory::Tier::HOST);
 }
 
@@ -398,19 +388,19 @@ TEST_CASE("data_batch accessor get_current_tier", "[data_batch]")
   {
     auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto batch = std::make_shared<data_batch>(1, std::move(data));
-    auto ro    = data_batch::to_read_only(std::move(batch));
+    auto ro    = batch->to_read_only();
     REQUIRE(ro.get_current_tier() == memory::Tier::GPU);
   }
   {
     auto data  = std::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
     auto batch = std::make_shared<data_batch>(2, std::move(data));
-    auto ro    = data_batch::to_read_only(std::move(batch));
+    auto ro    = batch->to_read_only();
     REQUIRE(ro.get_current_tier() == memory::Tier::HOST);
   }
   {
     auto data  = std::make_unique<mock_data_representation>(memory::Tier::DISK, 1024);
     auto batch = std::make_shared<data_batch>(3, std::move(data));
-    auto ro    = data_batch::to_read_only(std::move(batch));
+    auto ro    = batch->to_read_only();
     REQUIRE(ro.get_current_tier() == memory::Tier::DISK);
   }
 }
@@ -444,14 +434,10 @@ TEST_CASE("data_batch thread-safe concurrent readonly", "[data_batch]")
 
   std::vector<std::thread> threads;
   for (int i = 0; i < num_threads; ++i) {
-    // Each thread gets its own shared_ptr copy
-    auto thread_batch = batch;
-    threads.emplace_back([thread_batch = std::move(thread_batch)]() mutable {
+    threads.emplace_back([&batch]() {
       for (int j = 0; j < reads_per_thread; ++j) {
-        auto copy = thread_batch;
-        auto ro   = data_batch::to_read_only(std::move(copy));
+        auto ro = batch->to_read_only();
         REQUIRE(ro.get_batch_id() == 1);
-        thread_batch = data_batch::to_idle(std::move(ro));
       }
     });
   }
@@ -472,19 +458,15 @@ TEST_CASE("data_batch thread-safe mutable access serialized", "[data_batch]")
 
   std::vector<std::thread> threads;
   for (int i = 0; i < num_threads; ++i) {
-    auto thread_batch = batch;
-    threads.emplace_back(
-      [thread_batch = std::move(thread_batch), &concurrent_writers, &saw_concurrent]() mutable {
-        for (int j = 0; j < 10; ++j) {
-          auto copy = thread_batch;
-          auto rw   = data_batch::to_mutable(std::move(copy));
-          int count = concurrent_writers.fetch_add(1);
-          if (count > 0) { saw_concurrent.store(true); }
-          std::this_thread::sleep_for(std::chrono::microseconds(1));
-          concurrent_writers.fetch_sub(1);
-          thread_batch = data_batch::to_idle(std::move(rw));
-        }
-      });
+    threads.emplace_back([&batch, &concurrent_writers, &saw_concurrent]() {
+      for (int j = 0; j < 10; ++j) {
+        auto rw   = batch->to_mutable();
+        int count = concurrent_writers.fetch_add(1);
+        if (count > 0) { saw_concurrent.store(true); }
+        std::this_thread::sleep_for(std::chrono::microseconds(1));
+        concurrent_writers.fetch_sub(1);
+      }
+    });
   }
 
   for (auto& t : threads) {
@@ -503,7 +485,7 @@ TEST_CASE("data_batch clone creates independent copy", "[data_batch]")
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 2048);
   auto batch = std::make_shared<data_batch>(42, std::move(data));
 
-  auto ro     = data_batch::to_read_only(std::move(batch));
+  auto ro     = batch->to_read_only();
   auto cloned = ro.clone(100, rmm::cuda_stream_view{});
 
   REQUIRE(cloned != nullptr);
@@ -511,7 +493,7 @@ TEST_CASE("data_batch clone creates independent copy", "[data_batch]")
   REQUIRE(cloned->get_subscriber_count() == 0);
   REQUIRE(ro.get_batch_id() == 42);
 
-  auto ro_clone = data_batch::to_read_only(std::move(cloned));
+  auto ro_clone = cloned->to_read_only();
   REQUIRE(ro_clone.get_data()->get_size_in_bytes() == ro.get_data()->get_size_in_bytes());
   REQUIRE(ro_clone.get_data() != ro.get_data());
 }
@@ -521,7 +503,7 @@ TEST_CASE("data_batch clone with different batch IDs", "[data_batch]")
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  auto ro = data_batch::to_read_only(std::move(batch));
+  auto ro = batch->to_read_only();
 
   auto clone1 = ro.clone(1, rmm::cuda_stream_view{});
   REQUIRE(clone1->get_batch_id() == 1);
@@ -539,27 +521,27 @@ TEST_CASE("data_batch clone preserves tier information", "[data_batch]")
   {
     auto data   = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto batch  = std::make_shared<data_batch>(1, std::move(data));
-    auto ro     = data_batch::to_read_only(std::move(batch));
+    auto ro     = batch->to_read_only();
     auto cloned = ro.clone(2, rmm::cuda_stream_view{});
-    auto ro_cl  = data_batch::to_read_only(std::move(cloned));
+    auto ro_cl  = cloned->to_read_only();
     REQUIRE(ro_cl.get_current_tier() == memory::Tier::GPU);
   }
   SECTION("HOST tier")
   {
     auto data   = std::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
     auto batch  = std::make_shared<data_batch>(1, std::move(data));
-    auto ro     = data_batch::to_read_only(std::move(batch));
+    auto ro     = batch->to_read_only();
     auto cloned = ro.clone(2, rmm::cuda_stream_view{});
-    auto ro_cl  = data_batch::to_read_only(std::move(cloned));
+    auto ro_cl  = cloned->to_read_only();
     REQUIRE(ro_cl.get_current_tier() == memory::Tier::HOST);
   }
   SECTION("DISK tier")
   {
     auto data   = std::make_unique<mock_data_representation>(memory::Tier::DISK, 1024);
     auto batch  = std::make_shared<data_batch>(1, std::move(data));
-    auto ro     = data_batch::to_read_only(std::move(batch));
+    auto ro     = batch->to_read_only();
     auto cloned = ro.clone(2, rmm::cuda_stream_view{});
-    auto ro_cl  = data_batch::to_read_only(std::move(cloned));
+    auto ro_cl  = cloned->to_read_only();
     REQUIRE(ro_cl.get_current_tier() == memory::Tier::DISK);
   }
 }
@@ -581,12 +563,12 @@ TEST_CASE("data_batch clone with real GPU data verifies data integrity", "[data_
     std::make_unique<cudf::table>(std::move(table)), *gpu_space);
   auto batch = std::make_shared<data_batch>(1, std::move(gpu_repr));
 
-  auto ro     = data_batch::to_read_only(std::move(batch));
+  auto ro     = batch->to_read_only();
   auto cloned = ro.clone(2, stream.view());
   REQUIRE(cloned != nullptr);
   REQUIRE(cloned->get_batch_id() == 2);
 
-  auto ro_clone = data_batch::to_read_only(std::move(cloned));
+  auto ro_clone = cloned->to_read_only();
 
   auto* original_repr = dynamic_cast<gpu_table_representation*>(ro.get_data());
   auto* cloned_repr   = dynamic_cast<gpu_table_representation*>(ro_clone.get_data());
@@ -611,10 +593,10 @@ TEST_CASE("data_batch clone creates independent memory copies", "[data_batch][gp
     std::make_unique<cudf::table>(std::move(table)), *gpu_space);
   auto batch = std::make_shared<data_batch>(1, std::move(gpu_repr));
 
-  auto ro     = data_batch::to_read_only(std::move(batch));
+  auto ro     = batch->to_read_only();
   auto cloned = ro.clone(2, stream.view());
 
-  auto ro_clone = data_batch::to_read_only(std::move(cloned));
+  auto ro_clone = cloned->to_read_only();
 
   auto* original_repr = dynamic_cast<gpu_table_representation*>(ro.get_data());
   auto* cloned_repr   = dynamic_cast<gpu_table_representation*>(ro_clone.get_data());
@@ -639,7 +621,7 @@ TEST_CASE("data_batch multiple clones are all independent", "[data_batch][gpu]")
   auto batch = std::make_shared<data_batch>(1, std::move(gpu_repr));
 
   // Clone 3 times from the same read_only accessor (clone does not consume the accessor)
-  auto ro     = data_batch::to_read_only(std::move(batch));
+  auto ro     = batch->to_read_only();
   auto clone1 = ro.clone(10, stream.view());
   auto clone2 = ro.clone(20, stream.view());
   auto clone3 = ro.clone(30, stream.view());
@@ -648,9 +630,9 @@ TEST_CASE("data_batch multiple clones are all independent", "[data_batch][gpu]")
   REQUIRE(clone2->get_batch_id() == 20);
   REQUIRE(clone3->get_batch_id() == 30);
 
-  auto ro_c1 = data_batch::to_read_only(std::move(clone1));
-  auto ro_c2 = data_batch::to_read_only(std::move(clone2));
-  auto ro_c3 = data_batch::to_read_only(std::move(clone3));
+  auto ro_c1 = clone1->to_read_only();
+  auto ro_c2 = clone2->to_read_only();
+  auto ro_c3 = clone3->to_read_only();
 
   auto* original_repr = dynamic_cast<gpu_table_representation*>(ro.get_data());
   auto* clone1_repr   = dynamic_cast<gpu_table_representation*>(ro_c1.get_data());
@@ -676,11 +658,11 @@ TEST_CASE("data_batch clone with empty table", "[data_batch][gpu]")
     std::make_unique<cudf::table>(std::move(table)), *gpu_space);
   auto batch = std::make_shared<data_batch>(1, std::move(gpu_repr));
 
-  auto ro     = data_batch::to_read_only(std::move(batch));
+  auto ro     = batch->to_read_only();
   auto cloned = ro.clone(2, stream.view());
   REQUIRE(cloned != nullptr);
 
-  auto ro_clone     = data_batch::to_read_only(std::move(cloned));
+  auto ro_clone     = cloned->to_read_only();
   auto* cloned_repr = dynamic_cast<gpu_table_representation*>(ro_clone.get_data());
   REQUIRE(cloned_repr != nullptr);
   REQUIRE(cloned_repr->get_table().num_rows() == 0);
@@ -698,11 +680,11 @@ TEST_CASE("data_batch clone with large table", "[data_batch][gpu]")
     std::make_unique<cudf::table>(std::move(table)), *gpu_space);
   auto batch = std::make_shared<data_batch>(1, std::move(gpu_repr));
 
-  auto ro     = data_batch::to_read_only(std::move(batch));
+  auto ro     = batch->to_read_only();
   auto cloned = ro.clone(2, stream.view());
   REQUIRE(cloned != nullptr);
 
-  auto ro_clone = data_batch::to_read_only(std::move(cloned));
+  auto ro_clone = cloned->to_read_only();
 
   auto* original_repr = dynamic_cast<gpu_table_representation*>(ro.get_data());
   auto* cloned_repr   = dynamic_cast<gpu_table_representation*>(ro_clone.get_data());
@@ -731,30 +713,29 @@ TEST_CASE("data_batch initial state is idle", "[data_batch]")
   REQUIRE(batch->get_state() == batch_state::idle);
 }
 
-TEST_CASE("data_batch state transitions via static methods", "[data_batch]")
+TEST_CASE("data_batch state transitions", "[data_batch]")
 {
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
   SECTION("idle -> read_only -> idle")
   {
-    auto ro   = data_batch::to_read_only(std::move(batch));
+    auto ro   = batch->to_read_only();
     auto idle = data_batch::to_idle(std::move(ro));
     REQUIRE(idle->get_state() == batch_state::idle);
   }
 
   SECTION("idle -> mutable_locked -> idle")
   {
-    auto mut  = data_batch::to_mutable(std::move(batch));
+    auto mut  = batch->to_mutable();
     auto idle = data_batch::to_idle(std::move(mut));
     REQUIRE(idle->get_state() == batch_state::idle);
   }
 
   SECTION("try_to_read_only updates state on success")
   {
-    auto result = data_batch::try_to_read_only(batch);
+    auto result = batch->try_to_read_only();
     REQUIRE(result.has_value());
-    REQUIRE(batch == nullptr);
 
     auto idle = data_batch::to_idle(std::move(*result));
     REQUIRE(idle->get_state() == batch_state::idle);
@@ -762,9 +743,8 @@ TEST_CASE("data_batch state transitions via static methods", "[data_batch]")
 
   SECTION("try_to_mutable updates state on success")
   {
-    auto result = data_batch::try_to_mutable(batch);
+    auto result = batch->try_to_mutable();
     REQUIRE(result.has_value());
-    REQUIRE(batch == nullptr);
 
     auto idle = data_batch::to_idle(std::move(*result));
     REQUIRE(idle->get_state() == batch_state::idle);
@@ -840,7 +820,7 @@ TEST_CASE("data_batch readonly_to_mutable", "[data_batch]")
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  auto ro  = data_batch::to_read_only(std::move(batch));
+  auto ro  = batch->to_read_only();
   auto mut = data_batch::readonly_to_mutable(std::move(ro));
   REQUIRE(mut.get_batch_id() == 1);
 
@@ -853,7 +833,7 @@ TEST_CASE("data_batch mutable_to_readonly", "[data_batch]")
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  auto mut = data_batch::to_mutable(std::move(batch));
+  auto mut = batch->to_mutable();
   auto ro  = data_batch::mutable_to_readonly(std::move(mut));
   REQUIRE(ro.get_batch_id() == 1);
 
@@ -866,7 +846,7 @@ TEST_CASE("data_batch full cycle: idle -> ro -> mutable -> ro -> idle", "[data_b
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  auto ro1  = data_batch::to_read_only(std::move(batch));
+  auto ro1  = batch->to_read_only();
   auto mut  = data_batch::readonly_to_mutable(std::move(ro1));
   auto ro2  = data_batch::mutable_to_readonly(std::move(mut));
   auto idle = data_batch::to_idle(std::move(ro2));

--- a/test/data/test_data_batch.cpp
+++ b/test/data/test_data_batch.cpp
@@ -1934,3 +1934,93 @@ TEST_CASE(
 
   CUCASCADE_CUDA_TRY(cudaFreeHost(pinned_host));
 }
+
+// =============================================================================
+// task_created_count preserved across in_transit round-trip (STATE-01, STATE-02)
+// =============================================================================
+
+TEST_CASE("data_batch task_created_count preserved across in_transit round-trip single task",
+          "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  // Create one task
+  REQUIRE(batch->try_to_create_task() == true);
+  REQUIRE(batch->get_state() == batch_state::task_created);
+  REQUIRE(batch->get_task_created_count() == 1);
+
+  // Lock for in_transit
+  REQUIRE(batch->try_to_lock_for_in_transit() == true);
+  REQUIRE(batch->get_state() == batch_state::in_transit);
+  // task_created_count must still be 1 while in_transit
+  REQUIRE(batch->get_task_created_count() == 1);
+
+  // Release back to task_created
+  REQUIRE(batch->try_to_release_in_transit(batch_state::task_created) == true);
+  REQUIRE(batch->get_state() == batch_state::task_created);
+  // task_created_count must still be 1 after round-trip
+  REQUIRE(batch->get_task_created_count() == 1);
+}
+
+TEST_CASE("data_batch task_created_count preserved across in_transit round-trip multiple tasks",
+          "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  // Create three tasks
+  REQUIRE(batch->try_to_create_task() == true);
+  REQUIRE(batch->try_to_create_task() == true);
+  REQUIRE(batch->try_to_create_task() == true);
+  REQUIRE(batch->get_state() == batch_state::task_created);
+  REQUIRE(batch->get_task_created_count() == 3);
+
+  // Lock for in_transit
+  REQUIRE(batch->try_to_lock_for_in_transit() == true);
+  REQUIRE(batch->get_state() == batch_state::in_transit);
+  REQUIRE(batch->get_task_created_count() == 3);
+
+  // Release back to task_created
+  REQUIRE(batch->try_to_release_in_transit(batch_state::task_created) == true);
+  REQUIRE(batch->get_state() == batch_state::task_created);
+  REQUIRE(batch->get_task_created_count() == 3);
+}
+
+TEST_CASE("data_batch can lock_for_processing after in_transit round-trip from task_created",
+          "[data_batch]")
+{
+  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch    = std::make_shared<data_batch>(1, std::move(data));
+  auto space_id = batch->get_memory_space()->get_id();
+
+  // Create task, go through in_transit round-trip
+  REQUIRE(batch->try_to_create_task() == true);
+  REQUIRE(batch->try_to_lock_for_in_transit() == true);
+  REQUIRE(batch->try_to_release_in_transit(batch_state::task_created) == true);
+  REQUIRE(batch->get_state() == batch_state::task_created);
+  REQUIRE(batch->get_task_created_count() == 1);
+
+  // Should still be able to lock for processing
+  auto r = batch->try_to_lock_for_processing(space_id);
+  REQUIRE(r.success == true);
+  REQUIRE(batch->get_state() == batch_state::processing);
+}
+
+TEST_CASE("data_batch can cancel_task after in_transit round-trip from task_created",
+          "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  // Create task, go through in_transit round-trip
+  REQUIRE(batch->try_to_create_task() == true);
+  REQUIRE(batch->try_to_lock_for_in_transit() == true);
+  REQUIRE(batch->try_to_release_in_transit(batch_state::task_created) == true);
+  REQUIRE(batch->get_state() == batch_state::task_created);
+
+  // Should still be able to cancel task
+  REQUIRE(batch->try_to_cancel_task() == true);
+  REQUIRE(batch->get_state() == batch_state::idle);
+  REQUIRE(batch->get_task_created_count() == 0);
+}

--- a/test/data/test_data_repository.cpp
+++ b/test/data/test_data_repository.cpp
@@ -39,7 +39,7 @@ TEST_CASE("shared_data_repository Construction", "[data_repository]")
 {
   shared_data_repository repository;
 
-  auto batch = repository.pop_idle_data_batch();
+  auto batch = repository.pop_next_data_batch();
   REQUIRE(batch == nullptr);
 }
 
@@ -52,11 +52,11 @@ TEST_CASE("shared_data_repository Add and Pull Single Batch", "[data_repository]
 
   repository.add_data_batch(batch);
 
-  auto pulled_batch = repository.pop_idle_data_batch();
+  auto pulled_batch = repository.pop_next_data_batch();
   REQUIRE(pulled_batch != nullptr);
   REQUIRE(pulled_batch->get_batch_id() == 1);
 
-  auto empty = repository.pop_idle_data_batch();
+  auto empty = repository.pop_next_data_batch();
   REQUIRE(empty == nullptr);
 }
 
@@ -71,12 +71,12 @@ TEST_CASE("shared_data_repository FIFO Order", "[data_repository]")
   }
 
   for (uint64_t i = 1; i <= 5; ++i) {
-    auto pulled_batch = repository.pop_idle_data_batch();
+    auto pulled_batch = repository.pop_next_data_batch();
     REQUIRE(pulled_batch != nullptr);
     REQUIRE(pulled_batch->get_batch_id() == i);
   }
 
-  auto empty = repository.pop_idle_data_batch();
+  auto empty = repository.pop_next_data_batch();
   REQUIRE(empty == nullptr);
 }
 
@@ -93,9 +93,9 @@ TEST_CASE("shared_data_repository Same Batch Multiple Repositories", "[data_repo
   repo2.add_data_batch(batch);
   repo3.add_data_batch(batch);
 
-  auto pulled1 = repo1.pop_idle_data_batch();
-  auto pulled2 = repo2.pop_idle_data_batch();
-  auto pulled3 = repo3.pop_idle_data_batch();
+  auto pulled1 = repo1.pop_next_data_batch();
+  auto pulled2 = repo2.pop_next_data_batch();
+  auto pulled3 = repo3.pop_next_data_batch();
 
   REQUIRE(pulled1 != nullptr);
   REQUIRE(pulled2 != nullptr);
@@ -114,7 +114,7 @@ TEST_CASE("shared_data_repository Pull From Empty", "[data_repository]")
   shared_data_repository repository;
 
   for (int i = 0; i < 10; ++i) {
-    auto batch = repository.pop_idle_data_batch();
+    auto batch = repository.pop_next_data_batch();
     REQUIRE(batch == nullptr);
   }
 }
@@ -145,7 +145,7 @@ TEST_CASE("shared_data_repository Thread-Safe Adding", "[data_repository]")
 
   int count = 0;
   while (true) {
-    auto batch = repository.pop_idle_data_batch();
+    auto batch = repository.pop_next_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -172,7 +172,7 @@ TEST_CASE("shared_data_repository Thread-Safe Pulling", "[data_repository]")
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&, i]() {
       while (true) {
-        auto batch = repository.pop_idle_data_batch();
+        auto batch = repository.pop_next_data_batch();
         if (!batch) break;
         ++thread_counts[i];
       }
@@ -190,7 +190,7 @@ TEST_CASE("shared_data_repository Thread-Safe Pulling", "[data_repository]")
 
   REQUIRE(total_count == num_batches);
 
-  auto empty = repository.pop_idle_data_batch();
+  auto empty = repository.pop_next_data_batch();
   REQUIRE(empty == nullptr);
 }
 
@@ -239,7 +239,7 @@ TEST_CASE("shared_data_repository Thread-Safe Pulling with Multiple Partitions",
 
   REQUIRE(total_count == num_batches);
 
-  auto empty = repository.pop_idle_data_batch();
+  auto empty = repository.pop_next_data_batch();
   REQUIRE(empty == nullptr);
 }
 
@@ -251,7 +251,7 @@ TEST_CASE("unique_data_repository Construction", "[data_repository]")
 {
   unique_data_repository repository;
 
-  auto batch = repository.pop_idle_data_batch();
+  auto batch = repository.pop_next_data_batch();
   REQUIRE(batch == nullptr);
 }
 
@@ -264,11 +264,11 @@ TEST_CASE("unique_data_repository Add and Pull Single Batch", "[data_repository]
 
   repository.add_data_batch(std::move(batch));
 
-  auto pulled_batch = repository.pop_idle_data_batch();
+  auto pulled_batch = repository.pop_next_data_batch();
   REQUIRE(pulled_batch != nullptr);
   REQUIRE(pulled_batch->get_batch_id() == 1);
 
-  auto empty = repository.pop_idle_data_batch();
+  auto empty = repository.pop_next_data_batch();
   REQUIRE(empty == nullptr);
 }
 
@@ -283,12 +283,12 @@ TEST_CASE("unique_data_repository FIFO Order", "[data_repository]")
   }
 
   for (uint64_t i = 1; i <= 5; ++i) {
-    auto pulled_batch = repository.pop_idle_data_batch();
+    auto pulled_batch = repository.pop_next_data_batch();
     REQUIRE(pulled_batch != nullptr);
     REQUIRE(pulled_batch->get_batch_id() == i);
   }
 
-  auto empty = repository.pop_idle_data_batch();
+  auto empty = repository.pop_next_data_batch();
   REQUIRE(empty == nullptr);
 }
 
@@ -306,7 +306,7 @@ TEST_CASE("unique_data_repository Large Number of Batches", "[data_repository]")
 
   int count = 0;
   while (true) {
-    auto batch = repository.pop_idle_data_batch();
+    auto batch = repository.pop_next_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -325,13 +325,13 @@ TEST_CASE("unique_data_repository Interleaved Add and Pull", "[data_repository]"
       repository.add_data_batch(std::move(batch));
     }
 
-    auto batch = repository.pop_idle_data_batch();
+    auto batch = repository.pop_next_data_batch();
     REQUIRE(batch != nullptr);
   }
 
   int remaining = 0;
   while (true) {
-    auto batch = repository.pop_idle_data_batch();
+    auto batch = repository.pop_next_data_batch();
     if (!batch) break;
     ++remaining;
   }
@@ -366,7 +366,7 @@ TEST_CASE("unique_data_repository Thread-Safe Adding", "[data_repository]")
 
   int count = 0;
   while (true) {
-    auto batch = repository.pop_idle_data_batch();
+    auto batch = repository.pop_next_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -393,7 +393,7 @@ TEST_CASE("unique_data_repository Thread-Safe Pulling", "[data_repository]")
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&, i]() {
       while (true) {
-        auto batch = repository.pop_idle_data_batch();
+        auto batch = repository.pop_next_data_batch();
         if (!batch) break;
         ++thread_counts[i];
       }
@@ -411,7 +411,7 @@ TEST_CASE("unique_data_repository Thread-Safe Pulling", "[data_repository]")
 
   REQUIRE(total_count == num_batches);
 
-  auto empty = repository.pop_idle_data_batch();
+  auto empty = repository.pop_next_data_batch();
   REQUIRE(empty == nullptr);
 }
 
@@ -443,7 +443,7 @@ TEST_CASE("unique_data_repository Concurrent Add and Pull", "[data_repository]")
     threads.emplace_back([&]() {
       int local_count = 0;
       while (local_count < batches_per_thread) {
-        auto batch = repository.pop_idle_data_batch();
+        auto batch = repository.pop_next_data_batch();
         if (batch) {
           ++local_count;
           ++pulled_count;
@@ -481,7 +481,7 @@ TEST_CASE("unique_data_repository High Contention", "[data_repository]")
         repository.add_data_batch(std::move(batch));
         ++total_added;
 
-        auto pulled = repository.pop_idle_data_batch();
+        auto pulled = repository.pop_next_data_batch();
         if (pulled) { ++total_pulled; }
       }
     });
@@ -494,7 +494,7 @@ TEST_CASE("unique_data_repository High Contention", "[data_repository]")
   REQUIRE(total_added == num_threads * operations_per_thread);
 
   while (true) {
-    auto batch = repository.pop_idle_data_batch();
+    auto batch = repository.pop_next_data_batch();
     if (!batch) break;
     ++total_pulled;
   }
@@ -546,12 +546,12 @@ TEST_CASE("shared_data_repository size After Pulling", "[data_repository]")
   REQUIRE(repository.size() == 5);
 
   for (int i = 1; i <= 4; ++i) {
-    auto batch = repository.pop_idle_data_batch();
+    auto batch = repository.pop_next_data_batch();
     REQUIRE(batch != nullptr);
     REQUIRE(repository.size() == (5 - i));
   }
 
-  auto last_batch = repository.pop_idle_data_batch();
+  auto last_batch = repository.pop_next_data_batch();
   REQUIRE(last_batch != nullptr);
   REQUIRE(repository.size() == 0);
 }
@@ -571,14 +571,14 @@ TEST_CASE("shared_data_repository size Interleaved Operations", "[data_repositor
 
     REQUIRE(repository.size() == (cycle * 2 + 3));
 
-    auto batch = repository.pop_idle_data_batch();
+    auto batch = repository.pop_next_data_batch();
     REQUIRE(batch != nullptr);
 
     REQUIRE(repository.size() == (cycle * 2 + 2));
   }
 
   while (repository.size() > 0) {
-    auto batch = repository.pop_idle_data_batch();
+    auto batch = repository.pop_next_data_batch();
     REQUIRE(batch != nullptr);
   }
 
@@ -625,12 +625,12 @@ TEST_CASE("unique_data_repository size After Pulling", "[data_repository]")
   REQUIRE(repository.size() == 5);
 
   for (int i = 1; i <= 4; ++i) {
-    auto batch = repository.pop_idle_data_batch();
+    auto batch = repository.pop_next_data_batch();
     REQUIRE(batch != nullptr);
     REQUIRE(repository.size() == (5 - i));
   }
 
-  auto last_batch = repository.pop_idle_data_batch();
+  auto last_batch = repository.pop_next_data_batch();
   REQUIRE(last_batch != nullptr);
   REQUIRE(repository.size() == 0);
 }
@@ -650,14 +650,14 @@ TEST_CASE("unique_data_repository size Interleaved Operations", "[data_repositor
 
     REQUIRE(repository.size() == (cycle * 2 + 3));
 
-    auto batch = repository.pop_idle_data_batch();
+    auto batch = repository.pop_next_data_batch();
     REQUIRE(batch != nullptr);
 
     REQUIRE(repository.size() == (cycle * 2 + 2));
   }
 
   while (repository.size() > 0) {
-    auto batch = repository.pop_idle_data_batch();
+    auto batch = repository.pop_next_data_batch();
     REQUIRE(batch != nullptr);
   }
 
@@ -753,7 +753,7 @@ TEST_CASE("shared_data_repository size Concurrent Operations", "[data_repository
       int pulled = 0;
       while (pulled < operations) {
         if (repository.size() > 0) {
-          auto batch = repository.pop_idle_data_batch();
+          auto batch = repository.pop_next_data_batch();
           if (batch) { ++pulled; }
         } else {
           std::this_thread::yield();
@@ -926,35 +926,58 @@ TEST_CASE("unique_data_repository throws an error when trying to get a batch by 
 }
 
 // =============================================================================
-// Tests for state-specific pop methods
+// Tests for pop_next_data_batch
 // =============================================================================
 
-TEST_CASE("shared_data_repository pop_idle_data_batch skips non-idle batches", "[data_repository]")
+TEST_CASE("shared_data_repository pop_next_data_batch empty returns nullptr", "[data_repository]")
+{
+  shared_data_repository repository;
+  REQUIRE(repository.pop_next_data_batch() == nullptr);
+}
+
+TEST_CASE("shared_data_repository pop_next_data_batch returns idle batch", "[data_repository]")
 {
   shared_data_repository repository;
 
-  auto data1  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch1 = std::make_shared<data_batch>(1, std::move(data1));
-  auto data2  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch2 = std::make_shared<data_batch>(2, std::move(data2));
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+  repository.add_data_batch(batch);
 
-  // Transition batch1 to read_only (via non-static, caller's ptr survives)
-  auto accessor = batch1->to_read_only();
-
-  repository.add_data_batch(batch1);
-  repository.add_data_batch(batch2);
-
-  // pop_idle should skip batch1 (read_only) and return batch2 (idle)
-  auto popped = repository.pop_idle_data_batch();
+  auto popped = repository.pop_next_data_batch();
   REQUIRE(popped != nullptr);
-  REQUIRE(popped->get_batch_id() == 2);
-
-  // pop_idle again — batch1 is still read_only, no idle batches left
-  auto popped2 = repository.pop_idle_data_batch();
-  REQUIRE(popped2 == nullptr);
+  REQUIRE(popped->get_batch_id() == 1);
+  REQUIRE(repository.pop_next_data_batch() == nullptr);
 }
 
-TEST_CASE("shared_data_repository pop_read_only_data_batch finds read-locked batch",
+TEST_CASE("shared_data_repository pop_next_data_batch returns read_only batch", "[data_repository]")
+{
+  shared_data_repository repository;
+
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(2, std::move(data));
+  auto accessor = batch->to_read_only();
+  repository.add_data_batch(batch);
+
+  auto popped = repository.pop_next_data_batch();
+  REQUIRE(popped != nullptr);
+  REQUIRE(popped->get_batch_id() == 2);
+}
+
+TEST_CASE("shared_data_repository pop_next_data_batch returns mutable batch", "[data_repository]")
+{
+  shared_data_repository repository;
+
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(3, std::move(data));
+  auto accessor = batch->to_mutable();
+  repository.add_data_batch(batch);
+
+  auto popped = repository.pop_next_data_batch();
+  REQUIRE(popped != nullptr);
+  REQUIRE(popped->get_batch_id() == 3);
+}
+
+TEST_CASE("shared_data_repository pop_next_data_batch FIFO regardless of state",
           "[data_repository]")
 {
   shared_data_repository repository;
@@ -963,25 +986,33 @@ TEST_CASE("shared_data_repository pop_read_only_data_batch finds read-locked bat
   auto batch1 = std::make_shared<data_batch>(1, std::move(data1));
   auto data2  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch2 = std::make_shared<data_batch>(2, std::move(data2));
+  auto data3  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch3 = std::make_shared<data_batch>(3, std::move(data3));
 
-  // batch1 is idle, batch2 is read_only
-  auto accessor = batch2->to_read_only();
+  // batch1 read_only, batch2 mutable, batch3 idle — all three should come out in order
+  auto ro_accessor  = batch1->to_read_only();
+  auto mut_accessor = batch2->to_mutable();
 
   repository.add_data_batch(batch1);
   repository.add_data_batch(batch2);
+  repository.add_data_batch(batch3);
 
-  // pop_read_only should skip batch1 (idle) and return batch2 (read_only)
-  auto popped = repository.pop_read_only_data_batch();
-  REQUIRE(popped != nullptr);
-  REQUIRE(popped->get_batch_id() == 2);
+  auto p1 = repository.pop_next_data_batch();
+  REQUIRE(p1 != nullptr);
+  REQUIRE(p1->get_batch_id() == 1);
 
-  // No more read_only batches
-  auto popped2 = repository.pop_read_only_data_batch();
-  REQUIRE(popped2 == nullptr);
+  auto p2 = repository.pop_next_data_batch();
+  REQUIRE(p2 != nullptr);
+  REQUIRE(p2->get_batch_id() == 2);
+
+  auto p3 = repository.pop_next_data_batch();
+  REQUIRE(p3 != nullptr);
+  REQUIRE(p3->get_batch_id() == 3);
+
+  REQUIRE(repository.pop_next_data_batch() == nullptr);
 }
 
-TEST_CASE("shared_data_repository pop_mutable_data_batch finds mutable-locked batch",
-          "[data_repository]")
+TEST_CASE("shared_data_repository pop_next_data_batch with partitions", "[data_repository]")
 {
   shared_data_repository repository;
 
@@ -989,50 +1020,49 @@ TEST_CASE("shared_data_repository pop_mutable_data_batch finds mutable-locked ba
   auto batch1 = std::make_shared<data_batch>(1, std::move(data1));
   auto data2  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch2 = std::make_shared<data_batch>(2, std::move(data2));
-
-  // batch2 is mutable_locked
-  auto accessor = batch2->to_mutable();
-
-  repository.add_data_batch(batch1);
-  repository.add_data_batch(batch2);
-
-  // pop_mutable should skip batch1 (idle) and return batch2 (mutable_locked)
-  auto popped = repository.pop_mutable_data_batch();
-  REQUIRE(popped != nullptr);
-  REQUIRE(popped->get_batch_id() == 2);
-
-  // pop_idle should find batch1
-  auto popped2 = repository.pop_idle_data_batch();
-  REQUIRE(popped2 != nullptr);
-  REQUIRE(popped2->get_batch_id() == 1);
-}
-
-TEST_CASE("shared_data_repository state-specific pop from empty returns nullptr",
-          "[data_repository]")
-{
-  shared_data_repository repository;
-
-  REQUIRE(repository.pop_idle_data_batch() == nullptr);
-  REQUIRE(repository.pop_read_only_data_batch() == nullptr);
-  REQUIRE(repository.pop_mutable_data_batch() == nullptr);
-}
-
-TEST_CASE("shared_data_repository state-specific pop with partitions", "[data_repository]")
-{
-  shared_data_repository repository;
-
-  auto data1  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch1 = std::make_shared<data_batch>(1, std::move(data1));
-  auto data2  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch2 = std::make_shared<data_batch>(2, std::move(data2));
-
   auto accessor = batch1->to_read_only();
 
   repository.add_data_batch(batch1, 0);
   repository.add_data_batch(batch2, 1);
 
-  // Partition 0 has read_only batch, partition 1 has idle batch
-  REQUIRE(repository.pop_idle_data_batch(0) == nullptr);
-  REQUIRE(repository.pop_read_only_data_batch(0) != nullptr);
-  REQUIRE(repository.pop_idle_data_batch(1) != nullptr);
+  auto p0 = repository.pop_next_data_batch(0);
+  REQUIRE(p0 != nullptr);
+  REQUIRE(p0->get_batch_id() == 1);
+
+  auto p1 = repository.pop_next_data_batch(1);
+  REQUIRE(p1 != nullptr);
+  REQUIRE(p1->get_batch_id() == 2);
+
+  REQUIRE(repository.pop_next_data_batch(0) == nullptr);
+  REQUIRE(repository.pop_next_data_batch(1) == nullptr);
+}
+
+TEST_CASE("unique_data_repository pop_next_data_batch empty returns nullptr", "[data_repository]")
+{
+  unique_data_repository repository;
+  REQUIRE(repository.pop_next_data_batch() == nullptr);
+}
+
+TEST_CASE("unique_data_repository pop_next_data_batch returns batch regardless of state",
+          "[data_repository]")
+{
+  unique_data_repository repository;
+
+  auto data1  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch1 = std::make_unique<data_batch>(1, std::move(data1));
+  auto data2  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch2 = std::make_unique<data_batch>(2, std::move(data2));
+
+  repository.add_data_batch(std::move(batch1));
+  repository.add_data_batch(std::move(batch2));
+
+  auto p1 = repository.pop_next_data_batch();
+  REQUIRE(p1 != nullptr);
+  REQUIRE(p1->get_batch_id() == 1);
+
+  auto p2 = repository.pop_next_data_batch();
+  REQUIRE(p2 != nullptr);
+  REQUIRE(p2->get_batch_id() == 2);
+
+  REQUIRE(repository.pop_next_data_batch() == nullptr);
 }

--- a/test/data/test_data_repository.cpp
+++ b/test/data/test_data_repository.cpp
@@ -39,7 +39,7 @@ TEST_CASE("shared_data_repository Construction", "[data_repository]")
 {
   shared_data_repository repository;
 
-  auto batch = repository.pop_data_batch();
+  auto batch = repository.pop_idle_data_batch();
   REQUIRE(batch == nullptr);
 }
 
@@ -52,11 +52,11 @@ TEST_CASE("shared_data_repository Add and Pull Single Batch", "[data_repository]
 
   repository.add_data_batch(batch);
 
-  auto pulled_batch = repository.pop_data_batch();
+  auto pulled_batch = repository.pop_idle_data_batch();
   REQUIRE(pulled_batch != nullptr);
   REQUIRE(pulled_batch->get_batch_id() == 1);
 
-  auto empty = repository.pop_data_batch();
+  auto empty = repository.pop_idle_data_batch();
   REQUIRE(empty == nullptr);
 }
 
@@ -71,12 +71,12 @@ TEST_CASE("shared_data_repository FIFO Order", "[data_repository]")
   }
 
   for (uint64_t i = 1; i <= 5; ++i) {
-    auto pulled_batch = repository.pop_data_batch();
+    auto pulled_batch = repository.pop_idle_data_batch();
     REQUIRE(pulled_batch != nullptr);
     REQUIRE(pulled_batch->get_batch_id() == i);
   }
 
-  auto empty = repository.pop_data_batch();
+  auto empty = repository.pop_idle_data_batch();
   REQUIRE(empty == nullptr);
 }
 
@@ -93,9 +93,9 @@ TEST_CASE("shared_data_repository Same Batch Multiple Repositories", "[data_repo
   repo2.add_data_batch(batch);
   repo3.add_data_batch(batch);
 
-  auto pulled1 = repo1.pop_data_batch();
-  auto pulled2 = repo2.pop_data_batch();
-  auto pulled3 = repo3.pop_data_batch();
+  auto pulled1 = repo1.pop_idle_data_batch();
+  auto pulled2 = repo2.pop_idle_data_batch();
+  auto pulled3 = repo3.pop_idle_data_batch();
 
   REQUIRE(pulled1 != nullptr);
   REQUIRE(pulled2 != nullptr);
@@ -114,7 +114,7 @@ TEST_CASE("shared_data_repository Pull From Empty", "[data_repository]")
   shared_data_repository repository;
 
   for (int i = 0; i < 10; ++i) {
-    auto batch = repository.pop_data_batch();
+    auto batch = repository.pop_idle_data_batch();
     REQUIRE(batch == nullptr);
   }
 }
@@ -145,7 +145,7 @@ TEST_CASE("shared_data_repository Thread-Safe Adding", "[data_repository]")
 
   int count = 0;
   while (true) {
-    auto batch = repository.pop_data_batch();
+    auto batch = repository.pop_idle_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -172,7 +172,7 @@ TEST_CASE("shared_data_repository Thread-Safe Pulling", "[data_repository]")
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&, i]() {
       while (true) {
-        auto batch = repository.pop_data_batch();
+        auto batch = repository.pop_idle_data_batch();
         if (!batch) break;
         ++thread_counts[i];
       }
@@ -190,7 +190,7 @@ TEST_CASE("shared_data_repository Thread-Safe Pulling", "[data_repository]")
 
   REQUIRE(total_count == num_batches);
 
-  auto empty = repository.pop_data_batch();
+  auto empty = repository.pop_idle_data_batch();
   REQUIRE(empty == nullptr);
 }
 
@@ -216,8 +216,7 @@ TEST_CASE("shared_data_repository Thread-Safe Pulling with Multiple Partitions",
     threads.emplace_back([&, i]() {
       uint64_t batch_id = i;
       while (true) {
-        auto batch = repository.pop_data_batch_by_id(
-          batch_id, batch_id % num_partitions);
+        auto batch = repository.pop_data_batch_by_id(batch_id, batch_id % num_partitions);
         if (!batch) {
           break;
         } else {
@@ -240,7 +239,7 @@ TEST_CASE("shared_data_repository Thread-Safe Pulling with Multiple Partitions",
 
   REQUIRE(total_count == num_batches);
 
-  auto empty = repository.pop_data_batch();
+  auto empty = repository.pop_idle_data_batch();
   REQUIRE(empty == nullptr);
 }
 
@@ -252,7 +251,7 @@ TEST_CASE("unique_data_repository Construction", "[data_repository]")
 {
   unique_data_repository repository;
 
-  auto batch = repository.pop_data_batch();
+  auto batch = repository.pop_idle_data_batch();
   REQUIRE(batch == nullptr);
 }
 
@@ -265,11 +264,11 @@ TEST_CASE("unique_data_repository Add and Pull Single Batch", "[data_repository]
 
   repository.add_data_batch(std::move(batch));
 
-  auto pulled_batch = repository.pop_data_batch();
+  auto pulled_batch = repository.pop_idle_data_batch();
   REQUIRE(pulled_batch != nullptr);
   REQUIRE(pulled_batch->get_batch_id() == 1);
 
-  auto empty = repository.pop_data_batch();
+  auto empty = repository.pop_idle_data_batch();
   REQUIRE(empty == nullptr);
 }
 
@@ -284,12 +283,12 @@ TEST_CASE("unique_data_repository FIFO Order", "[data_repository]")
   }
 
   for (uint64_t i = 1; i <= 5; ++i) {
-    auto pulled_batch = repository.pop_data_batch();
+    auto pulled_batch = repository.pop_idle_data_batch();
     REQUIRE(pulled_batch != nullptr);
     REQUIRE(pulled_batch->get_batch_id() == i);
   }
 
-  auto empty = repository.pop_data_batch();
+  auto empty = repository.pop_idle_data_batch();
   REQUIRE(empty == nullptr);
 }
 
@@ -307,7 +306,7 @@ TEST_CASE("unique_data_repository Large Number of Batches", "[data_repository]")
 
   int count = 0;
   while (true) {
-    auto batch = repository.pop_data_batch();
+    auto batch = repository.pop_idle_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -326,13 +325,13 @@ TEST_CASE("unique_data_repository Interleaved Add and Pull", "[data_repository]"
       repository.add_data_batch(std::move(batch));
     }
 
-    auto batch = repository.pop_data_batch();
+    auto batch = repository.pop_idle_data_batch();
     REQUIRE(batch != nullptr);
   }
 
   int remaining = 0;
   while (true) {
-    auto batch = repository.pop_data_batch();
+    auto batch = repository.pop_idle_data_batch();
     if (!batch) break;
     ++remaining;
   }
@@ -367,7 +366,7 @@ TEST_CASE("unique_data_repository Thread-Safe Adding", "[data_repository]")
 
   int count = 0;
   while (true) {
-    auto batch = repository.pop_data_batch();
+    auto batch = repository.pop_idle_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -394,7 +393,7 @@ TEST_CASE("unique_data_repository Thread-Safe Pulling", "[data_repository]")
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&, i]() {
       while (true) {
-        auto batch = repository.pop_data_batch();
+        auto batch = repository.pop_idle_data_batch();
         if (!batch) break;
         ++thread_counts[i];
       }
@@ -412,7 +411,7 @@ TEST_CASE("unique_data_repository Thread-Safe Pulling", "[data_repository]")
 
   REQUIRE(total_count == num_batches);
 
-  auto empty = repository.pop_data_batch();
+  auto empty = repository.pop_idle_data_batch();
   REQUIRE(empty == nullptr);
 }
 
@@ -444,7 +443,7 @@ TEST_CASE("unique_data_repository Concurrent Add and Pull", "[data_repository]")
     threads.emplace_back([&]() {
       int local_count = 0;
       while (local_count < batches_per_thread) {
-        auto batch = repository.pop_data_batch();
+        auto batch = repository.pop_idle_data_batch();
         if (batch) {
           ++local_count;
           ++pulled_count;
@@ -482,7 +481,7 @@ TEST_CASE("unique_data_repository High Contention", "[data_repository]")
         repository.add_data_batch(std::move(batch));
         ++total_added;
 
-        auto pulled = repository.pop_data_batch();
+        auto pulled = repository.pop_idle_data_batch();
         if (pulled) { ++total_pulled; }
       }
     });
@@ -495,7 +494,7 @@ TEST_CASE("unique_data_repository High Contention", "[data_repository]")
   REQUIRE(total_added == num_threads * operations_per_thread);
 
   while (true) {
-    auto batch = repository.pop_data_batch();
+    auto batch = repository.pop_idle_data_batch();
     if (!batch) break;
     ++total_pulled;
   }
@@ -547,12 +546,12 @@ TEST_CASE("shared_data_repository size After Pulling", "[data_repository]")
   REQUIRE(repository.size() == 5);
 
   for (int i = 1; i <= 4; ++i) {
-    auto batch = repository.pop_data_batch();
+    auto batch = repository.pop_idle_data_batch();
     REQUIRE(batch != nullptr);
     REQUIRE(repository.size() == (5 - i));
   }
 
-  auto last_batch = repository.pop_data_batch();
+  auto last_batch = repository.pop_idle_data_batch();
   REQUIRE(last_batch != nullptr);
   REQUIRE(repository.size() == 0);
 }
@@ -572,14 +571,14 @@ TEST_CASE("shared_data_repository size Interleaved Operations", "[data_repositor
 
     REQUIRE(repository.size() == (cycle * 2 + 3));
 
-    auto batch = repository.pop_data_batch();
+    auto batch = repository.pop_idle_data_batch();
     REQUIRE(batch != nullptr);
 
     REQUIRE(repository.size() == (cycle * 2 + 2));
   }
 
   while (repository.size() > 0) {
-    auto batch = repository.pop_data_batch();
+    auto batch = repository.pop_idle_data_batch();
     REQUIRE(batch != nullptr);
   }
 
@@ -626,12 +625,12 @@ TEST_CASE("unique_data_repository size After Pulling", "[data_repository]")
   REQUIRE(repository.size() == 5);
 
   for (int i = 1; i <= 4; ++i) {
-    auto batch = repository.pop_data_batch();
+    auto batch = repository.pop_idle_data_batch();
     REQUIRE(batch != nullptr);
     REQUIRE(repository.size() == (5 - i));
   }
 
-  auto last_batch = repository.pop_data_batch();
+  auto last_batch = repository.pop_idle_data_batch();
   REQUIRE(last_batch != nullptr);
   REQUIRE(repository.size() == 0);
 }
@@ -651,14 +650,14 @@ TEST_CASE("unique_data_repository size Interleaved Operations", "[data_repositor
 
     REQUIRE(repository.size() == (cycle * 2 + 3));
 
-    auto batch = repository.pop_data_batch();
+    auto batch = repository.pop_idle_data_batch();
     REQUIRE(batch != nullptr);
 
     REQUIRE(repository.size() == (cycle * 2 + 2));
   }
 
   while (repository.size() > 0) {
-    auto batch = repository.pop_data_batch();
+    auto batch = repository.pop_idle_data_batch();
     REQUIRE(batch != nullptr);
   }
 
@@ -754,7 +753,7 @@ TEST_CASE("shared_data_repository size Concurrent Operations", "[data_repository
       int pulled = 0;
       while (pulled < operations) {
         if (repository.size() > 0) {
-          auto batch = repository.pop_data_batch();
+          auto batch = repository.pop_idle_data_batch();
           if (batch) { ++pulled; }
         } else {
           std::this_thread::yield();
@@ -888,30 +887,30 @@ TEST_CASE("shared_data_repository using get_data_batch_by_id Multiple Partitions
   }
 
   for (auto& batch : batches) {
-    auto batch_from_repo = repository.get_data_batch_by_id(
-      batch->get_batch_id(), batch->get_batch_id() % num_partitions);
+    auto batch_from_repo = repository.get_data_batch_by_id(batch->get_batch_id(),
+                                                           batch->get_batch_id() % num_partitions);
     REQUIRE(batch_from_repo != nullptr);
     REQUIRE(batch_from_repo->get_batch_id() == batch->get_batch_id());
     REQUIRE(batch_from_repo == batch);
 
     // get the same batch again
-    auto batch_from_repo2 = repository.get_data_batch_by_id(
-      batch->get_batch_id(), batch->get_batch_id() % num_partitions);
+    auto batch_from_repo2 = repository.get_data_batch_by_id(batch->get_batch_id(),
+                                                            batch->get_batch_id() % num_partitions);
     REQUIRE(batch_from_repo2 != nullptr);
     REQUIRE(batch_from_repo2->get_batch_id() == batch->get_batch_id());
     REQUIRE(batch_from_repo2 == batch);
     REQUIRE(batch_from_repo2 == batch_from_repo);
 
     // now pop the batch
-    auto batch_from_repo3 = repository.pop_data_batch_by_id(
-      batch->get_batch_id(), batch->get_batch_id() % num_partitions);
+    auto batch_from_repo3 = repository.pop_data_batch_by_id(batch->get_batch_id(),
+                                                            batch->get_batch_id() % num_partitions);
     REQUIRE(batch_from_repo3 != nullptr);
     REQUIRE(batch_from_repo3->get_batch_id() == batch->get_batch_id());
     REQUIRE(batch_from_repo3 == batch);
 
     // now get again — should be nullptr
-    auto batch_from_repo4 = repository.get_data_batch_by_id(
-      batch->get_batch_id(), batch->get_batch_id() % num_partitions);
+    auto batch_from_repo4 = repository.get_data_batch_by_id(batch->get_batch_id(),
+                                                            batch->get_batch_id() % num_partitions);
     REQUIRE(batch_from_repo4 == nullptr);
   }
   REQUIRE(repository.total_size() == 0);
@@ -924,4 +923,116 @@ TEST_CASE("unique_data_repository throws an error when trying to get a batch by 
   REQUIRE_THROWS_WITH(repository.get_data_batch_by_id(0, 0),
                       "get_data_batch_by_id is not supported for unique_ptr repositories. Use "
                       "pop_data_batch to move ownership instead.");
+}
+
+// =============================================================================
+// Tests for state-specific pop methods
+// =============================================================================
+
+TEST_CASE("shared_data_repository pop_idle_data_batch skips non-idle batches", "[data_repository]")
+{
+  shared_data_repository repository;
+
+  auto data1  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch1 = std::make_shared<data_batch>(1, std::move(data1));
+  auto data2  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch2 = std::make_shared<data_batch>(2, std::move(data2));
+
+  // Transition batch1 to read_only (via non-static, caller's ptr survives)
+  auto accessor = batch1->to_read_only();
+
+  repository.add_data_batch(batch1);
+  repository.add_data_batch(batch2);
+
+  // pop_idle should skip batch1 (read_only) and return batch2 (idle)
+  auto popped = repository.pop_idle_data_batch();
+  REQUIRE(popped != nullptr);
+  REQUIRE(popped->get_batch_id() == 2);
+
+  // pop_idle again — batch1 is still read_only, no idle batches left
+  auto popped2 = repository.pop_idle_data_batch();
+  REQUIRE(popped2 == nullptr);
+}
+
+TEST_CASE("shared_data_repository pop_read_only_data_batch finds read-locked batch",
+          "[data_repository]")
+{
+  shared_data_repository repository;
+
+  auto data1  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch1 = std::make_shared<data_batch>(1, std::move(data1));
+  auto data2  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch2 = std::make_shared<data_batch>(2, std::move(data2));
+
+  // batch1 is idle, batch2 is read_only
+  auto accessor = batch2->to_read_only();
+
+  repository.add_data_batch(batch1);
+  repository.add_data_batch(batch2);
+
+  // pop_read_only should skip batch1 (idle) and return batch2 (read_only)
+  auto popped = repository.pop_read_only_data_batch();
+  REQUIRE(popped != nullptr);
+  REQUIRE(popped->get_batch_id() == 2);
+
+  // No more read_only batches
+  auto popped2 = repository.pop_read_only_data_batch();
+  REQUIRE(popped2 == nullptr);
+}
+
+TEST_CASE("shared_data_repository pop_mutable_data_batch finds mutable-locked batch",
+          "[data_repository]")
+{
+  shared_data_repository repository;
+
+  auto data1  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch1 = std::make_shared<data_batch>(1, std::move(data1));
+  auto data2  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch2 = std::make_shared<data_batch>(2, std::move(data2));
+
+  // batch2 is mutable_locked
+  auto accessor = batch2->to_mutable();
+
+  repository.add_data_batch(batch1);
+  repository.add_data_batch(batch2);
+
+  // pop_mutable should skip batch1 (idle) and return batch2 (mutable_locked)
+  auto popped = repository.pop_mutable_data_batch();
+  REQUIRE(popped != nullptr);
+  REQUIRE(popped->get_batch_id() == 2);
+
+  // pop_idle should find batch1
+  auto popped2 = repository.pop_idle_data_batch();
+  REQUIRE(popped2 != nullptr);
+  REQUIRE(popped2->get_batch_id() == 1);
+}
+
+TEST_CASE("shared_data_repository state-specific pop from empty returns nullptr",
+          "[data_repository]")
+{
+  shared_data_repository repository;
+
+  REQUIRE(repository.pop_idle_data_batch() == nullptr);
+  REQUIRE(repository.pop_read_only_data_batch() == nullptr);
+  REQUIRE(repository.pop_mutable_data_batch() == nullptr);
+}
+
+TEST_CASE("shared_data_repository state-specific pop with partitions", "[data_repository]")
+{
+  shared_data_repository repository;
+
+  auto data1  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch1 = std::make_shared<data_batch>(1, std::move(data1));
+  auto data2  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch2 = std::make_shared<data_batch>(2, std::move(data2));
+
+  auto accessor = batch1->to_read_only();
+
+  repository.add_data_batch(batch1, 0);
+  repository.add_data_batch(batch2, 1);
+
+  // Partition 0 has read_only batch, partition 1 has idle batch
+  REQUIRE(repository.pop_idle_data_batch(0) == nullptr);
+  REQUIRE(repository.pop_read_only_data_batch(0) != nullptr);
+  REQUIRE(repository.pop_idle_data_batch(1) != nullptr);
 }

--- a/test/data/test_data_repository.cpp
+++ b/test/data/test_data_repository.cpp
@@ -23,7 +23,6 @@
 #include <catch2/catch.hpp>
 
 #include <atomic>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -36,110 +35,90 @@ using cucascade::test::mock_data_representation;
 // Tests for shared_ptr based repository
 // =============================================================================
 
-// Test basic construction with shared_ptr
 TEST_CASE("shared_data_repository Construction", "[data_repository]")
 {
   shared_data_repository repository;
 
-  // Repository should be empty initially
-  auto batch = repository.pop_data_batch(batch_state::task_created);
+  auto batch = repository.pop_data_batch();
   REQUIRE(batch == nullptr);
 }
 
-// Test adding and pulling a single batch with shared_ptr
 TEST_CASE("shared_data_repository Add and Pull Single Batch", "[data_repository]")
 {
   shared_data_repository repository;
 
-  // Create a batch
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
 
-  // Add to repository
   repository.add_data_batch(batch);
 
-  // Pull from repository
-  auto pulled_batch = repository.pop_data_batch(batch_state::task_created);
+  auto pulled_batch = repository.pop_data_batch();
   REQUIRE(pulled_batch != nullptr);
   REQUIRE(pulled_batch->get_batch_id() == 1);
 
-  // Repository should now be empty
-  auto empty = repository.pop_data_batch(batch_state::task_created);
+  auto empty = repository.pop_data_batch();
   REQUIRE(empty == nullptr);
 }
 
-// Test FIFO behavior with shared_ptr
 TEST_CASE("shared_data_repository FIFO Order", "[data_repository]")
 {
   shared_data_repository repository;
 
-  // Create multiple batches and add them
   for (uint64_t i = 1; i <= 5; ++i) {
     auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto batch = std::make_shared<data_batch>(i, std::move(data));
     repository.add_data_batch(batch);
   }
 
-  // Pull them back and verify FIFO order
   for (uint64_t i = 1; i <= 5; ++i) {
-    auto pulled_batch = repository.pop_data_batch(batch_state::task_created);
+    auto pulled_batch = repository.pop_data_batch();
     REQUIRE(pulled_batch != nullptr);
     REQUIRE(pulled_batch->get_batch_id() == i);
   }
 
-  // Repository should be empty
-  auto empty = repository.pop_data_batch(batch_state::task_created);
+  auto empty = repository.pop_data_batch();
   REQUIRE(empty == nullptr);
 }
 
-// Test shared_ptr allows same batch in multiple repositories
 TEST_CASE("shared_data_repository Same Batch Multiple Repositories", "[data_repository]")
 {
   shared_data_repository repo1;
   shared_data_repository repo2;
   shared_data_repository repo3;
 
-  // Create a single batch
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(42, std::move(data));
 
-  // Add same batch to multiple repositories
   repo1.add_data_batch(batch);
   repo2.add_data_batch(batch);
   repo3.add_data_batch(batch);
 
-  // All repositories should have the same batch
-  auto pulled1 = repo1.pop_data_batch(batch_state::task_created);
-  auto pulled2 = repo2.pop_data_batch(batch_state::task_created);
-  auto pulled3 = repo3.pop_data_batch(batch_state::task_created);
+  auto pulled1 = repo1.pop_data_batch();
+  auto pulled2 = repo2.pop_data_batch();
+  auto pulled3 = repo3.pop_data_batch();
 
   REQUIRE(pulled1 != nullptr);
   REQUIRE(pulled2 != nullptr);
   REQUIRE(pulled3 != nullptr);
 
-  // They should all point to the same batch
   REQUIRE(pulled1->get_batch_id() == 42);
   REQUIRE(pulled2->get_batch_id() == 42);
   REQUIRE(pulled3->get_batch_id() == 42);
 
-  // The pointers should be the same
   REQUIRE(pulled1.get() == pulled2.get());
   REQUIRE(pulled2.get() == pulled3.get());
 }
 
-// Test pulling from empty repository
 TEST_CASE("shared_data_repository Pull From Empty", "[data_repository]")
 {
   shared_data_repository repository;
 
-  // Pull from empty repository multiple times
   for (int i = 0; i < 10; ++i) {
-    auto batch = repository.pop_data_batch(batch_state::task_created);
+    auto batch = repository.pop_data_batch();
     REQUIRE(batch == nullptr);
   }
 }
 
-// Test thread-safe adding with shared_ptr
 TEST_CASE("shared_data_repository Thread-Safe Adding", "[data_repository]")
 {
   shared_data_repository repository;
@@ -149,7 +128,6 @@ TEST_CASE("shared_data_repository Thread-Safe Adding", "[data_repository]")
 
   std::vector<std::thread> threads;
 
-  // Launch threads to add batches
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&, i]() {
       for (int j = 0; j < batches_per_thread; ++j) {
@@ -161,31 +139,26 @@ TEST_CASE("shared_data_repository Thread-Safe Adding", "[data_repository]")
     });
   }
 
-  // Wait for all threads to complete
   for (auto& thread : threads) {
     thread.join();
   }
 
-  // Pull all batches and count
   int count = 0;
   while (true) {
-    auto batch = repository.pop_data_batch(batch_state::task_created);
+    auto batch = repository.pop_data_batch();
     if (!batch) break;
     ++count;
   }
 
-  // Should have exactly num_threads * batches_per_thread
   REQUIRE(count == num_threads * batches_per_thread);
 }
 
-// Test thread-safe pulling with shared_ptr
 TEST_CASE("shared_data_repository Thread-Safe Pulling", "[data_repository]")
 {
   shared_data_repository repository;
 
   constexpr int num_batches = 500;
 
-  // Add many batches
   for (int i = 0; i < num_batches; ++i) {
     auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto batch = std::make_shared<data_batch>(i, std::move(data));
@@ -196,38 +169,31 @@ TEST_CASE("shared_data_repository Thread-Safe Pulling", "[data_repository]")
   std::vector<std::thread> threads;
   std::vector<int> thread_counts(num_threads, 0);
 
-  // Launch threads to pull batches
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&, i]() {
       while (true) {
-        auto batch = repository.pop_data_batch(batch_state::task_created);
+        auto batch = repository.pop_data_batch();
         if (!batch) break;
         ++thread_counts[i];
       }
     });
   }
 
-  // Wait for all threads to complete
   for (auto& thread : threads) {
     thread.join();
   }
 
-  // Sum all thread counts
   int total_count = 0;
   for (int count : thread_counts) {
     total_count += count;
   }
 
-  // Should have pulled exactly num_batches
   REQUIRE(total_count == num_batches);
 
-  // Repository should be empty
-  auto empty = repository.pop_data_batch(batch_state::task_created);
+  auto empty = repository.pop_data_batch();
   REQUIRE(empty == nullptr);
 }
 
-// Test thread-safe pulling with shared_ptr but with multiple partitions and using
-// pop_data_batch_by_id
 TEST_CASE("shared_data_repository Thread-Safe Pulling with Multiple Partitions",
           "[data_repository]")
 {
@@ -236,7 +202,6 @@ TEST_CASE("shared_data_repository Thread-Safe Pulling with Multiple Partitions",
   constexpr int num_batches    = 500;
   constexpr int num_partitions = 30;
 
-  // Add many batches
   for (int i = 0; i < num_batches; ++i) {
     auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto batch = std::make_shared<data_batch>(i, std::move(data));
@@ -247,13 +212,12 @@ TEST_CASE("shared_data_repository Thread-Safe Pulling with Multiple Partitions",
   std::vector<std::thread> threads;
   std::vector<int> thread_counts(num_threads, 0);
 
-  // Launch threads to pull batches
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&, i]() {
       uint64_t batch_id = i;
       while (true) {
         auto batch = repository.pop_data_batch_by_id(
-          batch_id, batch_state::task_created, batch_id % num_partitions);
+          batch_id, batch_id % num_partitions);
         if (!batch) {
           break;
         } else {
@@ -265,22 +229,18 @@ TEST_CASE("shared_data_repository Thread-Safe Pulling with Multiple Partitions",
     });
   }
 
-  // Wait for all threads to complete
   for (auto& thread : threads) {
     thread.join();
   }
 
-  // Sum all thread counts
   int total_count = 0;
   for (int count : thread_counts) {
     total_count += count;
   }
 
-  // Should have pulled exactly num_batches
   REQUIRE(total_count == num_batches);
 
-  // Repository should be empty
-  auto empty = repository.pop_data_batch(batch_state::task_created);
+  auto empty = repository.pop_data_batch();
   REQUIRE(empty == nullptr);
 }
 
@@ -288,80 +248,66 @@ TEST_CASE("shared_data_repository Thread-Safe Pulling with Multiple Partitions",
 // Tests for unique_ptr based repository
 // =============================================================================
 
-// Test basic construction with unique_ptr
 TEST_CASE("unique_data_repository Construction", "[data_repository]")
 {
   unique_data_repository repository;
 
-  // Repository should be empty initially
-  auto batch = repository.pop_data_batch(batch_state::task_created);
+  auto batch = repository.pop_data_batch();
   REQUIRE(batch == nullptr);
 }
 
-// Test adding and pulling a single batch with unique_ptr
 TEST_CASE("unique_data_repository Add and Pull Single Batch", "[data_repository]")
 {
   unique_data_repository repository;
 
-  // Create a batch
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_unique<data_batch>(1, std::move(data));
 
-  // Add to repository
   repository.add_data_batch(std::move(batch));
 
-  // Pull from repository
-  auto pulled_batch = repository.pop_data_batch(batch_state::task_created);
+  auto pulled_batch = repository.pop_data_batch();
   REQUIRE(pulled_batch != nullptr);
   REQUIRE(pulled_batch->get_batch_id() == 1);
 
-  // Repository should now be empty
-  auto empty = repository.pop_data_batch(batch_state::task_created);
+  auto empty = repository.pop_data_batch();
   REQUIRE(empty == nullptr);
 }
 
-// Test FIFO behavior with unique_ptr
 TEST_CASE("unique_data_repository FIFO Order", "[data_repository]")
 {
   unique_data_repository repository;
 
-  // Create multiple batches and add them
   for (uint64_t i = 1; i <= 5; ++i) {
     auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto batch = std::make_unique<data_batch>(i, std::move(data));
     repository.add_data_batch(std::move(batch));
   }
 
-  // Pull them back and verify FIFO order
   for (uint64_t i = 1; i <= 5; ++i) {
-    auto pulled_batch = repository.pop_data_batch(batch_state::task_created);
+    auto pulled_batch = repository.pop_data_batch();
     REQUIRE(pulled_batch != nullptr);
     REQUIRE(pulled_batch->get_batch_id() == i);
   }
 
-  // Repository should be empty
-  auto empty = repository.pop_data_batch(batch_state::task_created);
+  auto empty = repository.pop_data_batch();
   REQUIRE(empty == nullptr);
 }
 
-// Test large number of batches with unique_ptr
 TEST_CASE("unique_data_repository Large Number of Batches", "[data_repository]")
 {
   unique_data_repository repository;
 
   constexpr int num_batches = 1000;
 
-  // Add many batches
   for (int i = 0; i < num_batches; ++i) {
     auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto batch = std::make_unique<data_batch>(i, std::move(data));
     repository.add_data_batch(std::move(batch));
   }
 
-  // Pull all batches
   int count = 0;
   while (true) {
-    auto batch = repository.pop_data_batch(batch_state::task_created);
+    auto batch = repository.pop_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -369,28 +315,24 @@ TEST_CASE("unique_data_repository Large Number of Batches", "[data_repository]")
   REQUIRE(count == num_batches);
 }
 
-// Test interleaved add and pull with unique_ptr
 TEST_CASE("unique_data_repository Interleaved Add and Pull", "[data_repository]")
 {
   unique_data_repository repository;
 
   for (int cycle = 0; cycle < 50; ++cycle) {
-    // Add some batches
     for (int i = 0; i < 3; ++i) {
       auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
       auto batch = std::make_unique<data_batch>(cycle * 3 + i, std::move(data));
       repository.add_data_batch(std::move(batch));
     }
 
-    // Pull one batch
-    auto batch = repository.pop_data_batch(batch_state::task_created);
+    auto batch = repository.pop_data_batch();
     REQUIRE(batch != nullptr);
   }
 
-  // Pull remaining batches
   int remaining = 0;
   while (true) {
-    auto batch = repository.pop_data_batch(batch_state::task_created);
+    auto batch = repository.pop_data_batch();
     if (!batch) break;
     ++remaining;
   }
@@ -399,7 +341,6 @@ TEST_CASE("unique_data_repository Interleaved Add and Pull", "[data_repository]"
   REQUIRE(remaining == 100);
 }
 
-// Test thread-safe adding with unique_ptr
 TEST_CASE("unique_data_repository Thread-Safe Adding", "[data_repository]")
 {
   unique_data_repository repository;
@@ -409,7 +350,6 @@ TEST_CASE("unique_data_repository Thread-Safe Adding", "[data_repository]")
 
   std::vector<std::thread> threads;
 
-  // Launch threads to add batches
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&, i]() {
       for (int j = 0; j < batches_per_thread; ++j) {
@@ -421,31 +361,26 @@ TEST_CASE("unique_data_repository Thread-Safe Adding", "[data_repository]")
     });
   }
 
-  // Wait for all threads to complete
   for (auto& thread : threads) {
     thread.join();
   }
 
-  // Pull all batches and count
   int count = 0;
   while (true) {
-    auto batch = repository.pop_data_batch(batch_state::task_created);
+    auto batch = repository.pop_data_batch();
     if (!batch) break;
     ++count;
   }
 
-  // Should have exactly num_threads * batches_per_thread
   REQUIRE(count == num_threads * batches_per_thread);
 }
 
-// Test thread-safe pulling with unique_ptr
 TEST_CASE("unique_data_repository Thread-Safe Pulling", "[data_repository]")
 {
   unique_data_repository repository;
 
   constexpr int num_batches = 500;
 
-  // Add many batches
   for (int i = 0; i < num_batches; ++i) {
     auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto batch = std::make_unique<data_batch>(i, std::move(data));
@@ -456,37 +391,31 @@ TEST_CASE("unique_data_repository Thread-Safe Pulling", "[data_repository]")
   std::vector<std::thread> threads;
   std::vector<int> thread_counts(num_threads, 0);
 
-  // Launch threads to pull batches
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&, i]() {
       while (true) {
-        auto batch = repository.pop_data_batch(batch_state::task_created);
+        auto batch = repository.pop_data_batch();
         if (!batch) break;
         ++thread_counts[i];
       }
     });
   }
 
-  // Wait for all threads to complete
   for (auto& thread : threads) {
     thread.join();
   }
 
-  // Sum all thread counts
   int total_count = 0;
   for (int count : thread_counts) {
     total_count += count;
   }
 
-  // Should have pulled exactly num_batches
   REQUIRE(total_count == num_batches);
 
-  // Repository should be empty
-  auto empty = repository.pop_data_batch(batch_state::task_created);
+  auto empty = repository.pop_data_batch();
   REQUIRE(empty == nullptr);
 }
 
-// Test concurrent adding and pulling with unique_ptr
 TEST_CASE("unique_data_repository Concurrent Add and Pull", "[data_repository]")
 {
   unique_data_repository repository;
@@ -498,7 +427,6 @@ TEST_CASE("unique_data_repository Concurrent Add and Pull", "[data_repository]")
   std::vector<std::thread> threads;
   std::atomic<int> pulled_count{0};
 
-  // Launch adding threads
   for (int i = 0; i < num_add_threads; ++i) {
     threads.emplace_back([&, i]() {
       for (int j = 0; j < batches_per_thread; ++j) {
@@ -507,39 +435,33 @@ TEST_CASE("unique_data_repository Concurrent Add and Pull", "[data_repository]")
         auto batch        = std::make_unique<data_batch>(batch_id, std::move(data));
         repository.add_data_batch(std::move(batch));
 
-        // Small delay to allow pullers to work
         std::this_thread::sleep_for(std::chrono::microseconds(10));
       }
     });
   }
 
-  // Launch pulling threads
   for (int i = 0; i < num_pull_threads; ++i) {
     threads.emplace_back([&]() {
       int local_count = 0;
       while (local_count < batches_per_thread) {
-        auto batch = repository.pop_data_batch(batch_state::task_created);
+        auto batch = repository.pop_data_batch();
         if (batch) {
           ++local_count;
           ++pulled_count;
         } else {
-          // Repository temporarily empty, yield to adders
           std::this_thread::yield();
         }
       }
     });
   }
 
-  // Wait for all threads to complete
   for (auto& thread : threads) {
     thread.join();
   }
 
-  // Should have pulled exactly num_add_threads * batches_per_thread
   REQUIRE(pulled_count == num_add_threads * batches_per_thread);
 }
 
-// Test high contention scenario with unique_ptr
 TEST_CASE("unique_data_repository High Contention", "[data_repository]")
 {
   unique_data_repository repository;
@@ -551,134 +473,71 @@ TEST_CASE("unique_data_repository High Contention", "[data_repository]")
   std::atomic<int> total_added{0};
   std::atomic<int> total_pulled{0};
 
-  // Launch threads doing both add and pull operations
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&, i]() {
       for (int j = 0; j < operations_per_thread; ++j) {
-        // Add a batch
         auto data         = std::make_unique<mock_data_representation>(memory::Tier::GPU, 512);
         uint64_t batch_id = i * operations_per_thread + j;
         auto batch        = std::make_unique<data_batch>(batch_id, std::move(data));
         repository.add_data_batch(std::move(batch));
         ++total_added;
 
-        // Immediately try to pull a batch (might be ours or someone else's)
-        auto pulled = repository.pop_data_batch(batch_state::task_created);
+        auto pulled = repository.pop_data_batch();
         if (pulled) { ++total_pulled; }
       }
     });
   }
 
-  // Wait for all threads
   for (auto& thread : threads) {
     thread.join();
   }
 
-  // Verify counts
   REQUIRE(total_added == num_threads * operations_per_thread);
 
-  // Clean up remaining batches
   while (true) {
-    auto batch = repository.pop_data_batch(batch_state::task_created);
+    auto batch = repository.pop_data_batch();
     if (!batch) break;
     ++total_pulled;
   }
 
-  // All batches should have been processed
   REQUIRE(total_pulled == total_added);
-}
-
-// Test that pop_data_batch transitions batch to the requested state
-TEST_CASE("shared_data_repository Pull Transitions State", "[data_repository]")
-{
-  shared_data_repository repository;
-
-  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch = std::make_shared<data_batch>(1, std::move(data));
-  repository.add_data_batch(batch);
-
-  auto pulled_batch = repository.pop_data_batch(batch_state::task_created);
-  REQUIRE(pulled_batch != nullptr);
-
-  // Batch state should be task_created after pulling with that target state
-  REQUIRE(pulled_batch->get_state() == batch_state::task_created);
-  REQUIRE(pulled_batch->get_task_created_count() == 1);
-  REQUIRE(pulled_batch->get_processing_count() == 0);
-}
-
-// Test that in_transit batches are skipped when pulling with task_created target
-TEST_CASE("shared_data_repository Pull Skips In Transit Batch", "[data_repository]")
-{
-  shared_data_repository repository;
-
-  // Add first batch and mark it as in_transit
-  auto data1  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch1 = std::make_shared<data_batch>(1, std::move(data1));
-  REQUIRE(batch1->try_to_lock_for_in_transit() == true);
-  REQUIRE(batch1->get_state() == batch_state::in_transit);
-  repository.add_data_batch(batch1);
-
-  // Add second batch in idle state
-  auto data2  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
-  auto batch2 = std::make_shared<data_batch>(2, std::move(data2));
-  repository.add_data_batch(batch2);
-
-  // Pull should skip the in_transit batch and return the idle one
-  auto pulled = repository.pop_data_batch(batch_state::task_created);
-  REQUIRE(pulled != nullptr);
-  REQUIRE(pulled->get_batch_id() == 2);  // Should get batch2, not batch1
-  REQUIRE(pulled->get_state() == batch_state::task_created);
-
-  // Repository should still have the in_transit batch
-  REQUIRE(repository.size() == 1);
 }
 
 // =============================================================================
 // Tests for size()
 // =============================================================================
 
-// Test size on empty shared repository
 TEST_CASE("shared_data_repository size Empty", "[data_repository]")
 {
   shared_data_repository repository;
-
-  // Initially empty
   REQUIRE(repository.size() == 0);
 }
 
-// Test size after adding batches to shared repository
 TEST_CASE("shared_data_repository size After Adding", "[data_repository]")
 {
   shared_data_repository repository;
 
-  // Initially empty
   REQUIRE(repository.size() == 0);
 
-  // Add one batch
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_shared<data_batch>(1, std::move(data));
   repository.add_data_batch(batch);
 
-  // Should now have batches available
   REQUIRE(repository.size() == 1);
 
-  // Add more batches
   for (int i = 2; i <= 5; ++i) {
     auto data2  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto batch2 = std::make_shared<data_batch>(i, std::move(data2));
     repository.add_data_batch(batch2);
   }
 
-  // Should still have batches available
   REQUIRE(repository.size() == 5);
 }
 
-// Test size after pulling batches from shared repository
 TEST_CASE("shared_data_repository size After Pulling", "[data_repository]")
 {
   shared_data_repository repository;
 
-  // Add multiple batches
   for (int i = 1; i <= 5; ++i) {
     auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto batch = std::make_shared<data_batch>(i, std::move(data));
@@ -687,23 +546,17 @@ TEST_CASE("shared_data_repository size After Pulling", "[data_repository]")
 
   REQUIRE(repository.size() == 5);
 
-  // Pull batches one by one
   for (int i = 1; i <= 4; ++i) {
-    auto batch = repository.pop_data_batch(batch_state::task_created);
+    auto batch = repository.pop_data_batch();
     REQUIRE(batch != nullptr);
-    // Should still have batches available
     REQUIRE(repository.size() == (5 - i));
   }
 
-  // Pull the last batch
-  auto last_batch = repository.pop_data_batch(batch_state::task_created);
+  auto last_batch = repository.pop_data_batch();
   REQUIRE(last_batch != nullptr);
-
-  // Now should be empty
   REQUIRE(repository.size() == 0);
 }
 
-// Test size with interleaved operations on shared repository
 TEST_CASE("shared_data_repository size Interleaved Operations", "[data_repository]")
 {
   shared_data_repository repository;
@@ -711,7 +564,6 @@ TEST_CASE("shared_data_repository size Interleaved Operations", "[data_repositor
   REQUIRE(repository.size() == 0);
 
   for (int cycle = 0; cycle < 10; ++cycle) {
-    // Add some batches
     for (int i = 0; i < 3; ++i) {
       auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
       auto batch = std::make_shared<data_batch>(cycle * 3 + i, std::move(data));
@@ -720,66 +572,51 @@ TEST_CASE("shared_data_repository size Interleaved Operations", "[data_repositor
 
     REQUIRE(repository.size() == (cycle * 2 + 3));
 
-    // Pull one batch
-    auto batch = repository.pop_data_batch(batch_state::task_created);
+    auto batch = repository.pop_data_batch();
     REQUIRE(batch != nullptr);
 
-    // Should still have batches (added 3, pulled 1)
     REQUIRE(repository.size() == (cycle * 2 + 2));
   }
 
-  // Pull all remaining batches
   while (repository.size() > 0) {
-    auto batch = repository.pop_data_batch(batch_state::task_created);
+    auto batch = repository.pop_data_batch();
     REQUIRE(batch != nullptr);
   }
 
-  // Should be empty now
   REQUIRE(repository.size() == 0);
 }
 
-// Test size on empty unique repository
 TEST_CASE("unique_data_repository size Empty", "[data_repository]")
 {
   unique_data_repository repository;
-
-  // Initially empty
   REQUIRE(repository.size() == 0);
 }
 
-// Test size after adding batches to unique repository
 TEST_CASE("unique_data_repository size After Adding", "[data_repository]")
 {
   unique_data_repository repository;
 
-  // Initially empty
   REQUIRE(repository.size() == 0);
 
-  // Add one batch
   auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
   auto batch = std::make_unique<data_batch>(1, std::move(data));
   repository.add_data_batch(std::move(batch));
 
-  // Should now have batches available
   REQUIRE(repository.size() == 1);
 
-  // Add more batches
   for (int i = 2; i <= 5; ++i) {
     auto data2  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto batch2 = std::make_unique<data_batch>(i, std::move(data2));
     repository.add_data_batch(std::move(batch2));
   }
 
-  // Should still have batches available
   REQUIRE(repository.size() == 5);
 }
 
-// Test size after pulling batches from unique repository
 TEST_CASE("unique_data_repository size After Pulling", "[data_repository]")
 {
   unique_data_repository repository;
 
-  // Add multiple batches
   for (int i = 1; i <= 5; ++i) {
     auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
     auto batch = std::make_unique<data_batch>(i, std::move(data));
@@ -788,23 +625,17 @@ TEST_CASE("unique_data_repository size After Pulling", "[data_repository]")
 
   REQUIRE(repository.size() == 5);
 
-  // Pull batches one by one
   for (int i = 1; i <= 4; ++i) {
-    auto batch = repository.pop_data_batch(batch_state::task_created);
+    auto batch = repository.pop_data_batch();
     REQUIRE(batch != nullptr);
-    // Should still have batches available
     REQUIRE(repository.size() == (5 - i));
   }
 
-  // Pull the last batch
-  auto last_batch = repository.pop_data_batch(batch_state::task_created);
+  auto last_batch = repository.pop_data_batch();
   REQUIRE(last_batch != nullptr);
-
-  // Now should be empty
   REQUIRE(repository.size() == 0);
 }
 
-// Test size with interleaved operations on unique repository
 TEST_CASE("unique_data_repository size Interleaved Operations", "[data_repository]")
 {
   unique_data_repository repository;
@@ -812,7 +643,6 @@ TEST_CASE("unique_data_repository size Interleaved Operations", "[data_repositor
   REQUIRE(repository.size() == 0);
 
   for (int cycle = 0; cycle < 10; ++cycle) {
-    // Add some batches
     for (int i = 0; i < 3; ++i) {
       auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
       auto batch = std::make_unique<data_batch>(cycle * 3 + i, std::move(data));
@@ -821,25 +651,20 @@ TEST_CASE("unique_data_repository size Interleaved Operations", "[data_repositor
 
     REQUIRE(repository.size() == (cycle * 2 + 3));
 
-    // Pull one batch
-    auto batch = repository.pop_data_batch(batch_state::task_created);
+    auto batch = repository.pop_data_batch();
     REQUIRE(batch != nullptr);
 
-    // Should still have batches (added 3, pulled 1)
     REQUIRE(repository.size() == (cycle * 2 + 2));
   }
 
-  // Pull all remaining batches
   while (repository.size() > 0) {
-    auto batch = repository.pop_data_batch(batch_state::task_created);
+    auto batch = repository.pop_data_batch();
     REQUIRE(batch != nullptr);
   }
 
-  // Should be empty now
   REQUIRE(repository.size() == 0);
 }
 
-// Test size thread-safety on shared repository
 TEST_CASE("shared_data_repository size Thread-Safe", "[data_repository]")
 {
   shared_data_repository repository;
@@ -850,7 +675,6 @@ TEST_CASE("shared_data_repository size Thread-Safe", "[data_repository]")
   std::vector<std::thread> threads;
   std::atomic<int> availability_check_count{0};
 
-  // Launch threads that add batches and check availability
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&, i]() {
       for (int j = 0; j < batches_per_thread; ++j) {
@@ -859,25 +683,19 @@ TEST_CASE("shared_data_repository size Thread-Safe", "[data_repository]")
         auto batch        = std::make_shared<data_batch>(batch_id, std::move(data));
         repository.add_data_batch(batch);
 
-        // Check availability after adding
         if (repository.size() > 0) { ++availability_check_count; }
       }
     });
   }
 
-  // Wait for all threads to complete
   for (auto& thread : threads) {
     thread.join();
   }
 
-  // All checks should have returned true since we were always adding
   REQUIRE(availability_check_count == num_threads * batches_per_thread);
-
-  // Verify repository is not empty
   REQUIRE(repository.size() > 0);
 }
 
-// Test size thread-safety on unique repository
 TEST_CASE("unique_data_repository size Thread-Safe", "[data_repository]")
 {
   unique_data_repository repository;
@@ -888,7 +706,6 @@ TEST_CASE("unique_data_repository size Thread-Safe", "[data_repository]")
   std::vector<std::thread> threads;
   std::atomic<int> availability_check_count{0};
 
-  // Launch threads that add batches and check availability
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([&, i]() {
       for (int j = 0; j < batches_per_thread; ++j) {
@@ -897,25 +714,19 @@ TEST_CASE("unique_data_repository size Thread-Safe", "[data_repository]")
         auto batch        = std::make_unique<data_batch>(batch_id, std::move(data));
         repository.add_data_batch(std::move(batch));
 
-        // Check availability after adding
         if (repository.size() > 0) { ++availability_check_count; }
       }
     });
   }
 
-  // Wait for all threads to complete
   for (auto& thread : threads) {
     thread.join();
   }
 
-  // All checks should have returned true since we were always adding
   REQUIRE(availability_check_count == num_threads * batches_per_thread);
-
-  // Verify repository is not empty
   REQUIRE(repository.size() > 0);
 }
 
-// Test size with concurrent add and pull operations
 TEST_CASE("shared_data_repository size Concurrent Operations", "[data_repository]")
 {
   shared_data_repository repository;
@@ -925,9 +736,7 @@ TEST_CASE("shared_data_repository size Concurrent Operations", "[data_repository
   constexpr int operations       = 100;
 
   std::vector<std::thread> threads;
-  std::atomic<bool> stop{false};
 
-  // Launch adding threads
   for (int i = 0; i < num_add_threads; ++i) {
     threads.emplace_back([&, i]() {
       for (int j = 0; j < operations; ++j) {
@@ -940,13 +749,12 @@ TEST_CASE("shared_data_repository size Concurrent Operations", "[data_repository
     });
   }
 
-  // Launch pulling threads that also check availability
   for (int i = 0; i < num_pull_threads; ++i) {
     threads.emplace_back([&]() {
       int pulled = 0;
       while (pulled < operations) {
         if (repository.size() > 0) {
-          auto batch = repository.pop_data_batch(batch_state::task_created);
+          auto batch = repository.pop_data_batch();
           if (batch) { ++pulled; }
         } else {
           std::this_thread::yield();
@@ -955,12 +763,10 @@ TEST_CASE("shared_data_repository size Concurrent Operations", "[data_repository
     });
   }
 
-  // Wait for all threads to complete
   for (auto& thread : threads) {
     thread.join();
   }
 
-  // Repository should be empty after all operations
   REQUIRE(repository.size() == 0);
 }
 
@@ -974,17 +780,14 @@ std::vector<std::shared_ptr<data_batch>> create_test_batches(std::vector<uint64_
   return batches;
 }
 
-// Test add and pop operations on multiple partitions and test size for each partition, and finally
-// test the size and empty status
 TEST_CASE("shared_data_repository pop Multiple Partitions", "[data_repository]")
 {
   shared_data_repository repository;
 
-  // Add batches to multiple partitions
   std::vector<uint64_t> batch_ids0 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   auto batches                     = create_test_batches(batch_ids0);
   for (auto& batch : batches) {
-    repository.add_data_batch(batch);  // Add to partition 0
+    repository.add_data_batch(batch);
   }
   REQUIRE(repository.size(0) == batch_ids0.size());
 
@@ -1002,45 +805,39 @@ TEST_CASE("shared_data_repository pop Multiple Partitions", "[data_repository]")
   }
   REQUIRE(repository.size(2) == batch_ids2.size());
 
-  // Test total size
   REQUIRE(repository.total_size() == batch_ids0.size() + batch_ids1.size() + batch_ids2.size());
 
-  // Test get batch ids from each partition
-  auto retrieved_batch_ids0 = repository.get_batch_ids();  // partition 0
+  auto retrieved_batch_ids0 = repository.get_batch_ids();
   REQUIRE(batch_ids0 == retrieved_batch_ids0);
   auto retrieved_batch_ids1 = repository.get_batch_ids(1);
   REQUIRE(batch_ids1 == retrieved_batch_ids1);
   auto retrieved_batch_ids2 = repository.get_batch_ids(2);
   REQUIRE(batch_ids2 == retrieved_batch_ids2);
 
-  // pop each batch by id from each partition
   for (auto batch_id : batch_ids0) {
-    auto batch = repository.pop_data_batch_by_id(batch_id, batch_state::task_created);
+    auto batch = repository.pop_data_batch_by_id(batch_id);
     REQUIRE(batch != nullptr);
     REQUIRE(batch->get_batch_id() == batch_id);
   }
   for (auto batch_id : batch_ids1) {
-    auto batch = repository.pop_data_batch_by_id(batch_id, batch_state::task_created, 1);
+    auto batch = repository.pop_data_batch_by_id(batch_id, 1);
     REQUIRE(batch != nullptr);
     REQUIRE(batch->get_batch_id() == batch_id);
   }
   for (auto batch_id : batch_ids2) {
-    auto batch = repository.pop_data_batch_by_id(batch_id, batch_state::task_created, 2);
+    auto batch = repository.pop_data_batch_by_id(batch_id, 2);
     REQUIRE(batch != nullptr);
     REQUIRE(batch->get_batch_id() == batch_id);
   }
 
-  // Test total size
   REQUIRE(repository.total_size() == 0);
 
-  // Test empty and all_empty
-  REQUIRE(repository.empty());  // partition 0
+  REQUIRE(repository.empty());
   REQUIRE(repository.empty(1));
   REQUIRE(repository.empty(2));
   REQUIRE(repository.all_empty());
 
-  // Test get batch ids from each partition
-  retrieved_batch_ids0 = repository.get_batch_ids();  // partition 0
+  retrieved_batch_ids0 = repository.get_batch_ids();
   REQUIRE(retrieved_batch_ids0.empty());
   retrieved_batch_ids1 = repository.get_batch_ids(1);
   REQUIRE(retrieved_batch_ids1.empty());
@@ -1048,47 +845,41 @@ TEST_CASE("shared_data_repository pop Multiple Partitions", "[data_repository]")
   REQUIRE(retrieved_batch_ids2.empty());
 }
 
-// Test using nullopt for target state
-TEST_CASE("shared_data_repository pop Multiple Partitions with Nullopt", "[data_repository]")
+TEST_CASE("shared_data_repository pop by id", "[data_repository]")
 {
   shared_data_repository repository;
 
-  // Add batches to multiple partitions
   std::vector<uint64_t> batch_ids0 = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
   auto batches                     = create_test_batches(batch_ids0);
   for (auto& batch : batches) {
-    repository.add_data_batch(batch);  // Add to partition 0
+    repository.add_data_batch(batch);
   }
   REQUIRE(repository.size(0) == batch_ids0.size());
 
-  // pop each batch by id from each partition
   for (auto batch_id : batch_ids0) {
-    auto batch = repository.pop_data_batch_by_id(batch_id, std::nullopt);
+    auto batch = repository.pop_data_batch_by_id(batch_id);
     REQUIRE(batch != nullptr);
     REQUIRE(batch->get_batch_id() == batch_id);
   }
 }
 
-// Test case when trying to pop a batch by id that does not exist
-TEST_CASE("shared_data_repository pop Multiple Partitions with Non-existent Batch ID",
-          "[data_repository]")
+TEST_CASE("shared_data_repository pop Non-existent Batch ID", "[data_repository]")
 {
   shared_data_repository repository;
-  // add some batches
+
   auto batches = create_test_batches({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
   for (auto& batch : batches) {
     repository.add_data_batch(batch);
   }
-  auto batch = repository.pop_data_batch_by_id(100, batch_state::task_created);
+  auto batch = repository.pop_data_batch_by_id(100);
   REQUIRE(batch == nullptr);
 }
 
-// Test case using get_data_batch_by_id
 TEST_CASE("shared_data_repository using get_data_batch_by_id Multiple Partitions",
           "[data_repository]")
 {
   shared_data_repository repository;
-  // add some batches
+
   auto batches                 = create_test_batches({0, 1, 2, 3, 4, 5, 6, 7, 8, 9});
   constexpr int num_partitions = 3;
   for (auto& batch : batches) {
@@ -1096,45 +887,41 @@ TEST_CASE("shared_data_repository using get_data_batch_by_id Multiple Partitions
     repository.add_data_batch(batch, partition_idx);
   }
 
-  // lets iterate through all batches and get them by id and check if they are the same
   for (auto& batch : batches) {
     auto batch_from_repo = repository.get_data_batch_by_id(
-      batch->get_batch_id(), batch_state::task_created, batch->get_batch_id() % num_partitions);
+      batch->get_batch_id(), batch->get_batch_id() % num_partitions);
     REQUIRE(batch_from_repo != nullptr);
     REQUIRE(batch_from_repo->get_batch_id() == batch->get_batch_id());
     REQUIRE(batch_from_repo == batch);
 
     // get the same batch again
     auto batch_from_repo2 = repository.get_data_batch_by_id(
-      batch->get_batch_id(), batch_state::task_created, batch->get_batch_id() % num_partitions);
+      batch->get_batch_id(), batch->get_batch_id() % num_partitions);
     REQUIRE(batch_from_repo2 != nullptr);
     REQUIRE(batch_from_repo2->get_batch_id() == batch->get_batch_id());
     REQUIRE(batch_from_repo2 == batch);
     REQUIRE(batch_from_repo2 == batch_from_repo);
 
-    // now lets pop the batch and check if it is the same
+    // now pop the batch
     auto batch_from_repo3 = repository.pop_data_batch_by_id(
-      batch->get_batch_id(), batch_state::task_created, batch->get_batch_id() % num_partitions);
+      batch->get_batch_id(), batch->get_batch_id() % num_partitions);
     REQUIRE(batch_from_repo3 != nullptr);
     REQUIRE(batch_from_repo3->get_batch_id() == batch->get_batch_id());
     REQUIRE(batch_from_repo3 == batch);
-    REQUIRE(batch_from_repo3 == batch_from_repo);
-    REQUIRE(batch_from_repo3 == batch_from_repo2);
 
-    // now lets get the batch again and it should be nullptr
+    // now get again — should be nullptr
     auto batch_from_repo4 = repository.get_data_batch_by_id(
-      batch->get_batch_id(), batch_state::task_created, batch->get_batch_id() % num_partitions);
+      batch->get_batch_id(), batch->get_batch_id() % num_partitions);
     REQUIRE(batch_from_repo4 == nullptr);
   }
   REQUIRE(repository.total_size() == 0);
 }
 
-// test unique_data_repository throws an error when trying to get a batch by id
 TEST_CASE("unique_data_repository throws an error when trying to get a batch by id",
           "[data_repository]")
 {
   unique_data_repository repository;
-  REQUIRE_THROWS_WITH(repository.get_data_batch_by_id(0, batch_state::task_created, 0),
+  REQUIRE_THROWS_WITH(repository.get_data_batch_by_id(0, 0),
                       "get_data_batch_by_id is not supported for unique_ptr repositories. Use "
                       "pop_data_batch to move ownership instead.");
 }

--- a/test/data/test_data_repository_manager.cpp
+++ b/test/data/test_data_repository_manager.cpp
@@ -132,7 +132,7 @@ TEST_CASE("shared_data_repository_manager Add Data Batch Single Operator",
 
   // Repository should have the batch
   auto& repo        = manager.get_repository(operator_id, "default");
-  auto pulled_batch = repo->pop_idle_data_batch();
+  auto pulled_batch = repo->pop_next_data_batch();
   REQUIRE(pulled_batch != nullptr);
   REQUIRE(pulled_batch->get_batch_id() == batch_id);
 }
@@ -163,7 +163,7 @@ TEST_CASE("shared_data_repository_manager Add Data Batch Multiple Operators",
   // All repositories should have the batch (same shared_ptr)
   for (size_t id : operator_ids) {
     auto& repo  = manager.get_repository(id, "default");
-    auto pulled = repo->pop_idle_data_batch();
+    auto pulled = repo->pop_next_data_batch();
     REQUIRE(pulled != nullptr);
     REQUIRE(pulled->get_batch_id() == batch_id);
   }
@@ -244,7 +244,7 @@ TEST_CASE("shared_data_repository_manager Thread-Safe Add Batch", "[data_reposit
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_idle_data_batch();
+    auto batch = repo->pop_next_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -299,7 +299,7 @@ TEST_CASE("unique_data_repository_manager Add Data Batch Single Operator",
 
   // Repository should have the batch
   auto& repo        = manager.get_repository(operator_id, "default");
-  auto pulled_batch = repo->pop_idle_data_batch();
+  auto pulled_batch = repo->pop_next_data_batch();
   REQUIRE(pulled_batch != nullptr);
   REQUIRE(pulled_batch->get_batch_id() == batch_id);
 }
@@ -349,7 +349,7 @@ TEST_CASE("unique_data_repository_manager Add Multiple Batches", "[data_reposito
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_idle_data_batch();
+    auto batch = repo->pop_next_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -408,7 +408,7 @@ TEST_CASE("shared_data_repository_manager Full Workflow", "[data_repository_mana
     auto& repo = manager.get_repository(0, "default");
     int count  = 0;
     while (true) {
-      auto batch = repo->pop_idle_data_batch();
+      auto batch = repo->pop_next_data_batch();
       if (!batch) break;
       ++count;
     }
@@ -420,7 +420,7 @@ TEST_CASE("shared_data_repository_manager Full Workflow", "[data_repository_mana
     auto& repo = manager.get_repository(1, "default");
     int count  = 0;
     while (true) {
-      auto batch = repo->pop_idle_data_batch();
+      auto batch = repo->pop_next_data_batch();
       if (!batch) break;
       ++count;
     }
@@ -432,7 +432,7 @@ TEST_CASE("shared_data_repository_manager Full Workflow", "[data_repository_mana
     auto& repo = manager.get_repository(2, "default");
     int count  = 0;
     while (true) {
-      auto batch = repo->pop_idle_data_batch();
+      auto batch = repo->pop_next_data_batch();
       if (!batch) break;
       ++count;
     }
@@ -483,7 +483,7 @@ TEST_CASE("shared_data_repository_manager Large Number of Batches", "[data_repos
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_idle_data_batch();
+    auto batch = repo->pop_next_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -561,7 +561,7 @@ TEST_CASE("shared_data_repository_manager Thread-Safe Mixed Operations",
         // Occasionally pull and store a batch (to test concurrent pull operations)
         if (j % 10 == 0) {
           auto& repo  = manager.get_repository(operator_id, "default");
-          auto pulled = repo->pop_idle_data_batch();
+          auto pulled = repo->pop_next_data_batch();
           if (pulled) {
             std::lock_guard<std::mutex> lock(pull_mutex);
             all_batches.push_back(std::move(pulled));
@@ -634,7 +634,7 @@ TEST_CASE("shared_data_repository_manager Concurrent Add and Pull", "[data_repos
 
       // Keep pulling while adders are working
       while (keep_adding.load()) {
-        auto batch = repo->pop_idle_data_batch();
+        auto batch = repo->pop_next_data_batch();
         if (batch) {
           ++batches_pulled;
         } else {
@@ -645,7 +645,7 @@ TEST_CASE("shared_data_repository_manager Concurrent Add and Pull", "[data_repos
 
       // Final cleanup - pull remaining batches
       while (true) {
-        auto batch = repo->pop_idle_data_batch();
+        auto batch = repo->pop_next_data_batch();
         if (!batch) break;
         ++batches_pulled;
       }
@@ -674,7 +674,7 @@ TEST_CASE("shared_data_repository_manager Concurrent Add and Pull", "[data_repos
   // All repositories should be empty
   for (int i = 0; i < num_operators; ++i) {
     auto& repo = manager.get_repository(i, "default");
-    auto batch = repo->pop_idle_data_batch();
+    auto batch = repo->pop_next_data_batch();
     REQUIRE(batch == nullptr);
   }
 }
@@ -710,7 +710,7 @@ TEST_CASE("shared_data_repository_manager High Contention Add Pull", "[data_repo
         ++total_added;
 
         // Immediately try to pull a batch (might be ours or someone else's)
-        auto pulled = repo->pop_idle_data_batch();
+        auto pulled = repo->pop_next_data_batch();
         if (pulled) { ++total_pulled; }
       }
     });
@@ -727,7 +727,7 @@ TEST_CASE("shared_data_repository_manager High Contention Add Pull", "[data_repo
   // Clean up remaining batches
   auto& repo = manager.get_repository(operator_id, "default");
   while (true) {
-    auto batch = repo->pop_idle_data_batch();
+    auto batch = repo->pop_next_data_batch();
     if (!batch) break;
     ++total_pulled;
   }
@@ -773,7 +773,7 @@ TEST_CASE("shared_data_repository_manager Concurrent Add Multiple Operators Per 
 
       // Pull all batches from this operator
       while (true) {
-        auto batch = repo->pop_idle_data_batch();
+        auto batch = repo->pop_next_data_batch();
         if (!batch) break;
         ++batches_pulled;
       }
@@ -792,7 +792,7 @@ TEST_CASE("shared_data_repository_manager Concurrent Add Multiple Operators Per 
   // All repositories should be empty
   for (int i = 0; i < num_operators; ++i) {
     auto& repo = manager.get_repository(i, "default");
-    auto batch = repo->pop_idle_data_batch();
+    auto batch = repo->pop_next_data_batch();
     REQUIRE(batch == nullptr);
   }
 }
@@ -876,7 +876,7 @@ TEST_CASE("unique_data_repository_manager Thread-Safe Add Batch", "[data_reposit
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_idle_data_batch();
+    auto batch = repo->pop_next_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -926,7 +926,7 @@ TEST_CASE("unique_data_repository_manager Concurrent Add and Pull", "[data_repos
       auto& repo = manager.get_repository(operator_id, "default");
 
       while (keep_adding.load()) {
-        auto batch = repo->pop_idle_data_batch();
+        auto batch = repo->pop_next_data_batch();
         if (batch) {
           ++batches_pulled;
         } else {
@@ -936,7 +936,7 @@ TEST_CASE("unique_data_repository_manager Concurrent Add and Pull", "[data_repos
 
       // Final cleanup
       while (true) {
-        auto batch = repo->pop_idle_data_batch();
+        auto batch = repo->pop_next_data_batch();
         if (!batch) break;
         ++batches_pulled;
       }
@@ -994,7 +994,7 @@ TEST_CASE("unique_data_repository_manager High Contention", "[data_repository_ma
         ++total_added;
 
         // Immediately try to pull a batch
-        auto pulled = repo->pop_idle_data_batch();
+        auto pulled = repo->pop_next_data_batch();
         if (pulled) { ++total_pulled; }
       }
     });
@@ -1011,7 +1011,7 @@ TEST_CASE("unique_data_repository_manager High Contention", "[data_repository_ma
   // Clean up remaining batches
   auto& repo = manager.get_repository(operator_id, "default");
   while (true) {
-    auto batch = repo->pop_idle_data_batch();
+    auto batch = repo->pop_next_data_batch();
     if (!batch) break;
     ++total_pulled;
   }
@@ -1080,7 +1080,7 @@ TEST_CASE("shared_data_repository_manager Batches With Different Sizes",
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_idle_data_batch();
+    auto batch = repo->pop_next_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -1112,7 +1112,7 @@ TEST_CASE("shared_data_repository_manager Batches With Different Tiers",
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_idle_data_batch();
+    auto batch = repo->pop_next_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -1139,11 +1139,11 @@ TEST_CASE("shared_data_repository_manager Rapid Add Pull Cycles", "[data_reposit
     manager.add_data_batch(batch, operator_ports);
 
     // Pull the batch
-    auto pulled = repo->pop_idle_data_batch();
+    auto pulled = repo->pop_next_data_batch();
     REQUIRE(pulled != nullptr);
   }
 
   // Repository should be empty
-  auto empty = repo->pop_idle_data_batch();
+  auto empty = repo->pop_next_data_batch();
   REQUIRE(empty == nullptr);
 }

--- a/test/data/test_data_repository_manager.cpp
+++ b/test/data/test_data_repository_manager.cpp
@@ -132,7 +132,7 @@ TEST_CASE("shared_data_repository_manager Add Data Batch Single Operator",
 
   // Repository should have the batch
   auto& repo        = manager.get_repository(operator_id, "default");
-  auto pulled_batch = repo->pop_data_batch();
+  auto pulled_batch = repo->pop_idle_data_batch();
   REQUIRE(pulled_batch != nullptr);
   REQUIRE(pulled_batch->get_batch_id() == batch_id);
 }
@@ -163,7 +163,7 @@ TEST_CASE("shared_data_repository_manager Add Data Batch Multiple Operators",
   // All repositories should have the batch (same shared_ptr)
   for (size_t id : operator_ids) {
     auto& repo  = manager.get_repository(id, "default");
-    auto pulled = repo->pop_data_batch();
+    auto pulled = repo->pop_idle_data_batch();
     REQUIRE(pulled != nullptr);
     REQUIRE(pulled->get_batch_id() == batch_id);
   }
@@ -244,7 +244,7 @@ TEST_CASE("shared_data_repository_manager Thread-Safe Add Batch", "[data_reposit
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_data_batch();
+    auto batch = repo->pop_idle_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -299,7 +299,7 @@ TEST_CASE("unique_data_repository_manager Add Data Batch Single Operator",
 
   // Repository should have the batch
   auto& repo        = manager.get_repository(operator_id, "default");
-  auto pulled_batch = repo->pop_data_batch();
+  auto pulled_batch = repo->pop_idle_data_batch();
   REQUIRE(pulled_batch != nullptr);
   REQUIRE(pulled_batch->get_batch_id() == batch_id);
 }
@@ -349,7 +349,7 @@ TEST_CASE("unique_data_repository_manager Add Multiple Batches", "[data_reposito
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_data_batch();
+    auto batch = repo->pop_idle_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -408,7 +408,7 @@ TEST_CASE("shared_data_repository_manager Full Workflow", "[data_repository_mana
     auto& repo = manager.get_repository(0, "default");
     int count  = 0;
     while (true) {
-      auto batch = repo->pop_data_batch();
+      auto batch = repo->pop_idle_data_batch();
       if (!batch) break;
       ++count;
     }
@@ -420,7 +420,7 @@ TEST_CASE("shared_data_repository_manager Full Workflow", "[data_repository_mana
     auto& repo = manager.get_repository(1, "default");
     int count  = 0;
     while (true) {
-      auto batch = repo->pop_data_batch();
+      auto batch = repo->pop_idle_data_batch();
       if (!batch) break;
       ++count;
     }
@@ -432,7 +432,7 @@ TEST_CASE("shared_data_repository_manager Full Workflow", "[data_repository_mana
     auto& repo = manager.get_repository(2, "default");
     int count  = 0;
     while (true) {
-      auto batch = repo->pop_data_batch();
+      auto batch = repo->pop_idle_data_batch();
       if (!batch) break;
       ++count;
     }
@@ -483,7 +483,7 @@ TEST_CASE("shared_data_repository_manager Large Number of Batches", "[data_repos
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_data_batch();
+    auto batch = repo->pop_idle_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -561,7 +561,7 @@ TEST_CASE("shared_data_repository_manager Thread-Safe Mixed Operations",
         // Occasionally pull and store a batch (to test concurrent pull operations)
         if (j % 10 == 0) {
           auto& repo  = manager.get_repository(operator_id, "default");
-          auto pulled = repo->pop_data_batch();
+          auto pulled = repo->pop_idle_data_batch();
           if (pulled) {
             std::lock_guard<std::mutex> lock(pull_mutex);
             all_batches.push_back(std::move(pulled));
@@ -634,7 +634,7 @@ TEST_CASE("shared_data_repository_manager Concurrent Add and Pull", "[data_repos
 
       // Keep pulling while adders are working
       while (keep_adding.load()) {
-        auto batch = repo->pop_data_batch();
+        auto batch = repo->pop_idle_data_batch();
         if (batch) {
           ++batches_pulled;
         } else {
@@ -645,7 +645,7 @@ TEST_CASE("shared_data_repository_manager Concurrent Add and Pull", "[data_repos
 
       // Final cleanup - pull remaining batches
       while (true) {
-        auto batch = repo->pop_data_batch();
+        auto batch = repo->pop_idle_data_batch();
         if (!batch) break;
         ++batches_pulled;
       }
@@ -674,7 +674,7 @@ TEST_CASE("shared_data_repository_manager Concurrent Add and Pull", "[data_repos
   // All repositories should be empty
   for (int i = 0; i < num_operators; ++i) {
     auto& repo = manager.get_repository(i, "default");
-    auto batch = repo->pop_data_batch();
+    auto batch = repo->pop_idle_data_batch();
     REQUIRE(batch == nullptr);
   }
 }
@@ -710,7 +710,7 @@ TEST_CASE("shared_data_repository_manager High Contention Add Pull", "[data_repo
         ++total_added;
 
         // Immediately try to pull a batch (might be ours or someone else's)
-        auto pulled = repo->pop_data_batch();
+        auto pulled = repo->pop_idle_data_batch();
         if (pulled) { ++total_pulled; }
       }
     });
@@ -727,7 +727,7 @@ TEST_CASE("shared_data_repository_manager High Contention Add Pull", "[data_repo
   // Clean up remaining batches
   auto& repo = manager.get_repository(operator_id, "default");
   while (true) {
-    auto batch = repo->pop_data_batch();
+    auto batch = repo->pop_idle_data_batch();
     if (!batch) break;
     ++total_pulled;
   }
@@ -773,7 +773,7 @@ TEST_CASE("shared_data_repository_manager Concurrent Add Multiple Operators Per 
 
       // Pull all batches from this operator
       while (true) {
-        auto batch = repo->pop_data_batch();
+        auto batch = repo->pop_idle_data_batch();
         if (!batch) break;
         ++batches_pulled;
       }
@@ -792,7 +792,7 @@ TEST_CASE("shared_data_repository_manager Concurrent Add Multiple Operators Per 
   // All repositories should be empty
   for (int i = 0; i < num_operators; ++i) {
     auto& repo = manager.get_repository(i, "default");
-    auto batch = repo->pop_data_batch();
+    auto batch = repo->pop_idle_data_batch();
     REQUIRE(batch == nullptr);
   }
 }
@@ -876,7 +876,7 @@ TEST_CASE("unique_data_repository_manager Thread-Safe Add Batch", "[data_reposit
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_data_batch();
+    auto batch = repo->pop_idle_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -926,7 +926,7 @@ TEST_CASE("unique_data_repository_manager Concurrent Add and Pull", "[data_repos
       auto& repo = manager.get_repository(operator_id, "default");
 
       while (keep_adding.load()) {
-        auto batch = repo->pop_data_batch();
+        auto batch = repo->pop_idle_data_batch();
         if (batch) {
           ++batches_pulled;
         } else {
@@ -936,7 +936,7 @@ TEST_CASE("unique_data_repository_manager Concurrent Add and Pull", "[data_repos
 
       // Final cleanup
       while (true) {
-        auto batch = repo->pop_data_batch();
+        auto batch = repo->pop_idle_data_batch();
         if (!batch) break;
         ++batches_pulled;
       }
@@ -994,7 +994,7 @@ TEST_CASE("unique_data_repository_manager High Contention", "[data_repository_ma
         ++total_added;
 
         // Immediately try to pull a batch
-        auto pulled = repo->pop_data_batch();
+        auto pulled = repo->pop_idle_data_batch();
         if (pulled) { ++total_pulled; }
       }
     });
@@ -1011,7 +1011,7 @@ TEST_CASE("unique_data_repository_manager High Contention", "[data_repository_ma
   // Clean up remaining batches
   auto& repo = manager.get_repository(operator_id, "default");
   while (true) {
-    auto batch = repo->pop_data_batch();
+    auto batch = repo->pop_idle_data_batch();
     if (!batch) break;
     ++total_pulled;
   }
@@ -1080,7 +1080,7 @@ TEST_CASE("shared_data_repository_manager Batches With Different Sizes",
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_data_batch();
+    auto batch = repo->pop_idle_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -1112,7 +1112,7 @@ TEST_CASE("shared_data_repository_manager Batches With Different Tiers",
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_data_batch();
+    auto batch = repo->pop_idle_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -1139,11 +1139,11 @@ TEST_CASE("shared_data_repository_manager Rapid Add Pull Cycles", "[data_reposit
     manager.add_data_batch(batch, operator_ports);
 
     // Pull the batch
-    auto pulled = repo->pop_data_batch();
+    auto pulled = repo->pop_idle_data_batch();
     REQUIRE(pulled != nullptr);
   }
 
   // Repository should be empty
-  auto empty = repo->pop_data_batch();
+  auto empty = repo->pop_idle_data_batch();
   REQUIRE(empty == nullptr);
 }

--- a/test/data/test_data_repository_manager.cpp
+++ b/test/data/test_data_repository_manager.cpp
@@ -132,7 +132,7 @@ TEST_CASE("shared_data_repository_manager Add Data Batch Single Operator",
 
   // Repository should have the batch
   auto& repo        = manager.get_repository(operator_id, "default");
-  auto pulled_batch = repo->pop_data_batch(batch_state::task_created);
+  auto pulled_batch = repo->pop_data_batch();
   REQUIRE(pulled_batch != nullptr);
   REQUIRE(pulled_batch->get_batch_id() == batch_id);
 }
@@ -163,7 +163,7 @@ TEST_CASE("shared_data_repository_manager Add Data Batch Multiple Operators",
   // All repositories should have the batch (same shared_ptr)
   for (size_t id : operator_ids) {
     auto& repo  = manager.get_repository(id, "default");
-    auto pulled = repo->pop_data_batch(batch_state::task_created);
+    auto pulled = repo->pop_data_batch();
     REQUIRE(pulled != nullptr);
     REQUIRE(pulled->get_batch_id() == batch_id);
   }
@@ -244,7 +244,7 @@ TEST_CASE("shared_data_repository_manager Thread-Safe Add Batch", "[data_reposit
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_data_batch(batch_state::task_created);
+    auto batch = repo->pop_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -299,7 +299,7 @@ TEST_CASE("unique_data_repository_manager Add Data Batch Single Operator",
 
   // Repository should have the batch
   auto& repo        = manager.get_repository(operator_id, "default");
-  auto pulled_batch = repo->pop_data_batch(batch_state::task_created);
+  auto pulled_batch = repo->pop_data_batch();
   REQUIRE(pulled_batch != nullptr);
   REQUIRE(pulled_batch->get_batch_id() == batch_id);
 }
@@ -349,7 +349,7 @@ TEST_CASE("unique_data_repository_manager Add Multiple Batches", "[data_reposito
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_data_batch(batch_state::task_created);
+    auto batch = repo->pop_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -408,7 +408,7 @@ TEST_CASE("shared_data_repository_manager Full Workflow", "[data_repository_mana
     auto& repo = manager.get_repository(0, "default");
     int count  = 0;
     while (true) {
-      auto batch = repo->pop_data_batch(batch_state::task_created);
+      auto batch = repo->pop_data_batch();
       if (!batch) break;
       ++count;
     }
@@ -420,7 +420,7 @@ TEST_CASE("shared_data_repository_manager Full Workflow", "[data_repository_mana
     auto& repo = manager.get_repository(1, "default");
     int count  = 0;
     while (true) {
-      auto batch = repo->pop_data_batch(batch_state::task_created);
+      auto batch = repo->pop_data_batch();
       if (!batch) break;
       ++count;
     }
@@ -432,7 +432,7 @@ TEST_CASE("shared_data_repository_manager Full Workflow", "[data_repository_mana
     auto& repo = manager.get_repository(2, "default");
     int count  = 0;
     while (true) {
-      auto batch = repo->pop_data_batch(batch_state::task_created);
+      auto batch = repo->pop_data_batch();
       if (!batch) break;
       ++count;
     }
@@ -483,7 +483,7 @@ TEST_CASE("shared_data_repository_manager Large Number of Batches", "[data_repos
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_data_batch(batch_state::task_created);
+    auto batch = repo->pop_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -561,7 +561,7 @@ TEST_CASE("shared_data_repository_manager Thread-Safe Mixed Operations",
         // Occasionally pull and store a batch (to test concurrent pull operations)
         if (j % 10 == 0) {
           auto& repo  = manager.get_repository(operator_id, "default");
-          auto pulled = repo->pop_data_batch(batch_state::task_created);
+          auto pulled = repo->pop_data_batch();
           if (pulled) {
             std::lock_guard<std::mutex> lock(pull_mutex);
             all_batches.push_back(std::move(pulled));
@@ -634,7 +634,7 @@ TEST_CASE("shared_data_repository_manager Concurrent Add and Pull", "[data_repos
 
       // Keep pulling while adders are working
       while (keep_adding.load()) {
-        auto batch = repo->pop_data_batch(batch_state::task_created);
+        auto batch = repo->pop_data_batch();
         if (batch) {
           ++batches_pulled;
         } else {
@@ -645,7 +645,7 @@ TEST_CASE("shared_data_repository_manager Concurrent Add and Pull", "[data_repos
 
       // Final cleanup - pull remaining batches
       while (true) {
-        auto batch = repo->pop_data_batch(batch_state::task_created);
+        auto batch = repo->pop_data_batch();
         if (!batch) break;
         ++batches_pulled;
       }
@@ -674,7 +674,7 @@ TEST_CASE("shared_data_repository_manager Concurrent Add and Pull", "[data_repos
   // All repositories should be empty
   for (int i = 0; i < num_operators; ++i) {
     auto& repo = manager.get_repository(i, "default");
-    auto batch = repo->pop_data_batch(batch_state::task_created);
+    auto batch = repo->pop_data_batch();
     REQUIRE(batch == nullptr);
   }
 }
@@ -710,7 +710,7 @@ TEST_CASE("shared_data_repository_manager High Contention Add Pull", "[data_repo
         ++total_added;
 
         // Immediately try to pull a batch (might be ours or someone else's)
-        auto pulled = repo->pop_data_batch(batch_state::task_created);
+        auto pulled = repo->pop_data_batch();
         if (pulled) { ++total_pulled; }
       }
     });
@@ -727,7 +727,7 @@ TEST_CASE("shared_data_repository_manager High Contention Add Pull", "[data_repo
   // Clean up remaining batches
   auto& repo = manager.get_repository(operator_id, "default");
   while (true) {
-    auto batch = repo->pop_data_batch(batch_state::task_created);
+    auto batch = repo->pop_data_batch();
     if (!batch) break;
     ++total_pulled;
   }
@@ -773,7 +773,7 @@ TEST_CASE("shared_data_repository_manager Concurrent Add Multiple Operators Per 
 
       // Pull all batches from this operator
       while (true) {
-        auto batch = repo->pop_data_batch(batch_state::task_created);
+        auto batch = repo->pop_data_batch();
         if (!batch) break;
         ++batches_pulled;
       }
@@ -792,7 +792,7 @@ TEST_CASE("shared_data_repository_manager Concurrent Add Multiple Operators Per 
   // All repositories should be empty
   for (int i = 0; i < num_operators; ++i) {
     auto& repo = manager.get_repository(i, "default");
-    auto batch = repo->pop_data_batch(batch_state::task_created);
+    auto batch = repo->pop_data_batch();
     REQUIRE(batch == nullptr);
   }
 }
@@ -876,7 +876,7 @@ TEST_CASE("unique_data_repository_manager Thread-Safe Add Batch", "[data_reposit
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_data_batch(batch_state::task_created);
+    auto batch = repo->pop_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -926,7 +926,7 @@ TEST_CASE("unique_data_repository_manager Concurrent Add and Pull", "[data_repos
       auto& repo = manager.get_repository(operator_id, "default");
 
       while (keep_adding.load()) {
-        auto batch = repo->pop_data_batch(batch_state::task_created);
+        auto batch = repo->pop_data_batch();
         if (batch) {
           ++batches_pulled;
         } else {
@@ -936,7 +936,7 @@ TEST_CASE("unique_data_repository_manager Concurrent Add and Pull", "[data_repos
 
       // Final cleanup
       while (true) {
-        auto batch = repo->pop_data_batch(batch_state::task_created);
+        auto batch = repo->pop_data_batch();
         if (!batch) break;
         ++batches_pulled;
       }
@@ -994,7 +994,7 @@ TEST_CASE("unique_data_repository_manager High Contention", "[data_repository_ma
         ++total_added;
 
         // Immediately try to pull a batch
-        auto pulled = repo->pop_data_batch(batch_state::task_created);
+        auto pulled = repo->pop_data_batch();
         if (pulled) { ++total_pulled; }
       }
     });
@@ -1011,7 +1011,7 @@ TEST_CASE("unique_data_repository_manager High Contention", "[data_repository_ma
   // Clean up remaining batches
   auto& repo = manager.get_repository(operator_id, "default");
   while (true) {
-    auto batch = repo->pop_data_batch(batch_state::task_created);
+    auto batch = repo->pop_data_batch();
     if (!batch) break;
     ++total_pulled;
   }
@@ -1080,7 +1080,7 @@ TEST_CASE("shared_data_repository_manager Batches With Different Sizes",
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_data_batch(batch_state::task_created);
+    auto batch = repo->pop_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -1112,7 +1112,7 @@ TEST_CASE("shared_data_repository_manager Batches With Different Tiers",
   auto& repo = manager.get_repository(operator_id, "default");
   int count  = 0;
   while (true) {
-    auto batch = repo->pop_data_batch(batch_state::task_created);
+    auto batch = repo->pop_data_batch();
     if (!batch) break;
     ++count;
   }
@@ -1139,11 +1139,11 @@ TEST_CASE("shared_data_repository_manager Rapid Add Pull Cycles", "[data_reposit
     manager.add_data_batch(batch, operator_ports);
 
     // Pull the batch
-    auto pulled = repo->pop_data_batch(batch_state::task_created);
+    auto pulled = repo->pop_data_batch();
     REQUIRE(pulled != nullptr);
   }
 
   // Repository should be empty
-  auto empty = repo->pop_data_batch(batch_state::task_created);
+  auto empty = repo->pop_data_batch();
   REQUIRE(empty == nullptr);
 }


### PR DESCRIPTION
## Summary

Replace the 4-state finite state machine (`batch_state`: idle, task_created, processing, in_transit) with a 3-class design where `data_batch` is the "idle" state and all data access requires acquiring a lock through RAII accessor types.

**Core invariant:** it is impossible to read or mutate batch data without holding the appropriate lock, and move semantics make stale references a compile error.

## Design

```
data_batch (idle — owns shared_mutex + data representation)
├── Lock-free public API: get_batch_id(), subscribe(), unsubscribe(), get_state()
├── Private data accessors: get_data(), get_current_tier(), set_data()
│   └── Only accessible by friend accessor classes
│
├── read_only_data_batch (RAII shared lock, holds shared_ptr<data_batch>)
│   └── Read accessors + clone() + clone_to()
│
└── mutable_data_batch (RAII exclusive lock, holds shared_ptr<data_batch>)
    └── Read accessors + clone() + clone_to() + set_data() + convert_to()
```

### Observable state

`data_batch` exposes an atomic `batch_state` enum (`idle`, `read_only`, `mutable_locked`) via `get_state()`. Updated during every state transition. Enables the repository to filter batches by lock state.

### State transitions

**Non-static methods** (use `shared_from_this` — caller's `shared_ptr` is NOT consumed):
```cpp
auto accessor = batch->to_read_only();   // batch still valid, state = read_only
auto accessor = batch->to_mutable();     // batch still valid, state = mutable_locked
```

**Static methods** (consume accessors via move):
```cpp
auto batch = data_batch::to_idle(std::move(ro));         // ro is now consumed
```

**Locked-to-locked transitions** (static, consume via move):
```cpp
auto mut = data_batch::readonly_to_mutable(std::move(ro));   // upgrade lock
auto ro = data_batch::mutable_to_readonly(std::move(mut));   // downgrade lock
```

Non-blocking variants (`try_to_read_only`, `try_to_mutable`) return `std::optional`.

### State-filtered repository

`pop_data_batch()` replaced with state-specific FIFO pops that filter by `get_state()`:
```cpp
auto idle_batch = repo.pop_idle_data_batch();       // first batch where state == idle
auto ro_batch   = repo.pop_read_only_data_batch();  // first batch where state == read_only
auto mut_batch  = repo.pop_mutable_data_batch();    // first batch where state == mutable_locked
```

`pop_data_batch_by_id()` and `get_data_batch_by_id()` unchanged — caller checks state after retrieval.

## Breaking changes

- `data_batch` now inherits `std::enable_shared_from_this<data_batch>`
- `data_batch` has observable `batch_state` enum and `get_state()` method
- `batch_state` enum replaced (old: idle/task_created/processing/in_transit → new: idle/read_only/mutable_locked)
- **`read_only_data_batch` and `mutable_data_batch` are no longer class templates** — they always hold `std::shared_ptr<data_batch>` (the `unique_ptr` variant was unused)
- Static entry-point methods removed (`to_read_only(PtrType&&)`, `to_mutable(PtrType&&)`, `try_to_read_only(PtrType&)`, `try_to_mutable(PtrType&)`) — use non-static `shared_from_this` variants instead
- `convert_to` moved from `data_batch` (private) to `mutable_data_batch` (public)
- `mutable_data_batch` now has `clone()` and `clone_to()` (matching `read_only_data_batch`)
- `pop_data_batch()` removed — use `pop_idle_data_batch()`, `pop_read_only_data_batch()`, or `pop_mutable_data_batch()`
- `idata_batch_probe`, `data_batch_processing_handle`, `lock_for_processing_result/status` removed
- `pop_data_batch_by_id()` and `get_data_batch_by_id()` no longer take `target_state`
- `data_repository_manager::add_data_batch_impl` uses `if constexpr` instead of SFINAE

## Files changed

| Area | Files | What |
|------|-------|------|
| Core type system | `data_batch.hpp`, `data_batch.cpp` | 3-class rewrite, observable state, `enable_shared_from_this`, locked↔locked transitions, de-templatized accessors |
| Repository layer | `data_repository.hpp` | State-filtered `pop_idle/read_only/mutable_data_batch()` |
| Repository impl | `data_repository.cpp`, `data_repository_manager.cpp` | Updated type references |
| Converter | `representation_converter.cpp` | Added new batch type support |
| Tests | `test_data_batch.cpp`, `test_data_repository.cpp`, `test_data_repository_manager.cpp` | Full rewrite + new state/transition/filtered-pop tests |

## Test plan

- [x] `pixi run build` compiles cleanly (all 68 targets)
- [x] `pixi run test` passes (43 test cases, 1116 assertions for `[data_batch]`)
- [x] Non-blocking `try_to_read_only` / `try_to_mutable` return `nullopt` when lock is held
- [x] `get_state()` returns correct value after every transition type
- [x] State-filtered pops skip batches in wrong state
- [x] Non-static transitions preserve caller's `shared_ptr`
- [x] `readonly_to_mutable` / `mutable_to_readonly` upgrade/downgrade correctly
- [x] `clone()` / `clone_to()` work on both `read_only_data_batch` and `mutable_data_batch`
- [x] `convert_to` on `mutable_data_batch` works with GPU sync
- [x] Accessor classes compile without template parameter (de-templatized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)