### PR TITLE
Restore RAPIDS 26.04 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         cuda: [12, 13]
-        rapids: [nightly]  # TODO: re-enable stable once it is fixed
+        rapids: [nightly, stable]
 
     env:
       SCCACHE_GHA_ENABLED: true
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         cuda: [12, 13]
-        rapids: [nightly]  # TODO: re-enable stable once it is fixed
+        rapids: [nightly, stable]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/include/cucascade/memory/common.hpp
+++ b/include/cucascade/memory/common.hpp
@@ -21,7 +21,9 @@
 #include <rmm/version_config.hpp>
 
 #include <cuda/memory_resource>
+#include <cuda/stream_ref>
 
+#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <functional>
@@ -102,7 +104,7 @@ class legacy_rmm_resource_adapter {
   void* allocate_sync(std::size_t bytes,
                       std::size_t alignment = alignof(std::max_align_t))
   {
-    auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
+    auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
     rmm::cuda_stream_default.synchronize();
     return ptr;
   }
@@ -111,7 +113,7 @@ class legacy_rmm_resource_adapter {
                        std::size_t bytes,
                        std::size_t alignment = alignof(std::max_align_t)) noexcept
   {
-    deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
+    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
     rmm::cuda_stream_default.synchronize_no_throw();
   }
 

--- a/include/cucascade/memory/common.hpp
+++ b/include/cucascade/memory/common.hpp
@@ -18,13 +18,23 @@
 #pragma once
 
 #include <rmm/error.hpp>
+#include <rmm/version_config.hpp>
 
 #include <cuda/memory_resource>
 
 #include <cstdint>
 #include <cstring>
 #include <functional>
+#include <memory>
 #include <utility>
+
+#if RMM_VERSION_MAJOR > 26 || (RMM_VERSION_MAJOR == 26 && RMM_VERSION_MINOR >= 6)
+#define CUCASCADE_RMM_HAS_MOVABLE_ANY_RESOURCE 1
+#else
+#define CUCASCADE_RMM_HAS_MOVABLE_ANY_RESOURCE 0
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/mr/device_memory_resource.hpp>
+#endif
 
 namespace cucascade {
 namespace memory {
@@ -63,6 +73,71 @@ class memory_space_id {
 using DeviceMemoryResourceFactoryFn =
   std::function<cuda::mr::any_resource<cuda::mr::device_accessible>(int device_id,
                                                                     std::size_t capacity)>;
+
+#if !CUCASCADE_RMM_HAS_MOVABLE_ANY_RESOURCE
+namespace detail {
+
+class legacy_rmm_resource_adapter {
+ public:
+  explicit legacy_rmm_resource_adapter(std::shared_ptr<rmm::mr::device_memory_resource> resource)
+    : resource_(std::move(resource))
+  {
+  }
+
+  void* allocate(cuda::stream_ref stream,
+                 std::size_t bytes,
+                 [[maybe_unused]] std::size_t alignment = alignof(std::max_align_t))
+  {
+    return resource_->allocate(rmm::cuda_stream_view{stream}, bytes);
+  }
+
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  [[maybe_unused]] std::size_t alignment = alignof(std::max_align_t)) noexcept
+  {
+    resource_->deallocate(rmm::cuda_stream_view{stream}, ptr, bytes);
+  }
+
+  void* allocate_sync(std::size_t bytes,
+                      std::size_t alignment = alignof(std::max_align_t))
+  {
+    auto* ptr = allocate(rmm::cuda_stream_default, bytes, alignment);
+    rmm::cuda_stream_default.synchronize();
+    return ptr;
+  }
+
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = alignof(std::max_align_t)) noexcept
+  {
+    deallocate(rmm::cuda_stream_default, ptr, bytes, alignment);
+    rmm::cuda_stream_default.synchronize_no_throw();
+  }
+
+  bool operator==(legacy_rmm_resource_adapter const& other) const noexcept
+  {
+    return resource_.get() == other.resource_.get();
+  }
+
+  friend void get_property(legacy_rmm_resource_adapter const&,
+                           cuda::mr::device_accessible) noexcept
+  {
+  }
+
+ private:
+  std::shared_ptr<rmm::mr::device_memory_resource> resource_;
+};
+
+}  // namespace detail
+
+inline cuda::mr::any_resource<cuda::mr::device_accessible> wrap_legacy_rmm_resource(
+  std::shared_ptr<rmm::mr::device_memory_resource> resource)
+{
+  return cuda::mr::any_resource<cuda::mr::device_accessible>{
+    detail::legacy_rmm_resource_adapter{std::move(resource)}};
+}
+#endif
 
 cuda::mr::any_resource<cuda::mr::device_accessible> make_default_gpu_memory_resource(
   int device_id, std::size_t capacity);

--- a/include/cucascade/memory/memory_space.hpp
+++ b/include/cucascade/memory/memory_space.hpp
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <cstring>
 #include <memory>
+#include <optional>
 #include <string>
 #include <variant>
 
@@ -166,6 +167,8 @@ class memory_space {
   // Memory resources owned by this memory_space
   cuda::mr::any_resource<cuda::mr::device_accessible> _allocator;
   reserving_adaptor_type _reservation_allocator;
+  std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>>
+    _reservation_allocator_resource;
   std::unique_ptr<rmm::cuda_stream_pool> _stream_pool;
   std::shared_ptr<idisk_io_backend> _io_backend;  ///< I/O backend for DISK tier (null for others)
 };

--- a/include/cucascade/memory/reservation_aware_resource_adaptor.hpp
+++ b/include/cucascade/memory/reservation_aware_resource_adaptor.hpp
@@ -244,6 +244,13 @@ class reservation_aware_resource_adaptor
     return get().allocate(stream, bytes, alignment);
   }
 
+#if !CUCASCADE_RMM_HAS_MOVABLE_ANY_RESOURCE
+  void* allocate(rmm::cuda_stream_view stream, std::size_t bytes, std::size_t alignment)
+  {
+    return allocate(cuda::stream_ref{stream}, bytes, alignment);
+  }
+#endif
+
   void deallocate(cuda::stream_ref stream,
                   void* ptr,
                   std::size_t bytes,
@@ -251,6 +258,16 @@ class reservation_aware_resource_adaptor
   {
     get().deallocate(stream, ptr, bytes, alignment);
   }
+
+#if !CUCASCADE_RMM_HAS_MOVABLE_ANY_RESOURCE
+  void deallocate(rmm::cuda_stream_view stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment) noexcept
+  {
+    deallocate(cuda::stream_ref{stream}, ptr, bytes, alignment);
+  }
+#endif
 };
 
 }  // namespace memory

