### PR TITLE
get_repositories() from data repository manager

### DIFF
--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -46,9 +46,9 @@ namespace cucascade {
  *
  * State transitions allowed:
  * - idle -> in_transit, task_created
- * - task_created -> processing, idle
+ * - task_created -> processing, idle, in_transit
  * - processing -> idle
- * - in_transit -> idle
+ * - in_transit -> idle, task_created
  */
 enum class batch_state {
   idle,          ///< Batch is idle, not being processed or in transit
@@ -450,9 +450,11 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
   /**
    * @brief Attempt to lock this batch for in-transit operations (e.g., downgrade).
    *
-   * Transitions the batch from idle to in_transit state.
+   * Transitions the batch from idle or task_created to in_transit state.
+   * When transitioning from task_created, the task_created_count is preserved
+   * so the pending task remains valid after the data is moved.
    *
-   * @return true if the batch was successfully locked (processing_count == 0 and state is idle)
+   * @return true if the batch was successfully locked (processing_count == 0 and state is idle or task_created with task_created_count > 0)
    * @return false if the batch could not be locked
    */
   bool try_to_lock_for_in_transit();
@@ -462,11 +464,13 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
    *
    * Transitions the batch from in_transit back to idle state.
    *
-   * @return true if the batch was successfully transitioned to idle
+   * @return true if the batch was successfully transitioned to the target state
    * @return false if the batch is not in in_transit state
    *
-   * @param target_state Optional state to transition to when releasing in_transit. If not set,
-   *        the batch returns to idle.
+   * @param target_state Optional state to transition to when releasing in_transit.
+   *        Supported target states: idle (default), task_created.
+   *        When restoring to task_created, the existing task_created_count is preserved,
+   *        allowing pending tasks to resume after data movement completes.
    */
   bool try_to_release_in_transit(std::optional<batch_state> target_state = std::nullopt);
 

--- a/include/cucascade/data/data_repository_manager.hpp
+++ b/include/cucascade/data/data_repository_manager.hpp
@@ -210,6 +210,7 @@ class data_repository_manager {
    * @param amount_to_downgrade The amount of data in bytes to downgrade
    * @return std::vector<PtrType> A vector of data batches that are candidates for downgrade
    */
+   // WSM TODO: remove this?
   std::vector<PtrType> get_data_batches_for_downgrade(
     [[maybe_unused]] cucascade::memory::memory_space_id memory_space_id,
     [[maybe_unused]] size_t amount_to_downgrade)
@@ -235,6 +236,27 @@ class data_repository_manager {
     for (auto& [key, repo] : _repositories) {
       if (repo) { visitor(repo.get()); }
     }
+  }
+
+  /**
+   * @brief Get a snapshot of all current repository pointers.
+   *
+   * Returns a vector of raw pointers to each non-null repository. The vector
+   * is built under the manager mutex, so callers can iterate it externally
+   * without holding the lock (the repositories themselves remain thread-safe).
+   *
+   * @return std::vector<repository_type*> Snapshot of non-null repository pointers
+   * @note Thread-safe — holds the manager mutex for the duration of collection.
+   */
+  std::vector<repository_type*> get_repositories()
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    std::vector<repository_type*> result;
+    result.reserve(_repositories.size());
+    for (auto& [key, repo] : _repositories) {
+      if (repo) { result.push_back(repo.get()); }
+    }
+    return result;
   }
 
  private:

--- a/include/cucascade/data/data_repository_manager.hpp
+++ b/include/cucascade/data/data_repository_manager.hpp
@@ -203,24 +203,7 @@ class data_repository_manager {
     return leaked;
   }
 
-  /**
-   * @brief Get N batches from the specified repositories for downgrade.
-   *
-   * @param memory_space_id The memory space id to get the data batches from
-   * @param amount_to_downgrade The amount of data in bytes to downgrade
-   * @return std::vector<PtrType> A vector of data batches that are candidates for downgrade
-   */
-   // WSM TODO: remove this?
-  std::vector<PtrType> get_data_batches_for_downgrade(
-    [[maybe_unused]] cucascade::memory::memory_space_id memory_space_id,
-    [[maybe_unused]] size_t amount_to_downgrade)
-  {
-    std::vector<PtrType> data_batches;
-    // Note: Implementation would iterate through repositories and collect batches
-    // This is a placeholder - actual implementation depends on how batches are tracked
-    return data_batches;
-  }
-
+  
   /**
    * @brief Iterate over all repositories, calling the visitor for each one.
    *

--- a/src/memory/fixed_size_host_memory_resource.cpp
+++ b/src/memory/fixed_size_host_memory_resource.cpp
@@ -171,7 +171,7 @@ std::vector<std::byte*> fixed_size_host_memory_resource::allocate_multiple_block
         if (tracker) tracker->allocated_bytes.fetch_sub(static_cast<int64_t>(total_bytes));
         throw rmm::out_of_memory(
           "Not enough free blocks available in fixed_size_host_memory_resource and pool expansion "
-          "failed.");
+          "failed. total_bytes: " + std::to_string(total_bytes) + ", upstream_tracked_bytes: " + std::to_string(upstream_tracked_bytes) + ", only " + std::to_string(_free_blocks.size()) + " free blocks available from " + std::to_string(num_blocks) + " requested blocks" + ".");
       }
 
       std::byte* ptr = static_cast<std::byte*>(_free_blocks.back());
@@ -183,7 +183,8 @@ std::vector<std::byte*> fixed_size_host_memory_resource::allocate_multiple_block
   } else {
     if (tracker) tracker->allocated_bytes.fetch_sub(static_cast<int64_t>(total_bytes));
     throw rmm::out_of_memory(
-      "Not enough free blocks available in fixed_size_host_memory_resource.");
+      "Not enough free blocks available in fixed_size_host_memory_resource. " 
+      "total_bytes: " + std::to_string(total_bytes) + ", upstream_tracked_bytes: " + std::to_string(upstream_tracked_bytes) + ", only " + std::to_string(_free_blocks.size()) + " free blocks available from " + std::to_string(num_blocks) + " requested blocks" + ".");
   }
   return {};
 }

--- a/test/data/test_data_batch.cpp
+++ b/test/data/test_data_batch.cpp
@@ -1934,3 +1934,93 @@ TEST_CASE(
 
   CUCASCADE_CUDA_TRY(cudaFreeHost(pinned_host));
 }
+
+// =============================================================================
+// task_created_count preserved across in_transit round-trip (STATE-01, STATE-02)
+// =============================================================================
+
+TEST_CASE("data_batch task_created_count preserved across in_transit round-trip single task",
+          "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  // Create one task
+  REQUIRE(batch->try_to_create_task() == true);
+  REQUIRE(batch->get_state() == batch_state::task_created);
+  REQUIRE(batch->get_task_created_count() == 1);
+
+  // Lock for in_transit
+  REQUIRE(batch->try_to_lock_for_in_transit() == true);
+  REQUIRE(batch->get_state() == batch_state::in_transit);
+  // task_created_count must still be 1 while in_transit
+  REQUIRE(batch->get_task_created_count() == 1);
+
+  // Release back to task_created
+  REQUIRE(batch->try_to_release_in_transit(batch_state::task_created) == true);
+  REQUIRE(batch->get_state() == batch_state::task_created);
+  // task_created_count must still be 1 after round-trip
+  REQUIRE(batch->get_task_created_count() == 1);
+}
+
+TEST_CASE("data_batch task_created_count preserved across in_transit round-trip multiple tasks",
+          "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  // Create three tasks
+  REQUIRE(batch->try_to_create_task() == true);
+  REQUIRE(batch->try_to_create_task() == true);
+  REQUIRE(batch->try_to_create_task() == true);
+  REQUIRE(batch->get_state() == batch_state::task_created);
+  REQUIRE(batch->get_task_created_count() == 3);
+
+  // Lock for in_transit
+  REQUIRE(batch->try_to_lock_for_in_transit() == true);
+  REQUIRE(batch->get_state() == batch_state::in_transit);
+  REQUIRE(batch->get_task_created_count() == 3);
+
+  // Release back to task_created
+  REQUIRE(batch->try_to_release_in_transit(batch_state::task_created) == true);
+  REQUIRE(batch->get_state() == batch_state::task_created);
+  REQUIRE(batch->get_task_created_count() == 3);
+}
+
+TEST_CASE("data_batch can lock_for_processing after in_transit round-trip from task_created",
+          "[data_batch]")
+{
+  auto data     = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch    = std::make_shared<data_batch>(1, std::move(data));
+  auto space_id = batch->get_memory_space()->get_id();
+
+  // Create task, go through in_transit round-trip
+  REQUIRE(batch->try_to_create_task() == true);
+  REQUIRE(batch->try_to_lock_for_in_transit() == true);
+  REQUIRE(batch->try_to_release_in_transit(batch_state::task_created) == true);
+  REQUIRE(batch->get_state() == batch_state::task_created);
+  REQUIRE(batch->get_task_created_count() == 1);
+
+  // Should still be able to lock for processing
+  auto r = batch->try_to_lock_for_processing(space_id);
+  REQUIRE(r.success == true);
+  REQUIRE(batch->get_state() == batch_state::processing);
+}
+
+TEST_CASE("data_batch can cancel_task after in_transit round-trip from task_created",
+          "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  // Create task, go through in_transit round-trip
+  REQUIRE(batch->try_to_create_task() == true);
+  REQUIRE(batch->try_to_lock_for_in_transit() == true);
+  REQUIRE(batch->try_to_release_in_transit(batch_state::task_created) == true);
+  REQUIRE(batch->get_state() == batch_state::task_created);
+
+  // Should still be able to cancel task
+  REQUIRE(batch->try_to_cancel_task() == true);
+  REQUIRE(batch->get_state() == batch_state::idle);
+  REQUIRE(batch->get_task_created_count() == 0);
+}


### PR DESCRIPTION
This PR adds a new API to allows for getting all data repositories from the data repository manager. It also deletes some dead code, improves some logging and cleans up some code comments.

Originally this PR was going to also allow transitioning data_batch state between task_created to in_transit and back. But that is already there, so we just added some unit tests