### PR TITLE
feat(data): add memory-space bandwidth profiler

### DIFF
--- a/docs/bandwidth-profiler.md
+++ b/docs/bandwidth-profiler.md
@@ -1,0 +1,159 @@
+# Memory Space Bandwidth Profiler — Design
+
+**Status:** Design locked, pending implementation
+**Date:** 2026-04-21
+
+## Purpose
+
+Given a list of `memory_space*`, measure pairwise transfer throughput between them so engines can use the resulting bandwidth matrix for routing decisions (where to place / downgrade / upgrade data).
+
+Measurements flow through the **existing converter registry and `disk_io_backend`** — results reflect the actual transfer paths engines will pay at runtime, including user-registered converters.
+
+## Scope
+
+- Measure GPU↔GPU, GPU↔HOST, HOST↔HOST as a full all-pairs matrix.
+- Measure DISK↔{GPU, HOST} for every (disk, non-disk) pair. **No disk↔disk entries** — not a routing path engines care about.
+- Measure **both directions** of every pair separately (`src→dst` and `dst→src`). PCIe, NVLink asymmetries, and especially disk read/write asymmetry must be visible.
+- Pure end-to-end function. No caching, no state. Runs at init time.
+- Does **not** go through `memory_reservation_manager` — allocates directly from each space's allocator. Caller is responsible for running this before production load begins.
+
+## Decisions
+
+### D-01. Transfer mechanism
+Use `representation_converter_registry::convert<T>()` for every transfer. The registry is initialized (via `register_builtin_converters()` or user registrations) before the profiler runs. If a pair has no registered converter, that cell is left empty / marked unavailable.
+
+**Why:** Engines route based on what converters will actually do at runtime. Raw `cudaMemcpyAsync` / `cuFileRead` numbers would diverge from production overhead (packing, metadata handling, backend selection).
+
+### D-02. Disk backend selection
+The profiler accepts an `std::shared_ptr<idisk_io_backend>` (same parameter as `register_builtin_converters`). Profiler results are scoped to that backend — a kvikIO profile is not interchangeable with a GDS profile. Callers wanting both profile twice.
+
+### D-03. Chunked-allocator detection — `chunked_resource_info` mixin
+New interface lives at `include/cucascade/memory/chunked_resource_info.hpp`:
+
+```cpp
+namespace cucascade::memory {
+
+struct chunked_resource_info {
+  virtual ~chunked_resource_info() = default;
+  [[nodiscard]] virtual std::size_t max_chunk_bytes() const = 0;
+};
+
+}  // namespace cucascade::memory
+```
+
+- Inherited **alongside** `rmm::mr::device_memory_resource` by any resource that hands out fixed-size chunks rather than arbitrary contiguous ranges. Allocators that don't inherit it are treated as contiguous.
+- `fixed_size_host_memory_resource` gets the mixin; `max_chunk_bytes()` forwards to the existing `get_block_size()`.
+- The profiler probes with `dynamic_cast<chunked_resource_info const*>(mr)`; on hit, it iterates chunks; on miss, it performs a single contiguous allocation.
+- The mixin is opt-in, non-intrusive, and does not alter the `device_memory_resource` contract. Any future allocator (GPU-side arenas, disk chunking) can opt in the same way.
+
+### D-04. Test-size semantics for chunked allocators
+When probing a chunked allocator at test size `N`:
+- Compute `k = ceil(N / max_chunk_bytes)` chunk allocations.
+- Issue `k` converter calls — one per chunk — and measure the aggregate transfer rate.
+- This matches production behavior: a `data_batch` backed by a chunked allocator will already be chunked, and real converters already handle the per-chunk dispatch.
+
+For contiguous allocators, a single allocation of size `N` is issued and one converter call measures the transfer.
+
+### D-05. Result shape
+Both per-size detail and an aggregated summary (so engines have a single number for routing, and the full curve is available for diagnostics):
+
+```cpp
+namespace cucascade::data {
+
+struct bandwidth_sample {
+  double gbps;                    // GB/s for this (pair, size)
+  std::chrono::duration<double> mean_transfer_time;
+  std::size_t bytes_transferred;  // effective bytes after chunk rounding
+};
+
+struct bandwidth_pair_result {
+  memory_space_id src;
+  memory_space_id dst;
+  std::map<std::size_t, bandwidth_sample> per_size;  // keyed by test size in bytes
+  bandwidth_sample summary;  // representative value (see D-06)
+  bool converter_available;  // false => pair has no registered converter
+};
+
+struct bandwidth_profile {
+  std::vector<bandwidth_pair_result> pairs;  // asymmetric: src→dst is distinct from dst→src
+  // Convenience accessors:
+  [[nodiscard]] double gbps(memory_space_id src, memory_space_id dst) const;  // uses summary
+  [[nodiscard]] std::optional<bandwidth_sample>
+    sample(memory_space_id src, memory_space_id dst, std::size_t size_bytes) const;
+};
+
+}  // namespace cucascade::data
+```
+
+### D-06. Summary-value aggregation
+The `summary` field reports the **median gbps across all measured sizes** for that pair. Rationale: median is robust to outliers at either end of the size curve (small-size latency-dominated, largest-size capacity-constrained) while still reflecting realistic throughput.
+
+### D-07. Default measurement config
+```cpp
+struct bandwidth_profile_config {
+  std::vector<std::size_t> test_sizes_bytes{
+    1ull << 20,   //   1 MiB
+    16ull << 20,  //  16 MiB
+    64ull << 20,  //  64 MiB
+    256ull << 20  // 256 MiB
+  };
+  std::size_t warmup_iterations = 3;
+  std::size_t timed_iterations  = 10;
+  std::chrono::milliseconds min_measurement_time{50};  // loop iterations until hit
+  bool measure_disk_pairs = true;  // disable to skip slow disk paths
+};
+```
+
+- Multiple sizes chosen to surface the small-vs-large transfer curve without dominating init cost.
+- `min_measurement_time` guards against cases where `timed_iterations` finishes faster than timer resolution.
+- Disk measurements are opt-out because they're orders of magnitude slower than GPU/HOST pairs.
+
+### D-08. Bidirectional measurement
+For every unique unordered pair `{A, B}` where at least one is non-disk (or both are non-disk), measure `A→B` and `B→A` as two independent entries in the result. For disk pairs, both directions are measured because write ≠ read throughput on NVMe. Self-pairs (`A→A`) are skipped.
+
+### D-09. Entry point
+Pure function:
+```cpp
+namespace cucascade::data {
+
+[[nodiscard]] bandwidth_profile measure_bandwidth(
+  std::span<memory_space* const> spaces,
+  representation_converter_registry const& registry,
+  std::shared_ptr<idisk_io_backend> disk_backend = nullptr,
+  bandwidth_profile_config const& config = {});
+
+}  // namespace cucascade::data
+```
+
+- No caching, no internal state. Call it at init, hand the result to engines.
+- `disk_backend` may be null if no DISK spaces are present; required when any DISK space is passed in.
+- Errors in individual pairs (OOM, transfer failure) mark that pair as `converter_available = false` with zeroed samples; they do not abort the whole profile.
+
+### D-10. Header locations
+- `include/cucascade/memory/chunked_resource_info.hpp` — the mixin trait (memory layer).
+- `include/cucascade/data/bandwidth_profiler.hpp` — `bandwidth_profile`, `bandwidth_profile_config`, `measure_bandwidth()` (data layer, depends on converter registry + memory layer).
+
+Direction of dependency: data → memory (consistent with existing architecture).
+
+### D-11. Stream usage
+Each transfer uses a stream acquired from the destination space's `exclusive_stream_pool` (policy `BLOCK`). The profiler never uses the default CUDA stream. Streams are released as the pool handle goes out of scope between iterations.
+
+### D-12. Thread safety
+`measure_bandwidth` itself is not required to be reentrant — it's a one-shot init call. Callers must not mutate the converter registry or the passed-in memory spaces during execution. Internal transfers use per-pair streams, so individual converter calls run concurrently where the registry supports it.
+
+## Existing Code Touched
+
+- `include/cucascade/memory/fixed_size_host_memory_resource.hpp` — add `: public chunked_resource_info` and an override that forwards to `get_block_size()`.
+- `include/cucascade/memory/chunked_resource_info.hpp` — **new**, the mixin interface.
+- `include/cucascade/data/bandwidth_profiler.hpp` — **new**, public API.
+- `src/data/bandwidth_profiler.cpp` — **new**, implementation.
+- `test/data/test_bandwidth_profiler.cpp` — **new**, Catch2 tests using mock memory spaces + mock converters.
+- Consumers: whatever engine code will call `measure_bandwidth()` at init and thread results into routing. Out of scope for this design — the profiler just returns the data.
+
+## Deferred / Out of Scope
+
+- **Caching or persistence of profiles across runs.** Bandwidth can drift (thermal, NUMA pinning, concurrent workload); callers that want persistence build it on top.
+- **Dynamic re-profiling under load.** This is an init-time tool.
+- **Concurrency bandwidth** (what happens when multiple engines transfer at once). Future work.
+- **Raw-hardware baseline mode** (bypassing converters). Can be added as an alternative `measure_bandwidth_raw()` later if needed for debugging converter overhead.
+- **Chunked disk allocators.** If `disk_access_limiter` grows chunked allocation semantics, it can opt into `chunked_resource_info` without touching the profiler.

