### PR TITLE
Support static cudart linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,8 @@ elseif(CUCASCADE_CUDA_RUNTIME_LIBRARY STREQUAL "Shared")
 else()
   message(
     FATAL_ERROR
-    "Unsupported CUDA runtime library: ${CUCASCADE_CUDA_RUNTIME_LIBRARY}"
+    "Unsupported CUDA runtime library: '${CUCASCADE_CUDA_RUNTIME_LIBRARY}'."
+    " Accepted values are 'Static' or 'Shared' (set via -DCMAKE_CUDA_RUNTIME_LIBRARY=<value>)."
   )
 endif()
 
@@ -160,11 +161,8 @@ target_link_libraries(cucascade_objects PUBLIC ${CUCASCADE_PUBLIC_LINK_LIBS})
 target_compile_features(cucascade_objects PUBLIC cxx_std_20)
 target_compile_features(cucascade_objects PRIVATE cuda_std_20)
 
-set_target_properties(
-  cucascade_objects
-  PROPERTIES CXX_EXTENSIONS OFF
-             POSITION_INDEPENDENT_CODE ON
-             CUDA_RUNTIME_LIBRARY "${CUCASCADE_CUDA_RUNTIME_LIBRARY}")
+set_target_properties(cucascade_objects PROPERTIES CXX_EXTENSIONS OFF
+                                                   POSITION_INDEPENDENT_CODE ON)
 
 # =============================================================================
 # Static library

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,13 +79,12 @@ elseif(CUCASCADE_CUDA_RUNTIME_LIBRARY STREQUAL "Shared")
     )
   endif()
   set(CUCASCADE_CUDART_TARGET CUDA::cudart)
-elseif(CUCASCADE_CUDA_RUNTIME_LIBRARY STREQUAL "None")
-  set(CUCASCADE_CUDART_TARGET)
 else()
   message(
     FATAL_ERROR
     "Unsupported CUDA runtime library: '${CUCASCADE_CUDA_RUNTIME_LIBRARY}'."
-    " Accepted values are 'Static', 'Shared', or 'None' (set via -DCMAKE_CUDA_RUNTIME_LIBRARY=<value>)."
+    " cuCascade requires the CUDA runtime library because it uses CUDA runtime APIs."
+    " Accepted values are 'Static' or 'Shared' (set via -DCMAKE_CUDA_RUNTIME_LIBRARY=<value>)."
   )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,28 @@ if(NOT CMAKE_CUDA_ARCHITECTURES)
   set(CMAKE_CUDA_ARCHITECTURES 75 80 86 90)
 endif()
 
+set(CUCASCADE_CUDA_RUNTIME_LIBRARY "${CMAKE_CUDA_RUNTIME_LIBRARY}")
+if(NOT CUCASCADE_CUDA_RUNTIME_LIBRARY)
+  set(CUCASCADE_CUDA_RUNTIME_LIBRARY Shared)
+endif()
+
+if(CUCASCADE_CUDA_RUNTIME_LIBRARY STREQUAL "Static")
+  if(NOT TARGET CUDA::cudart_static)
+    message(
+      FATAL_ERROR
+      "CMAKE_CUDA_RUNTIME_LIBRARY=Static was requested, but CUDA::cudart_static is unavailable"
+    )
+  endif()
+  set(CUCASCADE_CUDART_TARGET CUDA::cudart_static)
+elseif(CUCASCADE_CUDA_RUNTIME_LIBRARY STREQUAL "Shared")
+  set(CUCASCADE_CUDART_TARGET CUDA::cudart)
+else()
+  message(
+    FATAL_ERROR
+    "Unsupported CUDA runtime library: ${CUCASCADE_CUDA_RUNTIME_LIBRARY}"
+  )
+endif()
+
 # =============================================================================
 # Compiler warnings
 # =============================================================================