--- a/pixi.toml
+++ b/pixi.toml
@@ -38,17 +38,16 @@ activation = { env = { CUDAARCHS = "75-real;80-real;86-real;90a-real;100f-real" 
 channels = [{ channel = "rapidsai-nightly", priority = 1 }]
 dependencies = { "libcudf" = "26.06.*" }
 
-# TODO: re-enable stable once it works with the current changes
-# [feature.cudf-stable]
-# channels = [{ channel = "rapidsai", priority = 1 }]
-# dependencies = { "libcudf" = "26.04.*" }
+[feature.cudf-stable]
+channels = [{ channel = "rapidsai", priority = 1 }]
+dependencies = { "libcudf" = "26.04.*" }
 
 [environments]
 default = ["cuda-13", "cudf-nightly"]
 cuda-13-nightly = ["cuda-13", "cudf-nightly"]
 cuda-12-nightly = ["cuda-12", "cudf-nightly"]
-# cuda-13-stable = ["cuda-13", "cudf-stable"]
-# cuda-12-stable = ["cuda-12", "cudf-stable"]
+cuda-13-stable = ["cuda-13", "cudf-stable"]
+cuda-12-stable = ["cuda-12", "cudf-stable"]
 
 [tasks]
 build = "cmake --preset release && cmake --build build/release"

--- a/src/memory/common.cpp
+++ b/src/memory/common.cpp
@@ -30,7 +30,12 @@ cuda::mr::any_resource<cuda::mr::device_accessible> make_default_gpu_memory_reso
   int device_id, size_t capacity)
 {
   rmm::cuda_set_device_raii set_device(rmm::cuda_device_id{device_id});
+#if CUCASCADE_RMM_HAS_MOVABLE_ANY_RESOURCE
   return {rmm::mr::cuda_async_memory_resource(capacity)};
+#else
+  return wrap_legacy_rmm_resource(
+    std::make_shared<rmm::mr::cuda_async_memory_resource>(capacity));
+#endif
 }
 
 cuda::mr::any_resource<cuda::mr::device_accessible, cuda::mr::host_accessible>

--- a/src/memory/memory_space.cpp
+++ b/src/memory/memory_space.cpp
@@ -43,6 +43,57 @@ namespace cucascade {
 std::unique_ptr<idisk_io_backend> make_pipeline_io_backend(bool direct_io = false);
 
 namespace memory {
+namespace {
+
+class fixed_size_host_resource_ref {
+ public:
+  explicit fixed_size_host_resource_ref(fixed_size_host_memory_resource& resource)
+    : resource_(&resource)
+  {
+  }
+
+  void* allocate(cuda::stream_ref stream,
+                 std::size_t bytes,
+                 std::size_t alignment = alignof(std::max_align_t))
+  {
+    return resource_->allocate(stream, bytes, alignment);
+  }
+
+  void deallocate(cuda::stream_ref stream,
+                  void* ptr,
+                  std::size_t bytes,
+                  std::size_t alignment = alignof(std::max_align_t)) noexcept
+  {
+    resource_->deallocate(stream, ptr, bytes, alignment);
+  }
+
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t))
+  {
+    return resource_->allocate_sync(bytes, alignment);
+  }
+
+  void deallocate_sync(void* ptr,
+                       std::size_t bytes,
+                       std::size_t alignment = alignof(std::max_align_t)) noexcept
+  {
+    resource_->deallocate_sync(ptr, bytes, alignment);
+  }
+
+  bool operator==(fixed_size_host_resource_ref const& other) const noexcept
+  {
+    return resource_ == other.resource_;
+  }
+
+  friend void get_property(fixed_size_host_resource_ref const&,
+                           cuda::mr::device_accessible) noexcept
+  {
+  }
+
+ private:
+  fixed_size_host_memory_resource* resource_;
+};
+
+}  // namespace
 
 //===----------------------------------------------------------------------===//
 // memory_space Implementation
@@ -107,6 +158,9 @@ memory_space::memory_space(const host_memory_space_config& config)
                                                       config.block_size,
                                                       config.pool_size,
                                                       config.initial_number_pools);