--- a/include/cucascade/data/bandwidth_profiler.hpp
+++ b/include/cucascade/data/bandwidth_profiler.hpp
@@ -1,0 +1,164 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cucascade/data/representation_converter.hpp>
+#include <cucascade/memory/common.hpp>
+#include <cucascade/memory/memory_space.hpp>
+
+#include <cstddef>
+#include <map>
+#include <optional>
+#include <span>
+#include <string>
+#include <vector>
+
+namespace cucascade {
+namespace data {
+
+/**
+ * @brief A single timing measurement for a (pair, transfer-size) probe.
+ */
+struct bandwidth_sample {
+  double gbps                   = 0.0;  ///< Achieved throughput in GB/s (10^9 bytes)
+  double mean_seconds           = 0.0;  ///< Mean wall-clock time per iteration
+  std::size_t bytes_transferred = 0;    ///< Effective bytes moved per iteration
+  std::size_t iterations_timed  = 0;    ///< Number of timed iterations aggregated
+};
+
+/**
+ * @brief Bandwidth measurement for one ordered (src -> dst) pair of memory spaces.
+ *
+ * Results are asymmetric — `src -> dst` and `dst -> src` are separate entries.
+ * Disk pairs are only included when exactly one endpoint is DISK (no disk-to-disk).
+ */
+struct bandwidth_pair_result {
+  /// Source memory space. Overwritten before use; default values exist only because
+  /// `memory_space_id` has no default constructor.
+  memory::memory_space_id src{memory::Tier::GPU, 0};
+  /// Destination memory space. See `src` note.
+  memory::memory_space_id dst{memory::Tier::GPU, 0};
+
+  /// Chunk size advertised by the source's allocator (0 if contiguous / not a chunked resource).
+  std::size_t src_max_chunk_bytes = 0;
+  /// Chunk size advertised by the destination's allocator (0 if contiguous / not a chunked
+  /// resource).
+  std::size_t dst_max_chunk_bytes = 0;
+
+  /// Per-test-size detail. Keyed by requested transfer size in bytes.
+  std::map<std::size_t, bandwidth_sample> per_size;
+  /// Aggregated summary across per_size entries (median gbps).
+  bandwidth_sample summary;
+
+  /// False when no converter was available for this pair, or a transient error suppressed it.
+  bool converter_available = true;
+  /// Human-readable detail when `converter_available == false`.
+  std::string unavailable_reason;
+};
+
+/**
+ * @brief Configuration for `measure_bandwidth`.
+ */
+struct bandwidth_profile_config {
+  /// Transfer sizes to probe per pair. Defaults to a sweep from 1 MiB up to 256 MiB.
+  std::vector<std::size_t> test_sizes_bytes{
+    1ull << 20,    //   1 MiB
+    16ull << 20,   //  16 MiB
+    64ull << 20,   //  64 MiB
+    256ull << 20,  // 256 MiB
+  };
+  /// Untimed converter invocations run before measurement to warm caches, JIT, file cache, etc.
+  std::size_t warmup_iterations = 3;
+  /// Timed converter invocations aggregated into the per-size sample.
+  std::size_t timed_iterations = 10;
+  /// Skip disk pairs (useful when you only care about GPU/HOST cells).
+  bool measure_disk_pairs = true;
+  /// When true, call `posix_fadvise(POSIX_FADV_DONTNEED)` on disk source files between timed
+  /// iterations so every read hits the disk instead of the Linux page cache. Process-local;
+  /// no sudo required. Disable to measure warm-cache behavior.
+  bool drop_page_cache_between_iters = true;
+};
+
+/**
+ * @brief Asymmetric bandwidth profile across a set of memory spaces.
+ */
+struct bandwidth_profile {
+  std::vector<bandwidth_pair_result> pairs;
+
+  /**
+   * @brief Summary gbps for the given ordered pair, or 0 if not found / unavailable.
+   */
+  [[nodiscard]] double gbps(memory::memory_space_id src,
+                            memory::memory_space_id dst) const noexcept;
+
+  /**
+   * @brief Per-size sample for the given ordered pair and transfer size.
+   *
+   * @return The sample if the pair exists and size was measured; `std::nullopt` otherwise.
+   */
+  [[nodiscard]] std::optional<bandwidth_sample> sample(memory::memory_space_id src,
+                                                       memory::memory_space_id dst,
+                                                       std::size_t size_bytes) const;
+
+  /**
+   * @brief Find the result for a pair, if any.
+   */
+  [[nodiscard]] const bandwidth_pair_result* find(memory::memory_space_id src,
+                                                  memory::memory_space_id dst) const noexcept;
+};
+
+/**
+ * @brief Measure pairwise transfer throughput between a set of memory spaces.
+ *
+ * Results are asymmetric — both `src -> dst` and `dst -> src` are measured.
+ *
+ * Pair rules:
+ *   - GPU and HOST spaces are measured against each other in both directions, including
+ *     self-to-self across distinct device ids.
+ *   - DISK spaces are measured against each GPU and HOST space only (no disk-to-disk).
+ *   - Pairs that reduce to the same memory space id are skipped.
+ *
+ * Transfers flow through the converter registry, using the built-in canonical
+ * representation for each tier (GPU -> gpu_table_representation,
+ * HOST -> host_data_representation, DISK -> disk_data_representation). Pairs without a
+ * registered converter are marked `converter_available == false`.
+ *
+ * This function is pure and synchronous. It does not reserve through
+ * `memory_reservation_manager`; callers are expected to run it at init time when the
+ * target memory spaces are otherwise idle.
+ *
+ * Each DISK `memory_space` owns its own I/O backend, so the profile reflects whichever
+ * backend each disk space was constructed with — no separate backend parameter is needed.
+ * At least one GPU space must be present: it is used to materialize the canonical source
+ * cudf table that seeds every pairwise transfer.
+ *
+ * @param spaces   The memory spaces to profile.
+ * @param registry Converter registry to dispatch through. Pass a registry populated by
+ *                 `register_builtin_converters` plus any user-supplied converters.
+ * @param config   Measurement knobs; defaults probe a size sweep.
+ *
+ * @return `bandwidth_profile` containing one `bandwidth_pair_result` per ordered pair considered.
+ *
+ * @throws std::invalid_argument if no GPU space is present in `spaces`.
+ */
+[[nodiscard]] bandwidth_profile measure_bandwidth(std::span<memory::memory_space* const> spaces,
+                                                  const representation_converter_registry& registry,
+                                                  const bandwidth_profile_config& config = {});
+
+}  // namespace data
+}  // namespace cucascade

