### PR TITLE
Drop hard NVML link from cucascade

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,8 +122,8 @@ set(CUCASCADE_PUBLIC_INCLUDE_DIRS
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
-set(CUCASCADE_PUBLIC_LINK_LIBS rmm::rmm cudf::cudf CUDA::cudart CUDA::nvml
-                               Threads::Threads ${NUMA_LIB})
+set(CUCASCADE_PUBLIC_LINK_LIBS rmm::rmm cudf::cudf CUDA::cudart Threads::Threads
+                               ${NUMA_LIB})
 
 # Set include directories for the object library
 target_include_directories(cucascade_objects


### PR DESCRIPTION
## Summary
- remove `CUDA::nvml` from `CUCASCADE_PUBLIC_LINK_LIBS`
- keep NVML optional at runtime via the existing `dlopen("libnvidia-ml.so.1")` loader in `topology_discovery.cpp`
- avoid emitting a hard NVML `NEEDED` entry from `libcucascade.so`

## Verification
- `pixi run -e cuda-13-stable cmake -S . -B /tmp/cucascade-nvml-check-lib -G Ninja -DCMAKE_BUILD_TYPE=Release -DCUCASCADE_BUILD_TESTS=OFF -DCUCASCADE_BUILD_BENCHMARKS=OFF -DCMAKE_C_COMPILER_LAUNCHER:STRING= -DCMAKE_CXX_COMPILER_LAUNCHER:STRING= -DCMAKE_CUDA_COMPILER_LAUNCHER:STRING=`
- `pixi run -e cuda-13-stable cmake --build /tmp/cucascade-nvml-check-lib --target cucascade_shared -v`
- `readelf -d /tmp/cucascade-nvml-check-lib/libcucascade.so.0.1.0 | rg NEEDED`