### PR TITLE
Pin cuDF to 26.04 stable release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         cuda: [12, 13]
-        rapids: [nightly, stable]
 
     env:
       SCCACHE_GHA_ENABLED: true
@@ -24,11 +23,11 @@ jobs:
       - uses: prefix-dev/setup-pixi@82d477f15f3a381dbcc8adc1206ce643fe110fb7 # v0.9.3
         with:
           cache: false
-          environments: ${{ format('cuda-{0}-{1}', matrix.cuda, matrix.rapids) }}
+          environments: cuda-${{ matrix.cuda }}
 
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 
-      - run: pixi run -e ${{ format('cuda-{0}-{1}', matrix.cuda, matrix.rapids) }} build
+      - run: pixi run -e cuda-${{ matrix.cuda }} build
 
       - name: Package build artifacts
         run: tar -cf build-release.tar build/release/
@@ -36,7 +35,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: build-release-cuda-${{ matrix.cuda }}-${{ matrix.rapids }}
+          name: build-release-cuda-${{ matrix.cuda }}
           path: build-release.tar
           if-no-files-found: error
           retention-days: 1
@@ -47,7 +46,6 @@ jobs:
     strategy:
       matrix:
         cuda: [12, 13]
-        rapids: [nightly, stable]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -55,25 +53,21 @@ jobs:
       - uses: prefix-dev/setup-pixi@82d477f15f3a381dbcc8adc1206ce643fe110fb7 # v0.9.3
         with:
           cache: false
-          environments: ${{ format('cuda-{0}-{1}', matrix.cuda, matrix.rapids) }}
+          environments: cuda-${{ matrix.cuda }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: build-release-cuda-${{ matrix.cuda }}-${{ matrix.rapids }}
+          name: build-release-cuda-${{ matrix.cuda }}
 
       - name: Extract build artifacts
         run: tar -xf build-release.tar
 
-      - run: pixi run -e ${{ format('cuda-{0}-{1}', matrix.cuda, matrix.rapids) }} test
+      - run: pixi run -e cuda-${{ matrix.cuda }} test
 
   benchmark:
     needs: build
     runs-on: linux-amd64-gpu-t4-latest-1
-    strategy:
-      matrix:
-        cuda: [13]
-        rapids: [nightly]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -81,12 +75,12 @@ jobs:
       - uses: prefix-dev/setup-pixi@82d477f15f3a381dbcc8adc1206ce643fe110fb7 # v0.9.3
         with:
           cache: false
-          environments: ${{ format('cuda-{0}-{1}', matrix.cuda, matrix.rapids) }}
+          environments: cuda-13
 
       - name: Download build artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: build-release-cuda-${{ matrix.cuda }}-${{ matrix.rapids }}
+          name: build-release-cuda-13
 
       - name: Extract build artifacts
         run: tar -xf build-release.tar

--- a/pixi.toml
+++ b/pixi.toml
@@ -33,22 +33,15 @@ system-requirements = { cuda = "12.9" }
 dependencies = { "cuda-version" = "12.9.*" }
 activation = { env = { CUDAARCHS = "75-real;80-real;86-real;90a-real;100f-real" } }
 
-# cuDF (nightly channel, default)
-[feature.cudf-nightly]
-channels = [{ channel = "rapidsai-nightly", priority = 1 }]
-dependencies = { "libcudf" = "26.06.*" }
-
-# cuDF (stable release channel)
-[feature.cudf-stable]
+# cuDF 26.04 (stable release)
+[feature.cudf-26-04]
 channels = [{ channel = "rapidsai", priority = 1 }]
 dependencies = { "libcudf" = "26.04.*" }
 
 [environments]
-default = ["cuda-13", "cudf-nightly"]
-cuda-13-nightly = ["cuda-13", "cudf-nightly"]
-cuda-12-nightly = ["cuda-12", "cudf-nightly"]
-cuda-13-stable = ["cuda-13", "cudf-stable"]
-cuda-12-stable = ["cuda-12", "cudf-stable"]
+default = ["cuda-13", "cudf-26-04"]
+cuda-13 = ["cuda-13", "cudf-26-04"]
+cuda-12 = ["cuda-12", "cudf-26-04"]
 
 [tasks]
 build = "cmake --preset release && cmake --build build/release"


### PR DESCRIPTION
## Summary
- Pin all environments to `libcudf = "26.04.*"` from the `rapidsai` stable channel
- Remove nightly (26.06) feature and environments
- Rename cuDF feature to `cudf-26-04` for explicit version pinning

## Test plan
- [ ] `pixi install` resolves successfully for default, cuda-13, and cuda-12 environments
- [ ] `pixi run build` compiles against libcudf 26.04
- [ ] `pixi run test` passes