@@ -122,8 +144,8 @@ set(CUCASCADE_PUBLIC_INCLUDE_DIRS
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
-set(CUCASCADE_PUBLIC_LINK_LIBS rmm::rmm cudf::cudf CUDA::cudart Threads::Threads
-                               ${NUMA_LIB})
+set(CUCASCADE_PUBLIC_LINK_LIBS rmm::rmm cudf::cudf ${CUCASCADE_CUDART_TARGET}
+                               Threads::Threads ${NUMA_LIB})
 
 # Set include directories for the object library
 target_include_directories(cucascade_objects
@@ -138,8 +160,11 @@ target_link_libraries(cucascade_objects PUBLIC ${CUCASCADE_PUBLIC_LINK_LIBS})
 target_compile_features(cucascade_objects PUBLIC cxx_std_20)
 target_compile_features(cucascade_objects PRIVATE cuda_std_20)
 
-set_target_properties(cucascade_objects PROPERTIES CXX_EXTENSIONS OFF
-                                                   POSITION_INDEPENDENT_CODE ON)
+set_target_properties(
+  cucascade_objects
+  PROPERTIES CXX_EXTENSIONS OFF
+             POSITION_INDEPENDENT_CODE ON
+             CUDA_RUNTIME_LIBRARY "${CUCASCADE_CUDA_RUNTIME_LIBRARY}")
 
 # =============================================================================
 # Static library
@@ -154,8 +179,10 @@ if(CUCASCADE_BUILD_STATIC_LIBS)
   target_compile_features(cucascade_static PUBLIC cxx_std_20)
 
   set_target_properties(
-    cucascade_static PROPERTIES OUTPUT_NAME cucascade EXPORT_NAME
-                                                      cucascade_static)
+    cucascade_static
+    PROPERTIES OUTPUT_NAME cucascade
+               EXPORT_NAME cucascade_static
+               CUDA_RUNTIME_LIBRARY "${CUCASCADE_CUDA_RUNTIME_LIBRARY}")
 endif()
 
 # =============================================================================
@@ -173,6 +200,7 @@ if(CUCASCADE_BUILD_SHARED_LIBS)
   set_target_properties(
     cucascade_shared
     PROPERTIES OUTPUT_NAME cucascade
+               CUDA_RUNTIME_LIBRARY "${CUCASCADE_CUDA_RUNTIME_LIBRARY}"
                VERSION ${PROJECT_VERSION}
                SOVERSION ${PROJECT_VERSION_MAJOR})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,12 +72,20 @@ if(CUCASCADE_CUDA_RUNTIME_LIBRARY STREQUAL "Static")
   endif()
   set(CUCASCADE_CUDART_TARGET CUDA::cudart_static)
 elseif(CUCASCADE_CUDA_RUNTIME_LIBRARY STREQUAL "Shared")
+  if(NOT TARGET CUDA::cudart)
+    message(
+      FATAL_ERROR
+      "CMAKE_CUDA_RUNTIME_LIBRARY=Shared was requested, but CUDA::cudart is unavailable"
+    )
+  endif()
   set(CUCASCADE_CUDART_TARGET CUDA::cudart)
+elseif(CUCASCADE_CUDA_RUNTIME_LIBRARY STREQUAL "None")
+  set(CUCASCADE_CUDART_TARGET)
 else()
   message(
     FATAL_ERROR
     "Unsupported CUDA runtime library: '${CUCASCADE_CUDA_RUNTIME_LIBRARY}'."
-    " Accepted values are 'Static' or 'Shared' (set via -DCMAKE_CUDA_RUNTIME_LIBRARY=<value>)."
+    " Accepted values are 'Static', 'Shared', or 'None' (set via -DCMAKE_CUDA_RUNTIME_LIBRARY=<value>)."
   )
 endif()
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -64,9 +64,8 @@ target_compile_options(
     ${CUCASCADE_CUDA_WARNING_FLAGS})
 
 # Link dependencies
-target_link_libraries(
-  cucascade_benchmarks PRIVATE cucascade benchmark::benchmark
-                               benchmark::benchmark_main CUDA::cudart)
+target_link_libraries(cucascade_benchmarks PRIVATE cucascade benchmark::benchmark
+                                                   benchmark::benchmark_main)
 
 # Add custom target to run benchmarks
 add_custom_target(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,8 +60,7 @@ target_include_directories(
           ${Catch2_SOURCE_DIR}/single_include)
 
 # Link dependencies
-target_link_libraries(cucascade_tests PRIVATE cucascade Catch2::Catch2
-                                              CUDA::cudart)
+target_link_libraries(cucascade_tests PRIVATE cucascade Catch2::Catch2)
 
 # Register tests with CTest
 add_test(NAME cucascade_tests COMMAND cucascade_tests)


### PR DESCRIPTION
## Summary

Adds support for selecting the CUDA runtime library (shared vs static) at build time via the standard `CMAKE_CUDA_RUNTIME_LIBRARY` variable. This allows cuCascade to link against `cudart_static` when consumers require fully static CUDA runtime linkage (e.g. for self-contained deployments or to avoid `libcudart.so` version mismatches at runtime).

## Changes

- Derive `CUCASCADE_CUDART_TARGET` (`CUDA::cudart` or `CUDA::cudart_static`) from `CMAKE_CUDA_RUNTIME_LIBRARY`, defaulting to `Shared` when unset
- Replace the hardcoded `CUDA::cudart` in the public link interface with the selected target, so the choice propagates transitively to all consumers
- Set `CUDA_RUNTIME_LIBRARY` property on `cucascade_static` and `cucascade_shared` targets
- Remove redundant explicit `CUDA::cudart` from test and benchmark targets — they get it transitively via `cucascade`
- Error out with a clear message (listing accepted values) on unsupported `CMAKE_CUDA_RUNTIME_LIBRARY` values

## Usage

```cmake
# Static cudart (default is Shared)
cmake -DCMAKE_CUDA_RUNTIME_LIBRARY=Static ..
```

🤖 Created by Claude