--- a/include/cucascade/memory/chunked_resource_info.hpp
+++ b/include/cucascade/memory/chunked_resource_info.hpp
@@ -1,0 +1,58 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cstddef>
+
+namespace cucascade {
+namespace memory {
+
+/**
+ * @brief Opt-in mixin interface for memory resources that allocate in fixed-size chunks.
+ *
+ * A memory resource that hands out bounded-size chunks rather than arbitrary contiguous
+ * ranges can inherit from this interface (alongside `rmm::mr::device_memory_resource`)
+ * to advertise its chunk size. Probing code can then use `dynamic_cast` to detect
+ * chunked allocators without coupling to specific allocator types.
+ *
+ * Allocators that do not inherit from this interface are treated as contiguous
+ * (a single allocation of the requested size).
+ *
+ * @code
+ * rmm::mr::device_memory_resource* mr = space.get_default_allocator();
+ * if (auto* chunked = dynamic_cast<cucascade::memory::chunked_resource_info const*>(mr)) {
+ *   auto chunk = chunked->max_chunk_bytes();
+ *   // ... iterate chunks ...
+ * } else {
+ *   // ... single contiguous allocation ...
+ * }
+ * @endcode
+ */
+struct chunked_resource_info {
+  virtual ~chunked_resource_info() = default;
+
+  /**
+   * @brief The maximum size in bytes of a single allocation from this chunked resource.
+   *
+   * Callers requesting more than this must issue multiple allocations.
+   */
+  [[nodiscard]] virtual std::size_t max_chunk_bytes() const = 0;
+};
+
+}  // namespace memory
+}  // namespace cucascade

--- a/include/cucascade/memory/fixed_size_host_memory_resource.hpp
+++ b/include/cucascade/memory/fixed_size_host_memory_resource.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cucascade/error.hpp>
+#include <cucascade/memory/chunked_resource_info.hpp>
 #include <cucascade/memory/common.hpp>
 #include <cucascade/memory/error.hpp>
 #include <cucascade/memory/memory_reservation.hpp>