+  auto& host_allocator =
+    std::get<std::unique_ptr<fixed_size_host_memory_resource>>(_reservation_allocator);
+  _reservation_allocator_resource.emplace(fixed_size_host_resource_ref{*host_allocator});
 }
 
 memory_space::memory_space(const disk_memory_space_config& config)
@@ -303,7 +357,8 @@ rmm::device_async_resource_ref memory_space::get_default_allocator() const noexc
       },
       [&](const std::unique_ptr<fixed_size_host_memory_resource>&) {
         return rmm::device_async_resource_ref{
-          const_cast<cuda::mr::any_resource<cuda::mr::device_accessible>&>(_allocator)};
+          const_cast<cuda::mr::any_resource<cuda::mr::device_accessible>&>(
+            *_reservation_allocator_resource)};
       },
       [&](const std::unique_ptr<disk_access_limiter>&) {
         return rmm::device_async_resource_ref{

--- a/src/memory/memory_space.cpp
+++ b/src/memory/memory_space.cpp
@@ -65,9 +65,15 @@ memory_space::memory_space(const gpu_memory_space_config& config)
     _allocator = config.mr_factory_fn(config.device_id, config.memory_capacity);
   } else {
     rmm::cuda_set_device_raii set_device(rmm::cuda_device_id{config.device_id});
+#if CUCASCADE_RMM_HAS_MOVABLE_ANY_RESOURCE
     rmm::mr::cuda_async_memory_resource concrete_mr(config.memory_capacity);
     pool_handle = concrete_mr.pool_handle();
     _allocator  = cuda::mr::any_resource<cuda::mr::device_accessible>(std::move(concrete_mr));
+#else
+    auto concrete_mr = std::make_shared<rmm::mr::cuda_async_memory_resource>(config.memory_capacity);
+    pool_handle      = concrete_mr->pool_handle();
+    _allocator       = wrap_legacy_rmm_resource(std::move(concrete_mr));
+#endif
   }
 
   _reservation_allocator = std::make_unique<reservation_aware_resource_adaptor>(

--- a/src/memory/memory_space.cpp
+++ b/src/memory/memory_space.cpp
@@ -295,8 +295,21 @@ size_t memory_space::get_max_memory() const noexcept { return _memory_limit; }
 
 rmm::device_async_resource_ref memory_space::get_default_allocator() const noexcept
 {
-  return rmm::device_async_resource_ref(
-    const_cast<cuda::mr::any_resource<cuda::mr::device_accessible>&>(_allocator));
+  return std::visit(
+    utils::overloaded{
+      [&](const std::unique_ptr<reservation_aware_resource_adaptor>& mr) {
+        return rmm::device_async_resource_ref{
+          const_cast<reservation_aware_resource_adaptor&>(*mr)};
+      },
+      [&](const std::unique_ptr<fixed_size_host_memory_resource>&) {
+        return rmm::device_async_resource_ref{
+          const_cast<cuda::mr::any_resource<cuda::mr::device_accessible>&>(_allocator)};
+      },
+      [&](const std::unique_ptr<disk_access_limiter>&) {
+        return rmm::device_async_resource_ref{
+          const_cast<cuda::mr::any_resource<cuda::mr::device_accessible>&>(_allocator)};
+      }},
+    _reservation_allocator);
 }
 
 std::string_view memory_space::get_disk_mount_path() const

--- a/test/data/test_data_batch.cpp
+++ b/test/data/test_data_batch.cpp
@@ -321,9 +321,11 @@ TEST_CASE("data_batch Thread-Safe Processing Count", "[data_batch]")
   for (int i = 0; i < num_threads; ++i) {
     threads.emplace_back([batch, &thread_handles, i, space_id]() {
       for (int j = 0; j < locks_per_thread; ++j) {
-        // Create task first so threads can lock for processing
-        REQUIRE(batch->try_to_create_task() == true);
-        auto r = batch->try_to_lock_for_processing(space_id);
+        // Task creation is global to the batch; use the blocking API so each
+        // thread eventually consumes one created task without relying on
+        // per-thread ownership of it.
+        batch->wait_to_create_task();
+        auto r = batch->wait_to_lock_for_processing(space_id);
         REQUIRE(r.success == true);
         thread_handles[i].push_back(std::move(r.handle));
       }

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -21,7 +21,9 @@
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
+#include <rmm/version_config.hpp>
 
+#include <cuda/memory_resource>
 #include <cuda_runtime_api.h>
 
 #include <catch2/catch.hpp>
@@ -29,8 +31,39 @@
 #include <algorithm>
 #include <cstdlib>
 #include <memory>
+#include <optional>
+#include <utility>
 
 namespace {
+
+#if RMM_VERSION_MAJOR > 26 || (RMM_VERSION_MAJOR == 26 && RMM_VERSION_MINOR >= 6)
+using current_device_resource_handle = cuda::mr::any_resource<cuda::mr::device_accessible>;
+
+template <typename Resource>
+current_device_resource_handle replace_current_device_resource(Resource& resource)
+{
+  return rmm::mr::set_current_device_resource(
+    cuda::mr::any_resource<cuda::mr::device_accessible>{resource});
+}
+
+void restore_current_device_resource(current_device_resource_handle previous)
+{
+  rmm::mr::set_current_device_resource(std::move(previous));
+}
+#else
+using current_device_resource_handle = rmm::device_async_resource_ref;
+
+template <typename Resource>
+current_device_resource_handle replace_current_device_resource(Resource& resource)
+{
+  return rmm::mr::set_current_device_resource_ref(resource);
+}
+
+void restore_current_device_resource(current_device_resource_handle previous)
+{
+  rmm::mr::set_current_device_resource_ref(previous);
+}
+#endif
 
 class test_gpu_pool {
  public:
@@ -48,14 +81,15 @@ class test_gpu_pool {
     auto initial_bytes = default_initial_bytes;
     if (initial_bytes > max_bytes) { initial_bytes = max_bytes; }
 
-    pool_     = std::make_unique<rmm::mr::cuda_async_memory_resource>(initial_bytes, max_bytes);
-    previous_ = rmm::mr::get_current_device_resource_ref();
-    rmm::mr::set_current_device_resource_ref(*pool_);
+    pool_ = std::make_unique<rmm::mr::cuda_async_memory_resource>(initial_bytes, max_bytes);
+    previous_.emplace(replace_current_device_resource(*pool_));
   }
 
   ~test_gpu_pool()
   {
-    if (pool_ != nullptr) { rmm::mr::set_current_device_resource_ref(previous_); }
+    if (pool_ != nullptr && previous_.has_value()) {
+      restore_current_device_resource(std::move(*previous_));
+    }
   }
 
  private:
@@ -74,7 +108,7 @@ class test_gpu_pool {
   static constexpr std::size_t default_max_bytes     = 10ULL * 1024 * 1024 * 1024;
 
   std::unique_ptr<rmm::mr::cuda_async_memory_resource> pool_;
-  rmm::device_async_resource_ref previous_{rmm::mr::get_current_device_resource_ref()};
+  std::optional<current_device_resource_handle> previous_;
 };
 
 test_gpu_pool global_pool;

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -39,11 +39,12 @@ namespace {
 #if RMM_VERSION_MAJOR > 26 || (RMM_VERSION_MAJOR == 26 && RMM_VERSION_MINOR >= 6)
 using current_device_resource_handle = cuda::mr::any_resource<cuda::mr::device_accessible>;
 
-template <typename Resource>
-current_device_resource_handle replace_current_device_resource(Resource& resource)
+current_device_resource_handle replace_current_device_resource(std::size_t initial_bytes,
+                                                               std::size_t max_bytes)
 {
+  rmm::mr::cuda_async_memory_resource resource{initial_bytes, max_bytes};
   return rmm::mr::set_current_device_resource(
-    cuda::mr::any_resource<cuda::mr::device_accessible>{resource});
+    cuda::mr::any_resource<cuda::mr::device_accessible>{std::move(resource)});
 }
 
 void restore_current_device_resource(current_device_resource_handle previous)
@@ -81,15 +82,17 @@ class test_gpu_pool {
     auto initial_bytes = default_initial_bytes;
     if (initial_bytes > max_bytes) { initial_bytes = max_bytes; }
 
+#if RMM_VERSION_MAJOR > 26 || (RMM_VERSION_MAJOR == 26 && RMM_VERSION_MINOR >= 6)
+    previous_.emplace(replace_current_device_resource(initial_bytes, max_bytes));
+#else
     pool_ = std::make_unique<rmm::mr::cuda_async_memory_resource>(initial_bytes, max_bytes);
     previous_.emplace(replace_current_device_resource(*pool_));
+#endif
   }
 
   ~test_gpu_pool()
   {
-    if (pool_ != nullptr && previous_.has_value()) {
-      restore_current_device_resource(std::move(*previous_));
-    }
+    if (previous_.has_value()) { restore_current_device_resource(std::move(*previous_)); }
   }
 
  private:
@@ -107,7 +110,9 @@ class test_gpu_pool {
   static constexpr std::size_t default_initial_bytes = 2ULL * 1024 * 1024 * 1024;
   static constexpr std::size_t default_max_bytes     = 10ULL * 1024 * 1024 * 1024;
 
+#if !(RMM_VERSION_MAJOR > 26 || (RMM_VERSION_MAJOR == 26 && RMM_VERSION_MINOR >= 6))
   std::unique_ptr<rmm::mr::cuda_async_memory_resource> pool_;
+#endif
   std::optional<current_device_resource_handle> previous_;
 };
 

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -50,12 +50,12 @@ class test_gpu_pool {
 
     pool_     = std::make_unique<rmm::mr::cuda_async_memory_resource>(initial_bytes, max_bytes);
     previous_ = rmm::mr::get_current_device_resource_ref();
-    rmm::mr::set_current_device_resource(*pool_);
+    rmm::mr::set_current_device_resource_ref(*pool_);
   }
 
   ~test_gpu_pool()
   {
-    if (pool_ != nullptr) { rmm::mr::set_current_device_resource(previous_); }
+    if (pool_ != nullptr) { rmm::mr::set_current_device_resource_ref(previous_); }
   }
 
  private:

--- a/test/utils/cudf_test_utils.cpp
+++ b/test/utils/cudf_test_utils.cpp
@@ -391,7 +391,7 @@ static void install_rmm_logging_resource_once()
     auto prev = rmm::mr::get_current_device_resource_ref();
     logging_resource =
       cuda::mr::any_resource<cuda::mr::device_accessible>{logging_device_resource{prev}};
-    rmm::mr::set_current_device_resource(*logging_resource);
+    rmm::mr::set_current_device_resource_ref(*logging_resource);
     installed = true;
     std::cout << "[rmm-log ] installed logging device resource adaptor" << std::endl << std::flush;
   }

--- a/test/utils/cudf_test_utils.cpp
+++ b/test/utils/cudf_test_utils.cpp
@@ -29,6 +29,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/per_device_resource.hpp>
 #include <rmm/resource_ref.hpp>
+#include <rmm/version_config.hpp>
 
 #include <cuda/memory_resource>
 #include <cuda_runtime_api.h>
@@ -386,12 +387,19 @@ class logging_device_resource {
 static void install_rmm_logging_resource_once()
 {
   static bool installed = false;
+#if !(RMM_VERSION_MAJOR > 26 || (RMM_VERSION_MAJOR == 26 && RMM_VERSION_MINOR >= 6))
   static std::optional<cuda::mr::any_resource<cuda::mr::device_accessible>> logging_resource;
+#endif
   if (!installed) {
     auto prev = rmm::mr::get_current_device_resource_ref();
+#if RMM_VERSION_MAJOR > 26 || (RMM_VERSION_MAJOR == 26 && RMM_VERSION_MINOR >= 6)
+    rmm::mr::set_current_device_resource(
+      cuda::mr::any_resource<cuda::mr::device_accessible>{logging_device_resource{prev}});
+#else
     logging_resource =
       cuda::mr::any_resource<cuda::mr::device_accessible>{logging_device_resource{prev}};
     rmm::mr::set_current_device_resource_ref(*logging_resource);
+#endif
     installed = true;
     std::cout << "[rmm-log ] installed logging device resource adaptor" << std::endl << std::flush;
   }

--- a/test/utils/mock_test_utils.hpp
+++ b/test/utils/mock_test_utils.hpp
@@ -62,7 +62,12 @@ inline std::shared_ptr<memory::memory_space> make_mock_memory_space(memory::Tier
     config.device_id       = static_cast<int>(device_id);
     config.memory_capacity = 1024 * 1024 * 1024;
     config.mr_factory_fn   = [](int, size_t) {
+#if CUCASCADE_RMM_HAS_MOVABLE_ANY_RESOURCE
       return cuda::mr::any_resource<cuda::mr::device_accessible>{rmm::mr::cuda_memory_resource{}};
+#else
+      return cucascade::memory::wrap_legacy_rmm_resource(
+        std::make_shared<rmm::mr::cuda_memory_resource>());
+#endif
     };
     return std::make_shared<memory::memory_space>(config);
   } else if (tier == memory::Tier::HOST) {


### PR DESCRIPTION
## Summary
- re-enable the stable RAPIDS pixi environments and build/test CI jobs
- add RMM/cuDF 26.04 compatibility shims so cuCascade builds against both 26.04 and 26.06+
- update test utilities for the cross-version resource-ref APIs and fix the racy data_batch processing-count test uncovered during GPU validation

## Testing
- pixi run -e cuda-13-stable -- cmake --build build/stable-tests -j8 --target cucascade_tests
- pixi run -e cuda-13-stable -- ctest --test-dir build/stable-tests --output-on-failure -j4
- pixi run -e cuda-13-nightly -- ctest --test-dir build/nightly-tests --output-on-failure -j4

Closes #110. 