### PR TITLE
Bump `benchmark-action/github-action-benchmark` to `1.22.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           path: .cache/benchmark_result.json
 
       - name: Compare benchmark results
-        uses: benchmark-action/github-action-benchmark@4bdcce38c94cec68da58d012ac24b7b1155efe8b # v1.20.7
+        uses: benchmark-action/github-action-benchmark@a60cea5bc7b49e15c1f58f411161f99e0df48372 # v1.22.0
         with:
           tool: googlecpp
           output-file-path: ${{ github.workspace }}/benchmark_result.json


### PR DESCRIPTION
Updates to node 24 (20 is being deprecated).