@@ -64,7 +65,7 @@ namespace memory {
  * Modified to derive from device_memory_resource instead of host_memory_resource for RMM
  * compatibility.
  */
-class fixed_size_host_memory_resource {
+class fixed_size_host_memory_resource : public chunked_resource_info {
  public:
   static constexpr std::size_t default_block_size = 1 << 20;  ///< Default block size (1MB)
   static constexpr std::size_t default_pool_size  = 128;      ///< Default number of blocks in pool
@@ -251,6 +252,13 @@ class fixed_size_host_memory_resource {
    * @return std::size_t The size of each block in bytes
    */
   [[nodiscard]] std::size_t get_block_size() const noexcept;
+
+  /**
+   * @brief Advertise the per-allocation chunk size for chunked-allocator probes.
+   *
+   * Implements `chunked_resource_info::max_chunk_bytes()` by forwarding to `get_block_size()`.
+   */
+  [[nodiscard]] std::size_t max_chunk_bytes() const override { return get_block_size(); }
 
   /**
    * @brief Get the number of free blocks.

--- a/include/cucascade/memory/memory_space.hpp
+++ b/include/cucascade/memory/memory_space.hpp
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cucascade/memory/chunked_resource_info.hpp>
 #include <cucascade/memory/common.hpp>
 #include <cucascade/memory/config.hpp>
 #include <cucascade/memory/disk_access_limiter.hpp>
@@ -115,6 +116,14 @@ class memory_space {
 
   // Allocator management
   [[nodiscard]] rmm::device_async_resource_ref get_default_allocator() const noexcept;
+
+  /**
+   * @brief Probe the underlying allocator for the `chunked_resource_info` mixin.
+   *
+   * @return Non-null pointer to the mixin interface if the underlying allocator inherits from
+   * `chunked_resource_info`; `nullptr` otherwise (contiguous allocator).
+   */
+  [[nodiscard]] const chunked_resource_info* get_chunked_resource_info() const noexcept;
 
   template <typename T>
     requires(cuda::mr::resource_with<T, cuda::mr::device_accessible> ||

--- a/src/data/CMakeLists.txt
+++ b/src/data/CMakeLists.txt
@@ -17,7 +17,8 @@
 
 target_sources(
   cucascade_objects
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/cpu_data_representation.cpp
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/bandwidth_profiler.cpp
+          ${CMAKE_CURRENT_SOURCE_DIR}/cpu_data_representation.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/disk_data_representation.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/io_backend_registry.cpp
           ${CMAKE_CURRENT_SOURCE_DIR}/pipeline_io_backend.cpp

--- a/src/data/bandwidth_profiler.cpp
+++ b/src/data/bandwidth_profiler.cpp
@@ -1,0 +1,356 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cucascade/data/bandwidth_profiler.hpp>
+#include <cucascade/data/cpu_data_representation.hpp>
+#include <cucascade/data/disk_data_representation.hpp>
+#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/memory/chunked_resource_info.hpp>
+#include <cucascade/memory/memory_space.hpp>
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_device.hpp>
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/resource_ref.hpp>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <span>
+#include <stdexcept>
+#include <string>
+#include <typeindex>
+#include <vector>
+
+namespace cucascade {
+namespace data {
+
+namespace {
+
+/// Canonical `idata_representation` type for a tier — what the profiler uses as both the
+/// source-in-that-tier and the target-in-that-tier representation.
+std::type_index canonical_type_for(memory::Tier tier)
+{
+  switch (tier) {
+    case memory::Tier::GPU: return std::type_index(typeid(gpu_table_representation));
+    case memory::Tier::HOST: return std::type_index(typeid(host_data_representation));
+    case memory::Tier::DISK: return std::type_index(typeid(disk_data_representation));
+    default: throw std::invalid_argument("bandwidth_profiler: unsupported memory tier");
+  }
+}
+
+/// Probe an allocator for the chunked-resource mixin. Returns 0 for contiguous allocators.
+std::size_t probe_max_chunk_bytes(const memory::memory_space& space)
+{
+  auto const* chunked = space.get_chunked_resource_info();
+  return chunked != nullptr ? chunked->max_chunk_bytes() : 0;
+}
+
+/// Build a single-column INT32 cudf::table of approximately `size_bytes` bytes, allocated
+/// through the provided GPU memory resource reference.
+std::unique_ptr<cudf::table> make_gpu_table_of_size(std::size_t size_bytes,
+                                                    rmm::device_async_resource_ref gpu_mr,
+                                                    rmm::cuda_stream_view stream)
+{
+  constexpr std::size_t bytes_per_row = sizeof(std::int32_t);
+  auto num_rows                       = static_cast<cudf::size_type>(
+    std::max<std::size_t>(1, (size_bytes + bytes_per_row - 1) / bytes_per_row));
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  auto col = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::INT32}, num_rows, cudf::mask_state::UNALLOCATED, stream, gpu_mr);
+  cols.push_back(std::move(col));
+  return std::make_unique<cudf::table>(std::move(cols));
+}
+
+/// Materialize a source `idata_representation` of the given tier and size, living in `src_space`.
+/// Uses `bootstrap_gpu` as a scratch GPU space to build the initial cudf table. When `src_space`
+/// is a GPU other than the bootstrap, the GPU->GPU converter moves data across devices itself
+/// (it acquires a stream on the target GPU internally).
+std::unique_ptr<idata_representation> build_source_representation(
+  memory::memory_space* src_space,
+  memory::memory_space* bootstrap_gpu,
+  std::size_t size_bytes,
+  const representation_converter_registry& registry)
+{
+  // The initial cudf table MUST be allocated with the bootstrap GPU as the current CUDA device,
+  // otherwise cudf's scratch allocations land on the wrong GPU and we hit illegal-memory-access
+  // during subsequent cross-device work.
+  rmm::cuda_set_device_raii bootstrap_guard{rmm::cuda_device_id{bootstrap_gpu->get_device_id()}};
+
+  auto bootstrap_stream = bootstrap_gpu->acquire_stream();
+  auto gpu_mr           = bootstrap_gpu->get_default_allocator();
+  auto table            = make_gpu_table_of_size(size_bytes, gpu_mr, bootstrap_stream);
+  auto gpu_rep = std::make_unique<gpu_table_representation>(std::move(table), *bootstrap_gpu);
+  bootstrap_stream.synchronize();
+
+  // Step 2: land the data in the requested src space via the registry. The converter is
+  // responsible for switching device when moving data across GPUs.
+  if (src_space == bootstrap_gpu) { return gpu_rep; }
+
+  auto src_type = canonical_type_for(src_space->get_tier());
+  auto result   = registry.convert(*gpu_rep, src_type, src_space, bootstrap_stream);
+  // The converter may have enqueued async GPU reads from `gpu_rep`'s table on
+  // `bootstrap_stream`. Sync before `gpu_rep` goes out of scope — otherwise its cuDF table's
+  // RMM deallocation races with the in-flight copy and corrupts the converted output.
+  bootstrap_stream.synchronize();
+  return result;
+}
+
+/// Average a per-size sample set — pick the sample whose gbps is closest to the median as summary.
+bandwidth_sample compute_summary(const std::map<std::size_t, bandwidth_sample>& per_size)
+{
+  if (per_size.empty()) { return {}; }
+  std::vector<const bandwidth_sample*> samples;
+  samples.reserve(per_size.size());
+  for (auto const& [sz, s] : per_size) {
+    samples.push_back(&s);
+  }
+  std::sort(
+    samples.begin(), samples.end(), [](auto const* a, auto const* b) { return a->gbps < b->gbps; });
+  return *samples[samples.size() / 2];
+}
+
+/// Evict a file's contents from the OS page cache so the next read hits disk.
+/// Uses `posix_fadvise(POSIX_FADV_DONTNEED)` which is process-local and needs no privileges.
+/// Best-effort: silently ignores open/advise failures.
+void evict_page_cache(const std::string& path)
+{
+  int fd = ::open(path.c_str(), O_RDONLY);
+  if (fd < 0) return;
+  // Kernel drops DONTNEED pages lazily — syncing first ensures dirty pages are written out
+  // so they're actually eligible to drop.
+  ::fdatasync(fd);
+  (void)::posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
+  ::close(fd);
+}
+
+/// Core per-pair probe — warmup + timed loop around `registry.convert(...)`.
+bandwidth_sample measure_single_size(idata_representation& source,
+                                     std::type_index target_type,
+                                     memory::memory_space* dst_space,
+                                     const representation_converter_registry& registry,
+                                     rmm::cuda_stream_view stream,
+                                     std::size_t nominal_size_bytes,
+                                     std::size_t warmup_iters,
+                                     std::size_t timed_iters,
+                                     bool drop_page_cache_between_iters)
+{
+  // Grab the disk source's file path once so we can evict its page cache between iterations.
+  // For non-disk sources this stays empty and the evict call is skipped.
+  std::string disk_source_path;
+  if (auto const* disk_src = dynamic_cast<disk_data_representation const*>(&source)) {
+    disk_source_path = disk_src->get_disk_table().file_path;
+  }
+
+  auto evict_if_needed = [&]() {
+    if (drop_page_cache_between_iters && !disk_source_path.empty()) {
+      evict_page_cache(disk_source_path);
+    }
+  };
+
+  // Warmup — discard results.
+  for (std::size_t i = 0; i < warmup_iters; ++i) {
+    auto dst_rep = registry.convert(source, target_type, dst_space, stream);
+    stream.synchronize();
+    dst_rep.reset();
+    evict_if_needed();
+  }
+
+  // Timed loop. Time accumulated per-iteration around the transfer and synchronization only —
+  // page-cache eviction (fdatasync + posix_fadvise) happens AFTER each iteration's clock stops
+  // so it cannot inflate the reported bandwidth number.
+  using clock = std::chrono::steady_clock;
+  std::chrono::duration<double> elapsed{0};
+  for (std::size_t i = 0; i < timed_iters; ++i) {
+    auto iter_t0 = clock::now();
+    auto dst_rep = registry.convert(source, target_type, dst_space, stream);
+    stream.synchronize();
+    auto iter_t1 = clock::now();
+    elapsed += (iter_t1 - iter_t0);
+    dst_rep.reset();
+    evict_if_needed();
+  }
+  bandwidth_sample s{};
+  s.iterations_timed  = timed_iters;
+  s.bytes_transferred = nominal_size_bytes;
+  s.mean_seconds      = timed_iters > 0 ? elapsed.count() / static_cast<double>(timed_iters) : 0.0;
+  s.gbps =
+    s.mean_seconds > 0.0 ? static_cast<double>(nominal_size_bytes) / s.mean_seconds / 1.0e9 : 0.0;
+  return s;
+}
+
+bool should_skip_pair(const memory::memory_space& src,
+                      const memory::memory_space& dst,
+                      bool measure_disk_pairs)
+{
+  if (src.get_id() == dst.get_id()) return true;
+  if (src.get_tier() == memory::Tier::DISK && dst.get_tier() == memory::Tier::DISK) return true;
+  if (!measure_disk_pairs &&
+      (src.get_tier() == memory::Tier::DISK || dst.get_tier() == memory::Tier::DISK)) {
+    return true;
+  }
+  return false;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------------------------
+// bandwidth_profile lookups
+// ---------------------------------------------------------------------------------------------
+
+const bandwidth_pair_result* bandwidth_profile::find(memory::memory_space_id src,
+                                                     memory::memory_space_id dst) const noexcept
+{
+  for (auto const& p : pairs) {
+    if (p.src == src && p.dst == dst) return &p;
+  }
+  return nullptr;
+}
+
+double bandwidth_profile::gbps(memory::memory_space_id src,
+                               memory::memory_space_id dst) const noexcept
+{
+  auto const* p = find(src, dst);
+  if (p == nullptr || !p->converter_available) return 0.0;
+  return p->summary.gbps;
+}
+
+std::optional<bandwidth_sample> bandwidth_profile::sample(memory::memory_space_id src,
+                                                          memory::memory_space_id dst,
+                                                          std::size_t size_bytes) const
+{
+  auto const* p = find(src, dst);
+  if (p == nullptr) return std::nullopt;
+  auto it = p->per_size.find(size_bytes);
+  if (it == p->per_size.end()) return std::nullopt;
+  return it->second;
+}
+
+// ---------------------------------------------------------------------------------------------
+// measure_bandwidth
+// ---------------------------------------------------------------------------------------------
+
+bandwidth_profile measure_bandwidth(std::span<memory::memory_space* const> spaces,
+                                    const representation_converter_registry& registry,
+                                    const bandwidth_profile_config& config)
+{
+  bandwidth_profile profile;
+
+  // Locate bootstrap GPU space — used to materialize the canonical cudf source table that feeds
+  // every subsequent conversion. The profiler requires at least one GPU space in `spaces`.
+  memory::memory_space* bootstrap_gpu = nullptr;
+  for (auto* s : spaces) {
+    if (s == nullptr) continue;
+    if (s->get_tier() == memory::Tier::GPU && bootstrap_gpu == nullptr) {
+      bootstrap_gpu = s;
+      break;
+    }
+  }
+
+  if (bootstrap_gpu == nullptr) {
+    throw std::invalid_argument(
+      "bandwidth_profiler: at least one GPU memory_space must be present in `spaces`");
+  }
+
+  for (auto* src : spaces) {
+    if (src == nullptr) continue;
+    for (auto* dst : spaces) {
+      if (dst == nullptr) continue;
+      if (should_skip_pair(*src, *dst, config.measure_disk_pairs)) continue;
+
+      bandwidth_pair_result result;
+      result.src                 = src->get_id();
+      result.dst                 = dst->get_id();
+      result.src_max_chunk_bytes = probe_max_chunk_bytes(*src);
+      result.dst_max_chunk_bytes = probe_max_chunk_bytes(*dst);
+      result.converter_available = true;
+
+      auto const target_type = canonical_type_for(dst->get_tier());
+
+      // The registry lacks a type-only probe, so we detect unavailable converters lazily:
+      // if build_source_representation or the first convert() throws, we record the reason and
+      // skip remaining sizes for this pair.
+      //
+      // Streams are per-CUDA-context: passing a stream that belongs to a different device than
+      // where the source table's memory lives causes illegal-memory-access on cross-device copies
+      // (cudf::pack reads the source with the passed stream). So when the source tier is GPU we
+      // must use a stream from the source GPU; otherwise any GPU stream will do and we borrow
+      // the bootstrap's.
+      auto* stream_owner = src->get_tier() == memory::Tier::GPU
+                             ? src
+                             : (dst->get_tier() == memory::Tier::GPU ? dst : bootstrap_gpu);
+      auto stream        = stream_owner->acquire_stream();
+
+      for (auto size_bytes : config.test_sizes_bytes) {
+        try {
+          auto source = build_source_representation(src, bootstrap_gpu, size_bytes, registry);
+
+          // Pin the current CUDA context to the stream's device for the duration of the
+          // measurement loop. Some converter and disk-backend code paths allocate scratch on
+          // the current device rather than the stream's device — mismatch triggers
+          // cudaErrorInvalidValue / cudaErrorInvalidResourceHandle when src and dst straddle
+          // GPUs or the pipeline backend was initialized under a different context. This guard
+          // is placed AFTER build_source_representation so the bootstrap build can run with
+          // bootstrap_gpu as current.
+          std::optional<rmm::cuda_set_device_raii> device_guard;
+          if (stream_owner->get_tier() == memory::Tier::GPU) {
+            device_guard.emplace(rmm::cuda_device_id{stream_owner->get_device_id()});
+          }
+
+          // Ensure source construction is complete on the destination's stream (converters may
+          // enqueue work on it during the warmup iterations).
+          stream.synchronize();
+          auto sample = measure_single_size(*source,
+                                            target_type,
+                                            dst,
+                                            registry,
+                                            stream,
+                                            size_bytes,
+                                            config.warmup_iterations,
+                                            config.timed_iterations,
+                                            config.drop_page_cache_between_iters);
+          result.per_size.emplace(size_bytes, sample);
+        } catch (const std::exception& e) {
+          result.converter_available = false;
+          result.unavailable_reason  = e.what();
+          result.per_size.clear();
+          break;
+        }
+      }
+
+      if (result.converter_available) { result.summary = compute_summary(result.per_size); }
+      profile.pairs.push_back(std::move(result));
+    }
+  }
+
+  return profile;
+}
+
+}  // namespace data
+}  // namespace cucascade

--- a/src/data/pipeline_io_backend.cpp
+++ b/src/data/pipeline_io_backend.cpp
@@ -37,6 +37,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <unordered_map>
 #include <vector>
 
 namespace cucascade {
@@ -146,16 +147,29 @@ class pipeline_io_backend : public idisk_io_backend {
  public:
   explicit pipeline_io_backend(bool direct_io) : _direct_io(direct_io)
   {
+    // Pinned host buffers are context-independent under UVA — safe to share across GPUs.
     CUCASCADE_CUDA_TRY(cudaMallocHost(&_buf[0], PIPELINE_BUF_SIZE));
     CUCASCADE_CUDA_TRY(cudaMallocHost(&_buf[1], PIPELINE_BUF_SIZE));
-    CUCASCADE_CUDA_TRY(cudaStreamCreate(&_copy_stream));
-    CUCASCADE_CUDA_TRY(cudaEventCreateWithFlags(&_order_event, cudaEventDisableTiming));
+    // The copy stream and order event are CUDA-context-specific. They are created lazily
+    // per device in get_device_resources() so this backend works across multiple GPU
+    // contexts within the same process.
   }
 
   ~pipeline_io_backend() noexcept override
   {
-    cudaEventDestroy(_order_event);
-    cudaStreamDestroy(_copy_stream);
+    // Save and restore the caller thread's current CUDA device. Without this, the final
+    // cudaSetDevice in the loop below would silently leak out of the destructor, changing
+    // the current device for any code that runs after this backend is destroyed.
+    int saved_dev = 0;
+    cudaGetDevice(&saved_dev);
+    for (auto& [dev, res] : _per_device) {
+      // Destroy each resource under the device where it was created. CUDA event/stream
+      // handles from one context are invalid in another, so the set-device call matters.
+      cudaSetDevice(dev);
+      cudaEventDestroy(res.order_event);
+      cudaStreamDestroy(res.copy_stream);
+    }
+    cudaSetDevice(saved_dev);
     if (_buf[0]) { cudaFreeHost(_buf[0]); }
     if (_buf[1]) { cudaFreeHost(_buf[1]); }
   }
@@ -173,9 +187,15 @@ class pipeline_io_backend : public idisk_io_backend {
   {
     if (size == 0) return;
 
+    // Serialize: shared pinned buffers and per-device (copy_stream, order_event) must not be
+    // used concurrently by multiple threads.
+    std::lock_guard<std::mutex> io_lock(_device_io_mutex);
+
+    auto& res = get_device_resources();
+
     // Ensure all GPU work on the caller's stream completes before D2H copies begin
-    CUCASCADE_CUDA_TRY(cudaEventRecord(_order_event, stream.value()));
-    CUCASCADE_CUDA_TRY(cudaStreamWaitEvent(_copy_stream, _order_event));
+    CUCASCADE_CUDA_TRY(cudaEventRecord(res.order_event, stream.value()));
+    CUCASCADE_CUDA_TRY(cudaStreamWaitEvent(res.copy_stream, res.order_event));
 
     int flags = O_CREAT | O_WRONLY;
     if (_direct_io) { flags |= O_DIRECT; }
@@ -198,8 +218,8 @@ class pipeline_io_backend : public idisk_io_backend {
                                          static_cast<const char*>(dev_ptr) + src_offset,
                                          chunk,
                                          cudaMemcpyDeviceToHost,
-                                         _copy_stream));
-      CUCASCADE_CUDA_TRY(cudaStreamSynchronize(_copy_stream));
+                                         res.copy_stream));
+      CUCASCADE_CUDA_TRY(cudaStreamSynchronize(res.copy_stream));
 
       // Wait for previous disk write to finish before reusing that buffer
       if (write_future.valid()) { write_future.get(); }
@@ -242,9 +262,15 @@ class pipeline_io_backend : public idisk_io_backend {
   {
     if (size == 0) return;
 
+    // Serialize: shared pinned buffers and per-device (copy_stream, order_event) must not be
+    // used concurrently by multiple threads.
+    std::lock_guard<std::mutex> io_lock(_device_io_mutex);
+
+    auto& res = get_device_resources();
+
     // Ensure caller's stream work completes before we use the destination buffer
-    CUCASCADE_CUDA_TRY(cudaEventRecord(_order_event, stream.value()));
-    CUCASCADE_CUDA_TRY(cudaStreamWaitEvent(_copy_stream, _order_event));
+    CUCASCADE_CUDA_TRY(cudaEventRecord(res.order_event, stream.value()));
+    CUCASCADE_CUDA_TRY(cudaStreamWaitEvent(res.copy_stream, res.order_event));
 
     int flags = O_RDONLY;
     if (_direct_io) { flags |= O_DIRECT; }
@@ -283,7 +309,7 @@ class pipeline_io_backend : public idisk_io_backend {
                                            _buf[cur],
                                            chunks_to_copy,
                                            cudaMemcpyHostToDevice,
-                                           _copy_stream));
+                                           res.copy_stream));
         dst_offset += chunks_to_copy;
       }
 
@@ -308,7 +334,7 @@ class pipeline_io_backend : public idisk_io_backend {
       }
 
       // Wait for H2D copy to complete
-      if (chunks_to_copy > 0) { CUCASCADE_CUDA_TRY(cudaStreamSynchronize(_copy_stream)); }
+      if (chunks_to_copy > 0) { CUCASCADE_CUDA_TRY(cudaStreamSynchronize(res.copy_stream)); }
 
       // Wait for disk read to complete
       if (read_future.valid()) { read_future.get(); }
@@ -373,9 +399,15 @@ class pipeline_io_backend : public idisk_io_backend {
   {
     if (entries.empty()) return;
 
+    // Serialize: shared pinned buffers and per-device (copy_stream, order_event) must not be
+    // used concurrently by multiple threads.
+    std::lock_guard<std::mutex> io_lock(_device_io_mutex);
+
+    auto& res = get_device_resources();
+
     // Ensure all GPU work on the caller's stream completes before D2H copies begin
-    CUCASCADE_CUDA_TRY(cudaEventRecord(_order_event, stream.value()));
-    CUCASCADE_CUDA_TRY(cudaStreamWaitEvent(_copy_stream, _order_event));
+    CUCASCADE_CUDA_TRY(cudaEventRecord(res.order_event, stream.value()));
+    CUCASCADE_CUDA_TRY(cudaStreamWaitEvent(res.copy_stream, res.order_event));
 
     int flags = O_CREAT | O_WRONLY;
     if (_direct_io) { flags |= O_DIRECT; }
@@ -408,8 +440,8 @@ class pipeline_io_backend : public idisk_io_backend {
     for (const auto& c : chunks) {
       // D2H copy into current buffer
       CUCASCADE_CUDA_TRY(
-        cudaMemcpyAsync(_buf[cur], c.src, c.size, cudaMemcpyDeviceToHost, _copy_stream));
-      CUCASCADE_CUDA_TRY(cudaStreamSynchronize(_copy_stream));
+        cudaMemcpyAsync(_buf[cur], c.src, c.size, cudaMemcpyDeviceToHost, res.copy_stream));
+      CUCASCADE_CUDA_TRY(cudaStreamSynchronize(res.copy_stream));
 
       // Wait for previous write to finish (so we can reuse its buffer next iteration)
       if (write_future.valid()) { write_future.get(); }
@@ -439,11 +471,38 @@ class pipeline_io_backend : public idisk_io_backend {
   }
 
  private:
+  struct device_resources {
+    cudaStream_t copy_stream{};
+    cudaEvent_t order_event{};
+  };
+
+  /// Return stream+event for the current CUDA device, lazy-creating on first access.
+  /// Subsequent lookups return the cached pair. References remain stable across inserts
+  /// because `std::unordered_map` does not invalidate value references on rehash.
+  device_resources& get_device_resources()
+  {
+    int dev = 0;
+    CUCASCADE_CUDA_TRY(cudaGetDevice(&dev));
+    std::lock_guard<std::mutex> lock(_resources_mutex);
+    auto it = _per_device.find(dev);
+    if (it != _per_device.end()) { return it->second; }
+    device_resources res{};
+    CUCASCADE_CUDA_TRY(cudaStreamCreate(&res.copy_stream));
+    CUCASCADE_CUDA_TRY(cudaEventCreateWithFlags(&res.order_event, cudaEventDisableTiming));
+    return _per_device.emplace(dev, res).first->second;
+  }
+
   void* _buf[2]{nullptr, nullptr};
-  cudaStream_t _copy_stream{};
-  cudaEvent_t _order_event{};
   bool _direct_io;
   io_worker _io_worker;
+  std::mutex _resources_mutex;
+  std::unordered_map<int, device_resources> _per_device;
+  // Serializes the device read/write paths so concurrent callers don't race on the shared
+  // pinned buffers (_buf[0], _buf[1]) or on a device's shared (copy_stream, order_event).
+  // This matches the project's "disk I/O must be safe for concurrent use" constraint —
+  // correctness, not parallelism. A per-call pool of (buffer, stream, event) contexts would
+  // unlock true concurrency; deferred until needed.
+  std::mutex _device_io_mutex;
 };
 
 }  // namespace

--- a/src/memory/memory_space.cpp
+++ b/src/memory/memory_space.cpp
@@ -293,6 +293,20 @@ rmm::device_async_resource_ref memory_space::get_default_allocator() const noexc
     const_cast<cuda::mr::any_resource<cuda::mr::device_accessible>&>(_allocator));
 }
 
+const chunked_resource_info* memory_space::get_chunked_resource_info() const noexcept
+{
+  const chunked_resource_info* result = nullptr;
+  std::visit(
+    [&result](const auto& ptr) {
+      using held_type = std::remove_reference_t<decltype(*ptr)>;
+      if constexpr (std::is_base_of_v<chunked_resource_info, held_type>) {
+        if (ptr != nullptr) { result = static_cast<const chunked_resource_info*>(ptr.get()); }
+      }
+    },
+    _reservation_allocator);
+  return result;
+}
+
 std::string_view memory_space::get_disk_mount_path() const
 {
   if (_id.tier != Tier::DISK) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,6 +37,7 @@ set(TEST_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/memory/test_topology_discovery.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/memory/test_gpu_kernels.cu
     # Data tests
+    ${CMAKE_CURRENT_SOURCE_DIR}/data/test_bandwidth_profiler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data/test_data_batch.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data/test_data_repository.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data/test_data_repository_manager.cpp

--- a/test/data/test_bandwidth_profiler.cpp
+++ b/test/data/test_bandwidth_profiler.cpp
@@ -1,0 +1,443 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "utils/mock_test_utils.hpp"
+
+#include <cucascade/data/bandwidth_profiler.hpp>
+#include <cucascade/data/representation_converter.hpp>
+#include <cucascade/memory/chunked_resource_info.hpp>
+#include <cucascade/memory/fixed_size_host_memory_resource.hpp>
+#include <cucascade/memory/memory_space.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <catch2/catch.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using namespace cucascade;
+using cucascade::data::bandwidth_profile;
+using cucascade::data::bandwidth_profile_config;
+using cucascade::data::measure_bandwidth;
+using cucascade::test::make_mock_memory_space;
+
+// Shared memory spaces across the bandwidth profiler test cases — avoids the CUDA-context
+// degradation we've seen from repeated memory_space creation/destruction in the converter tests.
+namespace {
+
+auto& shared_gpu_space()
+{
+  static auto s = make_mock_memory_space(memory::Tier::GPU, 0);
+  return s;
+}
+
+auto& shared_host_space()
+{
+  static auto s = make_mock_memory_space(memory::Tier::HOST, 0);
+  return s;
+}
+
+auto& shared_disk_space()
+{
+  static auto s = make_mock_memory_space(memory::Tier::DISK, 0);
+  return s;
+}
+
+bandwidth_profile_config tiny_config()
+{
+  bandwidth_profile_config cfg;
+  cfg.test_sizes_bytes   = {64ull * 1024};  // single 64 KiB size keeps the tests fast
+  cfg.warmup_iterations  = 1;
+  cfg.timed_iterations   = 2;
+  cfg.measure_disk_pairs = true;
+  return cfg;
+}
+
+}  // namespace
+
+// =============================================================================
+// chunked_resource_info mixin detection
+// =============================================================================
+
+TEST_CASE("chunked_resource_info is exposed by fixed_size_host_memory_resource",
+          "[bandwidth_profiler][chunked_resource_info]")
+{
+  // A HOST memory_space uses fixed_size_host_memory_resource as its reservation allocator, which
+  // inherits chunked_resource_info. GPU and DISK spaces do not.
+  auto& gpu  = shared_gpu_space();
+  auto& host = shared_host_space();
+  auto& disk = shared_disk_space();
+
+  CHECK(gpu->get_chunked_resource_info() == nullptr);
+  CHECK(disk->get_chunked_resource_info() == nullptr);
+
+  auto const* host_info = host->get_chunked_resource_info();
+  REQUIRE(host_info != nullptr);
+  CHECK(host_info->max_chunk_bytes() > 0);
+}
+
+// =============================================================================
+// Input validation
+// =============================================================================
+
+TEST_CASE("measure_bandwidth rejects input without a GPU space", "[bandwidth_profiler]")
+{
+  representation_converter_registry registry;
+  register_builtin_converters(registry);
+
+  auto& host              = shared_host_space();
+  auto& disk              = shared_disk_space();
+  std::array spaces_array = {host.get(), disk.get()};
+  std::span<memory::memory_space* const> spaces{spaces_array};
+
+  REQUIRE_THROWS_AS(measure_bandwidth(spaces, registry, tiny_config()), std::invalid_argument);
+}
+
+// =============================================================================
+// Pair enumeration rules — GPU/HOST/DISK, no disk-to-disk, no self, bidirectional
+// =============================================================================
+
+TEST_CASE("measure_bandwidth enumerates pairs with bidirectional entries and no disk-to-disk",
+          "[bandwidth_profiler]")
+{
+  representation_converter_registry registry;
+  register_builtin_converters(registry);
+
+  auto& gpu   = shared_gpu_space();
+  auto& host  = shared_host_space();
+  auto& disk  = shared_disk_space();
+  auto& disk2 = []() -> auto& {
+    static auto s = make_mock_memory_space(memory::Tier::DISK, 1);
+    return s;
+  }();
+
+  std::array spaces_array = {gpu.get(), host.get(), disk.get(), disk2.get()};
+  std::span<memory::memory_space* const> spaces{spaces_array};
+
+  auto profile = measure_bandwidth(spaces, registry, tiny_config());
+
+  // No self-pair and no disk-to-disk.
+  for (auto const& pair : profile.pairs) {
+    CHECK(pair.src != pair.dst);
+    CHECK_FALSE((pair.src.tier == memory::Tier::DISK && pair.dst.tier == memory::Tier::DISK));
+  }
+
+  // Bidirectional: whenever (A -> B) is present, (B -> A) must also be present (even if
+  // one direction is marked unavailable).
+  for (auto const& ab : profile.pairs) {
+    auto const* ba = profile.find(ab.dst, ab.src);
+    INFO("missing reverse pair for " << static_cast<int>(ab.src.tier) << "->"
+                                     << static_cast<int>(ab.dst.tier));
+    CHECK(ba != nullptr);
+  }
+
+  // GPU-HOST pair should be present in both directions.
+  CHECK(profile.find(gpu->get_id(), host->get_id()) != nullptr);
+  CHECK(profile.find(host->get_id(), gpu->get_id()) != nullptr);
+  // GPU-DISK pair present.
+  CHECK(profile.find(gpu->get_id(), disk->get_id()) != nullptr);
+  CHECK(profile.find(disk->get_id(), gpu->get_id()) != nullptr);
+  // disk-to-disk absent.
+  CHECK(profile.find(disk->get_id(), disk2->get_id()) == nullptr);
+  CHECK(profile.find(disk2->get_id(), disk->get_id()) == nullptr);
+}
+
+// =============================================================================
+// Size override is honored
+// =============================================================================
+
+TEST_CASE("measure_bandwidth records only the configured sizes per pair", "[bandwidth_profiler]")
+{
+  representation_converter_registry registry;
+  register_builtin_converters(registry);
+
+  auto& gpu             = shared_gpu_space();
+  auto& host            = shared_host_space();
+  std::array spaces_arr = {gpu.get(), host.get()};
+  std::span<memory::memory_space* const> spaces{spaces_arr};
+
+  bandwidth_profile_config cfg;
+  cfg.test_sizes_bytes   = {8ull * 1024, 64ull * 1024};
+  cfg.warmup_iterations  = 1;
+  cfg.timed_iterations   = 2;
+  cfg.measure_disk_pairs = false;
+
+  auto profile = measure_bandwidth(spaces, registry, cfg);
+
+  auto const* gh = profile.find(gpu->get_id(), host->get_id());
+  REQUIRE(gh != nullptr);
+  if (gh->converter_available) {
+    CHECK(gh->per_size.size() == cfg.test_sizes_bytes.size());
+    for (auto sz : cfg.test_sizes_bytes) {
+      CHECK(gh->per_size.count(sz) == 1);
+    }
+  }
+}
+
+// =============================================================================
+// Chunked detection is reflected in result metadata
+// =============================================================================
+
+TEST_CASE("per-pair result records chunk size for chunked source/destination spaces",
+          "[bandwidth_profiler][chunked_resource_info]")
+{
+  representation_converter_registry registry;
+  register_builtin_converters(registry);
+
+  auto& gpu             = shared_gpu_space();
+  auto& host            = shared_host_space();
+  std::array spaces_arr = {gpu.get(), host.get()};
+  std::span<memory::memory_space* const> spaces{spaces_arr};
+
+  auto profile = measure_bandwidth(spaces, registry, tiny_config());
+
+  // GPU allocator is contiguous; HOST allocator is fixed_size_host_memory_resource (chunked).
+  // So for every pair the chunked byte count should be > 0 on the HOST side and 0 on the GPU side.
+  for (auto const& pair : profile.pairs) {
+    if (pair.src.tier == memory::Tier::HOST) { CHECK(pair.src_max_chunk_bytes > 0); }
+    if (pair.src.tier == memory::Tier::GPU) { CHECK(pair.src_max_chunk_bytes == 0); }
+    if (pair.dst.tier == memory::Tier::HOST) { CHECK(pair.dst_max_chunk_bytes > 0); }
+    if (pair.dst.tier == memory::Tier::GPU) { CHECK(pair.dst_max_chunk_bytes == 0); }
+  }
+}
+
+// =============================================================================
+// Unavailable converter is reported, not thrown
+// =============================================================================
+
+TEST_CASE("pairs without a registered converter are reported as unavailable",
+          "[bandwidth_profiler]")
+{
+  // Empty registry — no converters registered.
+  representation_converter_registry registry;
+
+  auto& gpu             = shared_gpu_space();
+  auto& host            = shared_host_space();
+  std::array spaces_arr = {gpu.get(), host.get()};
+  std::span<memory::memory_space* const> spaces{spaces_arr};
+
+  auto profile = measure_bandwidth(spaces, registry, tiny_config());
+
+  // All enumerated pairs should be marked unavailable with a non-empty reason.
+  REQUIRE_FALSE(profile.pairs.empty());
+  for (auto const& pair : profile.pairs) {
+    CHECK_FALSE(pair.converter_available);
+    CHECK_FALSE(pair.unavailable_reason.empty());
+    CHECK(pair.per_size.empty());
+  }
+
+  // Summary lookup returns 0 for unavailable pairs.
+  CHECK(profile.gbps(gpu->get_id(), host->get_id()) == 0.0);
+  CHECK_FALSE(profile.sample(gpu->get_id(), host->get_id(), 64ull * 1024).has_value());
+}
+
+// =============================================================================
+// End-to-end smoke: real converters produce positive throughput
+// =============================================================================
+
+// =============================================================================
+// Hidden: prints the full bandwidth matrix for the provided spaces.
+//
+//   Run with:  ./build/release/test/cucascade_tests "[bandwidth_matrix]"
+//   Or:        pixi run test -- "[bandwidth_matrix]"
+//
+// The tag leads with `.` so it's excluded from the default `[~@nonunit]` run.
+// =============================================================================
+
+namespace {
+
+std::string format_space_id(memory::memory_space_id id)
+{
+  std::ostringstream os;
+  switch (id.tier) {
+    case memory::Tier::GPU: os << "GPU"; break;
+    case memory::Tier::HOST: os << "HOST"; break;
+    case memory::Tier::DISK: os << "DISK"; break;
+    default: os << "???"; break;
+  }
+  os << ":" << id.device_id;
+  return os.str();
+}
+
+std::string format_bytes(std::size_t bytes)
+{
+  std::ostringstream os;
+  if (bytes >= (1ull << 30)) {
+    os << (bytes / (1ull << 30)) << " GiB";
+  } else if (bytes >= (1ull << 20)) {
+    os << (bytes / (1ull << 20)) << " MiB";
+  } else if (bytes >= (1ull << 10)) {
+    os << (bytes / (1ull << 10)) << " KiB";
+  } else {
+    os << bytes << " B";
+  }
+  return os.str();
+}
+
+}  // namespace
+
+TEST_CASE("print bandwidth matrix", "[.bandwidth_matrix]")
+{
+  representation_converter_registry registry;
+  register_builtin_converters(registry);
+
+  int device_count = 0;
+  cudaGetDeviceCount(&device_count);
+
+  auto& gpu  = shared_gpu_space();
+  auto& host = shared_host_space();
+  auto& disk = shared_disk_space();
+
+  // Discover additional GPUs at runtime so the matrix test works on 1-GPU and N-GPU hosts.
+  std::vector<std::shared_ptr<memory::memory_space>> extra_gpus;
+  for (int d = 1; d < device_count; ++d) {
+    extra_gpus.push_back(make_mock_memory_space(memory::Tier::GPU, static_cast<std::size_t>(d)));
+  }
+
+  std::vector<memory::memory_space*> spaces_vec;
+  spaces_vec.push_back(gpu.get());
+  for (auto& s : extra_gpus) {
+    spaces_vec.push_back(s.get());
+  }
+  spaces_vec.push_back(host.get());
+  spaces_vec.push_back(disk.get());
+  std::span<memory::memory_space* const> spaces{spaces_vec};
+
+  cucascade::data::bandwidth_profile_config cfg;
+  cfg.test_sizes_bytes              = {1ull << 20, 16ull << 20, 64ull << 20};
+  cfg.warmup_iterations             = 2;
+  cfg.timed_iterations              = 5;
+  cfg.measure_disk_pairs            = true;
+  cfg.drop_page_cache_between_iters = true;
+
+  auto profile = measure_bandwidth(spaces, registry, cfg);
+
+  std::ostringstream out;
+  out << "\n\n=== Bandwidth Profile ===\n";
+  out << "Detected " << device_count << " CUDA device(s); page-cache eviction "
+      << (cfg.drop_page_cache_between_iters ? "ON" : "off") << "\n";
+  out << "Spaces:\n";
+  for (std::size_t i = 0; i < spaces_vec.size(); ++i) {
+    auto const* mr_info = spaces_vec[i]->get_chunked_resource_info();
+    out << "  [" << i << "] " << format_space_id(spaces_vec[i]->get_id());
+    if (mr_info != nullptr) {
+      out << "  (chunked, " << format_bytes(mr_info->max_chunk_bytes()) << " blocks)";
+    } else {
+      out << "  (contiguous)";
+    }
+    out << "\n";
+  }
+
+  out << "\nSummary GB/s (row = src, column = dst)\n";
+  out << std::setw(12) << " ";
+  for (auto* dst : spaces_vec) {
+    out << std::setw(12) << format_space_id(dst->get_id());
+  }
+  out << "\n";
+  for (auto* src : spaces_vec) {
+    out << std::setw(12) << format_space_id(src->get_id());
+    for (auto* dst : spaces_vec) {
+      if (src == dst) {
+        out << std::setw(12) << "-";
+      } else {
+        auto const* pair = profile.find(src->get_id(), dst->get_id());
+        if (pair == nullptr) {
+          out << std::setw(12) << "n/a";
+        } else if (!pair->converter_available) {
+          out << std::setw(12) << "no-conv";
+        } else {
+          std::ostringstream cell;
+          cell << std::fixed << std::setprecision(2) << pair->summary.gbps;
+          out << std::setw(12) << cell.str();
+        }
+      }
+    }
+    out << "\n";
+  }
+
+  out << "\nPer-size detail (median-picked summary marked *):\n";
+  for (auto const& pair : profile.pairs) {
+    out << "  " << format_space_id(pair.src) << " -> " << format_space_id(pair.dst);
+    if (!pair.converter_available) {
+      out << "  [unavailable: " << pair.unavailable_reason << "]\n";
+      continue;
+    }
+    out << "  (summary " << std::fixed << std::setprecision(2) << pair.summary.gbps << " GB/s)\n";
+    for (auto const& [size_bytes, sample] : pair.per_size) {
+      bool is_summary = (sample.gbps == pair.summary.gbps);
+      out << "      " << std::setw(8) << format_bytes(size_bytes) << ":  " << std::fixed
+          << std::setprecision(2) << std::setw(7) << sample.gbps << " GB/s  ("
+          << std::setprecision(3) << (sample.mean_seconds * 1e3) << " ms/iter, "
+          << sample.iterations_timed << " iters)" << (is_summary ? "  *" : "") << "\n";
+    }
+  }
+  out << "\n";
+
+  std::cerr << out.str();
+
+  // Also write to a stable file path so we can view the matrix from outside ctest
+  // (which suppresses stdout on success).
+  const char* out_path_env = std::getenv("CUCASCADE_BANDWIDTH_MATRIX_OUT");
+  std::filesystem::path out_path =
+    out_path_env != nullptr ? out_path_env : "/tmp/cucascade_bandwidth_matrix.txt";
+  {
+    std::ofstream f(out_path);
+    f << out.str();
+  }
+
+  // Sanity check so the test can still fail if the profiler produced nothing.
+  REQUIRE_FALSE(profile.pairs.empty());
+}
+
+TEST_CASE("measure_bandwidth produces positive gbps for GPU<->HOST with builtin converters",
+          "[bandwidth_profiler][integration]")
+{
+  representation_converter_registry registry;
+  register_builtin_converters(registry);
+
+  auto& gpu             = shared_gpu_space();
+  auto& host            = shared_host_space();
+  std::array spaces_arr = {gpu.get(), host.get()};
+  std::span<memory::memory_space* const> spaces{spaces_arr};
+
+  auto profile = measure_bandwidth(spaces, registry, tiny_config());
+
+  auto const* gh = profile.find(gpu->get_id(), host->get_id());
+  auto const* hg = profile.find(host->get_id(), gpu->get_id());
+  REQUIRE(gh != nullptr);
+  REQUIRE(hg != nullptr);
+
+  if (gh->converter_available) {
+    CHECK(gh->summary.gbps > 0.0);
+    CHECK(gh->summary.mean_seconds > 0.0);
+    CHECK(gh->summary.bytes_transferred > 0);
+  }
+  if (hg->converter_available) {
+    CHECK(hg->summary.gbps > 0.0);
+    CHECK(hg->summary.mean_seconds > 0.0);
+  }
+}


### PR DESCRIPTION
Introduces measure_bandwidth() — a pure init-time function that measures pairwise transfer throughput between a set of memory_space objects via the converter registry. Produces an asymmetric bandwidth_profile that engines can consume for routing decisions.

* chunked_resource_info — opt-in mixin letting allocators that hand out fixed-size chunks advertise max_chunk_bytes() without altering the rmm::mr::device_memory_resource contract. fixed_size_host_memory_resource inherits it; memory_space exposes the probe via get_chunked_resource_info().
* bandwidth_profiler — enumerates GPU/HOST all-pairs plus disk<->{GPU,HOST} (no disk<->disk), measures both directions, records per-size samples and a median summary per pair. Uses converters so user-registered overrides are honored. Optional posix_fadvise(DONTNEED) between timed iterations evicts source files from the page cache so disk reads reflect real NVMe throughput instead of cached reads.
* pipeline_io_backend — replace the single shared copy_stream/order_event with a per-device cache, lazy-created on first use from each GPU context. Unblocks cross-context usage (e.g. GPU:N <-> DISK for N > 0) which previously failed with cudaErrorInvalidResourceHandle.
* Design doc at docs/bandwidth-profiler.md.