### PR TITLE
Feature: Allow creation of gpu_data_represenaiton from cudf::table_view

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,8 +121,8 @@ set(CUCASCADE_PUBLIC_INCLUDE_DIRS
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
-set(CUCASCADE_PUBLIC_LINK_LIBS rmm::rmm cudf::cudf CUDA::cudart Threads::Threads
-                               ${NUMA_LIB})
+set(CUCASCADE_PUBLIC_LINK_LIBS rmm::rmm cudf::cudf CUDA::cudart
+                               Threads::Threads ${NUMA_LIB})
 
 # Set include directories for the object library
 target_include_directories(cucascade_objects

--- a/docs/data-management.md
+++ b/docs/data-management.md
@@ -81,8 +81,8 @@ class gpu_table_representation : public idata_representation {
     std::unique_ptr<cudf::table> _table;
 
 public:
-    const cudf::table& get_table() const;
-    std::unique_ptr<cudf::table> release_table();  // Transfer ownership
+    const cudf::table& get_table(rmm::cuda_stream_view stream) const;
+    std::unique_ptr<cudf::table> release_table(rmm::cuda_stream_view stream);  // Transfer ownership
 
     std::size_t get_size_in_bytes() const override;
     std::unique_ptr<idata_representation> clone(rmm::cuda_stream_view stream) override;
@@ -218,7 +218,7 @@ auto result = batch.try_to_lock_for_processing(memory_space_id);
 if (result.success) {
     // result.handle is a data_batch_processing_handle
     auto& data = batch.get_data()->cast<gpu_table_representation>();
-    process(data.get_table());
+    process(data.get_table(stream));
     // handle destructs here -> processing_count--
     // if count reaches 0: processing -> idle (or task_created if tasks pending)
 }

--- a/docs/data-management.md
+++ b/docs/data-management.md
@@ -81,7 +81,6 @@ class gpu_table_representation : public idata_representation {
     std::unique_ptr<cudf::table> _table;
 
 public:
-    const cudf::table& get_table(rmm::cuda_stream_view stream) const;
     std::unique_ptr<cudf::table> release_table(rmm::cuda_stream_view stream);  // Transfer ownership
 
     std::size_t get_size_in_bytes() const override;
@@ -218,7 +217,7 @@ auto result = batch.try_to_lock_for_processing(memory_space_id);
 if (result.success) {
     // result.handle is a data_batch_processing_handle
     auto& data = batch.get_data()->cast<gpu_table_representation>();
-    process(data.get_table(stream));
+    process(data.get_table_view());
     // handle destructs here -> processing_count--
     // if count reaches 0: processing -> idle (or task_created if tasks pending)
 }

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -454,7 +454,8 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
    * When transitioning from task_created, the task_created_count is preserved
    * so the pending task remains valid after the data is moved.
    *
-   * @return true if the batch was successfully locked (processing_count == 0 and state is idle or task_created with task_created_count > 0)
+   * @return true if the batch was successfully locked (processing_count == 0 and state is idle or
+   * task_created with task_created_count > 0)
    * @return false if the batch could not be locked
    */
   bool try_to_lock_for_in_transit();

--- a/include/cucascade/data/data_repository_manager.hpp
+++ b/include/cucascade/data/data_repository_manager.hpp
@@ -203,7 +203,6 @@ class data_repository_manager {
     return leaked;
   }
 
-  
   /**
    * @brief Iterate over all repositories, calling the visitor for each one.
    *

--- a/include/cucascade/data/gpu_data_representation.hpp
+++ b/include/cucascade/data/gpu_data_representation.hpp
@@ -27,7 +27,6 @@
 #include <cstddef>
 #include <memory>
 #include <variant>
-#include <vector>
 
 namespace cucascade {
 
@@ -88,13 +87,6 @@ class gpu_table_representation : public idata_representation {
    * @return std::unique_ptr<idata_representation> A new gpu_table_representation with copied data
    */
   std::unique_ptr<idata_representation> clone(rmm::cuda_stream_view stream) override;
-
-  /**
-   * @brief Get the underlying cuDF table
-   *
-   * @return const cudf::table& Reference to the cuDF table
-   */
-  const cudf::table& get_table(rmm::cuda_stream_view stream) const;
 
   /**
    * @brief Get the underlying cuDF table view

--- a/include/cucascade/data/gpu_data_representation.hpp
+++ b/include/cucascade/data/gpu_data_representation.hpp
@@ -21,8 +21,12 @@
 #include <cucascade/memory/memory_space.hpp>
 
 #include <cudf/table/table.hpp>
+#include <cudf/table/table_view.hpp>
 
+#include <any>
+#include <cstddef>
 #include <memory>
+#include <variant>
 #include <vector>
 
 namespace cucascade {
@@ -47,6 +51,19 @@ class gpu_table_representation : public idata_representation {
    * @param memory_space The memory space where the GPU table resides
    */
   gpu_table_representation(std::unique_ptr<cudf::table> table,
+                           cucascade::memory::memory_space& memory_space);
+
+  /**
+   * @brief Construct a new gpu_table_representation object
+   *
+   * @param table Unique pointer to the cuDF table with the data (ownership is transferred)
+   * @tparam Owner The type of the owner of the cuDF table (e.g., a specific operator or component)
+   * @param memory_space The memory space where the GPU table resides
+   */
+  template <typename Owner>
+  gpu_table_representation(cudf::table_view table_view,
+                           Owner&& owner,
+                           std::size_t alloc_size,
                            cucascade::memory::memory_space& memory_space);
 
   /**
@@ -77,7 +94,14 @@ class gpu_table_representation : public idata_representation {
    *
    * @return const cudf::table& Reference to the cuDF table
    */
-  const cudf::table& get_table() const;
+  const cudf::table& get_table(rmm::cuda_stream_view stream) const;
+
+  /**
+   * @brief Get the underlying cuDF table view
+   *
+   * @return cudf::table_view A view of the cuDF table
+   */
+  cudf::table_view get_table_view() const;
 
   /**
    * @brief Release ownership of the underlying cuDF table
@@ -86,11 +110,28 @@ class gpu_table_representation : public idata_representation {
    *
    * @return std::unique_ptr<cudf::table> The cuDF table
    */
-  std::unique_ptr<cudf::table> release_table();
+  std::unique_ptr<cudf::table> release_table(rmm::cuda_stream_view stream);
 
  private:
-  std::unique_ptr<cudf::table>
+  struct owning_table_view {
+    std::any owner;  ///< The owner of the cuDF table
+    std::size_t alloc_size{0};
+    cudf::table_view view;  ///< A view of the owned table for easy access
+  };
+
+  mutable std::variant<std::unique_ptr<cudf::table>, owning_table_view>
     _table;  ///< cudf::table is the underlying representation of the data
 };
+
+template <typename Owner>
+gpu_table_representation::gpu_table_representation(cudf::table_view table_view,
+                                                   Owner&& owner,
+                                                   std::size_t alloc_size,
+                                                   cucascade::memory::memory_space& memory_space)
+  : idata_representation(memory_space),
+    _table(
+      owning_table_view{std::make_any<Owner>(std::forward<Owner>(owner)), alloc_size, table_view})
+{
+}
 
 }  // namespace cucascade

--- a/include/cucascade/data/gpu_data_representation.hpp
+++ b/include/cucascade/data/gpu_data_representation.hpp
@@ -111,7 +111,7 @@ class gpu_table_representation : public idata_representation {
     cudf::table_view view;  ///< A view of the owned table for easy access
   };
 
-  mutable std::variant<std::unique_ptr<cudf::table>, owning_table_view>
+  std::variant<std::unique_ptr<cudf::table>, owning_table_view>
     _table;  ///< cudf::table is the underlying representation of the data
 };
 

--- a/include/cucascade/memory/common.hpp
+++ b/include/cucascade/memory/common.hpp
@@ -101,8 +101,7 @@ class legacy_rmm_resource_adapter {
     resource_->deallocate(rmm::cuda_stream_view{stream}, ptr, bytes);
   }
 
-  void* allocate_sync(std::size_t bytes,
-                      std::size_t alignment = alignof(std::max_align_t))
+  void* allocate_sync(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t))
   {
     auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
     rmm::cuda_stream_default.synchronize();
@@ -122,8 +121,7 @@ class legacy_rmm_resource_adapter {
     return resource_.get() == other.resource_.get();
   }
 
-  friend void get_property(legacy_rmm_resource_adapter const&,
-                           cuda::mr::device_accessible) noexcept
+  friend void get_property(legacy_rmm_resource_adapter const&, cuda::mr::device_accessible) noexcept
   {
   }
 

--- a/src/data/gpu_data_representation.cpp
+++ b/src/data/gpu_data_representation.cpp
@@ -28,21 +28,64 @@ gpu_table_representation::gpu_table_representation(std::unique_ptr<cudf::table> 
 {
 }
 
-std::size_t gpu_table_representation::get_size_in_bytes() const { return _table->alloc_size(); }
+std::size_t gpu_table_representation::get_size_in_bytes() const
+{
+  if (std::holds_alternative<std::unique_ptr<cudf::table>>(_table)) {
+    return std::get<std::unique_ptr<cudf::table>>(_table)->alloc_size();
+  } else if (std::holds_alternative<owning_table_view>(_table)) {
+    return std::get<owning_table_view>(_table).alloc_size;
+  }
+  return 0;
+}
 
 std::size_t gpu_table_representation::get_uncompressed_data_size_in_bytes() const
 {
   return get_size_in_bytes();
 }
 
-const cudf::table& gpu_table_representation::get_table() const { return *_table; }
+const cudf::table& gpu_table_representation::get_table(
+  [[maybe_unused]] rmm::cuda_stream_view stream) const
+{
+  if (std::holds_alternative<std::unique_ptr<cudf::table>>(_table)) {
+    return *std::get<std::unique_ptr<cudf::table>>(_table);
+  } else {
+    auto tbl = std::make_unique<cudf::table>(std::get<owning_table_view>(_table).view, stream);
+    _table   = std::move(tbl);
+    return *std::get<std::unique_ptr<cudf::table>>(_table);
+  }
+}
 
-std::unique_ptr<cudf::table> gpu_table_representation::release_table() { return std::move(_table); }
+cudf::table_view gpu_table_representation::get_table_view() const
+{
+  if (std::holds_alternative<std::unique_ptr<cudf::table>>(_table)) {
+    return std::get<std::unique_ptr<cudf::table>>(_table)->view();
+  } else {
+    return std::get<owning_table_view>(_table).view;
+  }
+}
+
+std::unique_ptr<cudf::table> gpu_table_representation::release_table(
+  [[maybe_unused]] rmm::cuda_stream_view stream)
+{
+  if (std::holds_alternative<std::unique_ptr<cudf::table>>(_table)) {
+    return std::move(std::get<std::unique_ptr<cudf::table>>(_table));
+  } else {
+    _table = std::make_unique<cudf::table>(std::get<owning_table_view>(_table).view, stream);
+    return std::move(std::get<std::unique_ptr<cudf::table>>(_table));
+  }
+}
 
 std::unique_ptr<idata_representation> gpu_table_representation::clone(rmm::cuda_stream_view stream)
 {
   // Create a deep copy of the cuDF table using the provided stream
-  auto table_copy = std::make_unique<cudf::table>(_table->view(), stream);
+  std::unique_ptr<cudf::table> table_copy;
+  if (std::holds_alternative<std::unique_ptr<cudf::table>>(_table)) {
+    auto& original_table = *std::get<std::unique_ptr<cudf::table>>(_table);
+    table_copy           = std::make_unique<cudf::table>(original_table, stream);
+  } else {
+    auto& owning_view = std::get<owning_table_view>(_table);
+    table_copy        = std::make_unique<cudf::table>(owning_view.view, stream);
+  }
   return std::make_unique<gpu_table_representation>(std::move(table_copy), get_memory_space());
 }
 

--- a/src/data/gpu_data_representation.cpp
+++ b/src/data/gpu_data_representation.cpp
@@ -43,18 +43,6 @@ std::size_t gpu_table_representation::get_uncompressed_data_size_in_bytes() cons
   return get_size_in_bytes();
 }
 
-const cudf::table& gpu_table_representation::get_table(
-  [[maybe_unused]] rmm::cuda_stream_view stream) const
-{
-  if (std::holds_alternative<std::unique_ptr<cudf::table>>(_table)) {
-    return *std::get<std::unique_ptr<cudf::table>>(_table);
-  } else {
-    auto tbl = std::make_unique<cudf::table>(std::get<owning_table_view>(_table).view, stream);
-    _table   = std::move(tbl);
-    return *std::get<std::unique_ptr<cudf::table>>(_table);
-  }
-}
-
 cudf::table_view gpu_table_representation::get_table_view() const
 {
   if (std::holds_alternative<std::unique_ptr<cudf::table>>(_table)) {
@@ -67,26 +55,18 @@ cudf::table_view gpu_table_representation::get_table_view() const
 std::unique_ptr<cudf::table> gpu_table_representation::release_table(
   [[maybe_unused]] rmm::cuda_stream_view stream)
 {
-  if (std::holds_alternative<std::unique_ptr<cudf::table>>(_table)) {
-    return std::move(std::get<std::unique_ptr<cudf::table>>(_table));
-  } else {
+  if (std::holds_alternative<owning_table_view>(_table)) {
     _table = std::make_unique<cudf::table>(std::get<owning_table_view>(_table).view, stream);
-    return std::move(std::get<std::unique_ptr<cudf::table>>(_table));
   }
+  return std::move(std::get<std::unique_ptr<cudf::table>>(_table));
 }
 
 std::unique_ptr<idata_representation> gpu_table_representation::clone(rmm::cuda_stream_view stream)
 {
   // Create a deep copy of the cuDF table using the provided stream
-  std::unique_ptr<cudf::table> table_copy;
-  if (std::holds_alternative<std::unique_ptr<cudf::table>>(_table)) {
-    auto& original_table = *std::get<std::unique_ptr<cudf::table>>(_table);
-    table_copy           = std::make_unique<cudf::table>(original_table, stream);
-  } else {
-    auto& owning_view = std::get<owning_table_view>(_table);
-    table_copy        = std::make_unique<cudf::table>(owning_view.view, stream);
-  }
-  return std::make_unique<gpu_table_representation>(std::move(table_copy), get_memory_space());
+  cudf::table_view view = get_table_view();
+  return std::make_unique<gpu_table_representation>(std::make_unique<cudf::table>(view, stream),
+                                                    get_memory_space());
 }
 
 }  // namespace cucascade

--- a/src/data/representation_converter.cpp
+++ b/src/data/representation_converter.cpp
@@ -151,7 +151,7 @@ std::unique_ptr<idata_representation> convert_gpu_to_gpu(
     return source.clone(stream);
   }
 
-  auto packed_data = cudf::pack(gpu_source.get_table(), stream);
+  auto packed_data = cudf::pack(gpu_source.get_table_view(), stream);
 
   assert(source.get_device_id() != target_memory_space->get_device_id());
   auto const target_device_id = target_memory_space->get_device_id();
@@ -206,7 +206,7 @@ std::unique_ptr<idata_representation> convert_gpu_to_host(
   stream.synchronize();
 
   auto& gpu_source = source.cast<gpu_table_representation>();
-  auto packed_data = cudf::pack(gpu_source.get_table(), stream);
+  auto packed_data = cudf::pack(gpu_source.get_table_view(), stream);
 
   auto mr = target_memory_space->get_memory_resource_as<memory::fixed_size_host_memory_resource>();
   auto allocation = mr->allocate_multiple_blocks(packed_data.gpu_data->size());
@@ -588,7 +588,7 @@ std::unique_ptr<idata_representation> convert_gpu_to_host_fast(
   rmm::cuda_stream_view stream)
 {
   auto& gpu_source            = source.cast<gpu_table_representation>();
-  const cudf::table_view view = gpu_source.get_table().view();
+  const cudf::table_view view = gpu_source.get_table_view();
 
   // --- Pass 1: plan the allocation layout ---
   std::size_t current_offset = 0;
@@ -1253,8 +1253,7 @@ static std::unique_ptr<idata_representation> convert_gpu_to_disk(
 {
   auto& backend       = target_memory_space->get_io_backend();
   auto& gpu_source    = source.cast<gpu_table_representation>();
-  const auto& table   = gpu_source.get_table();
-  cudf::table_view tv = table.view();
+  cudf::table_view tv = gpu_source.get_table_view();
 
   // Generate unique file path under the disk memory space's mount directory
   auto mount_path = target_memory_space->get_disk_mount_path();

--- a/src/memory/common.cpp
+++ b/src/memory/common.cpp
@@ -33,8 +33,7 @@ cuda::mr::any_resource<cuda::mr::device_accessible> make_default_gpu_memory_reso
 #if CUCASCADE_RMM_HAS_MOVABLE_ANY_RESOURCE
   return {rmm::mr::cuda_async_memory_resource(capacity)};
 #else
-  return wrap_legacy_rmm_resource(
-    std::make_shared<rmm::mr::cuda_async_memory_resource>(capacity));
+  return wrap_legacy_rmm_resource(std::make_shared<rmm::mr::cuda_async_memory_resource>(capacity));
 #endif
 }
 

--- a/src/memory/fixed_size_host_memory_resource.cpp
+++ b/src/memory/fixed_size_host_memory_resource.cpp
@@ -171,7 +171,10 @@ std::vector<std::byte*> fixed_size_host_memory_resource::allocate_multiple_block
         if (tracker) tracker->allocated_bytes.fetch_sub(static_cast<int64_t>(total_bytes));
         throw rmm::out_of_memory(
           "Not enough free blocks available in fixed_size_host_memory_resource and pool expansion "
-          "failed. total_bytes: " + std::to_string(total_bytes) + ", upstream_tracked_bytes: " + std::to_string(upstream_tracked_bytes) + ", only " + std::to_string(_free_blocks.size()) + " free blocks available from " + std::to_string(num_blocks) + " requested blocks" + ".");
+          "failed. total_bytes: " +
+          std::to_string(total_bytes) + ", upstream_tracked_bytes: " +
+          std::to_string(upstream_tracked_bytes) + ", only " + std::to_string(_free_blocks.size()) +
+          " free blocks available from " + std::to_string(num_blocks) + " requested blocks" + ".");
       }
 
       std::byte* ptr = static_cast<std::byte*>(_free_blocks.back());
@@ -183,8 +186,11 @@ std::vector<std::byte*> fixed_size_host_memory_resource::allocate_multiple_block
   } else {
     if (tracker) tracker->allocated_bytes.fetch_sub(static_cast<int64_t>(total_bytes));
     throw rmm::out_of_memory(
-      "Not enough free blocks available in fixed_size_host_memory_resource. " 
-      "total_bytes: " + std::to_string(total_bytes) + ", upstream_tracked_bytes: " + std::to_string(upstream_tracked_bytes) + ", only " + std::to_string(_free_blocks.size()) + " free blocks available from " + std::to_string(num_blocks) + " requested blocks" + ".");
+      "Not enough free blocks available in fixed_size_host_memory_resource. "
+      "total_bytes: " +
+      std::to_string(total_bytes) + ", upstream_tracked_bytes: " +
+      std::to_string(upstream_tracked_bytes) + ", only " + std::to_string(_free_blocks.size()) +
+      " free blocks available from " + std::to_string(num_blocks) + " requested blocks" + ".");
   }
   return {};
 }

--- a/src/memory/memory_space.cpp
+++ b/src/memory/memory_space.cpp
@@ -121,9 +121,10 @@ memory_space::memory_space(const gpu_memory_space_config& config)
     pool_handle = concrete_mr.pool_handle();
     _allocator  = cuda::mr::any_resource<cuda::mr::device_accessible>(std::move(concrete_mr));
 #else
-    auto concrete_mr = std::make_shared<rmm::mr::cuda_async_memory_resource>(config.memory_capacity);
-    pool_handle      = concrete_mr->pool_handle();
-    _allocator       = wrap_legacy_rmm_resource(std::move(concrete_mr));
+    auto concrete_mr =
+      std::make_shared<rmm::mr::cuda_async_memory_resource>(config.memory_capacity);
+    pool_handle = concrete_mr->pool_handle();
+    _allocator  = wrap_legacy_rmm_resource(std::move(concrete_mr));
 #endif
   }
 
@@ -352,8 +353,7 @@ rmm::device_async_resource_ref memory_space::get_default_allocator() const noexc
   return std::visit(
     utils::overloaded{
       [&](const std::unique_ptr<reservation_aware_resource_adaptor>& mr) {
-        return rmm::device_async_resource_ref{
-          const_cast<reservation_aware_resource_adaptor&>(*mr)};
+        return rmm::device_async_resource_ref{const_cast<reservation_aware_resource_adaptor&>(*mr)};
       },
       [&](const std::unique_ptr<fixed_size_host_memory_resource>&) {
         return rmm::device_async_resource_ref{

--- a/test/data/test_data_batch.cpp
+++ b/test/data/test_data_batch.cpp
@@ -906,13 +906,13 @@ TEST_CASE("data_batch clone with real GPU data verifies data integrity", "[data_
   REQUIRE(cloned_repr != nullptr);
 
   // Verify table shape matches
-  REQUIRE(cloned_repr->get_table().num_rows() == original_rows);
-  REQUIRE(cloned_repr->get_table().num_columns() == original_columns);
+  REQUIRE(cloned_repr->get_table_view().num_rows() == original_rows);
+  REQUIRE(cloned_repr->get_table_view().num_columns() == original_columns);
 
   // Verify actual data content matches
   stream.synchronize();
   expect_cudf_tables_equal_on_stream(
-    original_repr->get_table(), cloned_repr->get_table(), stream.view());
+    original_repr->get_table_view(), cloned_repr->get_table_view(), stream.view());
 }
 
 TEST_CASE("data_batch clone creates independent memory copies", "[data_batch][gpu]")
@@ -933,13 +933,10 @@ TEST_CASE("data_batch clone creates independent memory copies", "[data_batch][gp
   // Verify the data representations are different objects
   REQUIRE(batch->get_data() != cloned->get_data());
 
-  // Verify the underlying cudf tables are different objects
-  REQUIRE(&original_repr->get_table() != &cloned_repr->get_table());
-
   // Verify each column points to different memory
-  for (cudf::size_type i = 0; i < original_repr->get_table().num_columns(); ++i) {
-    REQUIRE(original_repr->get_table().view().column(i).head() !=
-            cloned_repr->get_table().view().column(i).head());
+  for (cudf::size_type i = 0; i < original_repr->get_table_view().num_columns(); ++i) {
+    REQUIRE(original_repr->get_table_view().column(i).head() !=
+            cloned_repr->get_table_view().column(i).head());
   }
 }
 
@@ -971,7 +968,7 @@ TEST_CASE("data_batch clone with real GPU data while processing", "[data_batch][
 
   stream.synchronize();
   expect_cudf_tables_equal_on_stream(
-    original_repr->get_table(), cloned_repr->get_table(), stream.view());
+    original_repr->get_table_view(), cloned_repr->get_table_view(), stream.view());
 
   // Original should still be processing
   REQUIRE(batch->get_processing_count() == 1);
@@ -1018,11 +1015,11 @@ TEST_CASE("data_batch multiple clones are all independent", "[data_batch][gpu]")
 
   stream.synchronize();
   expect_cudf_tables_equal_on_stream(
-    original_repr->get_table(), clone1_repr->get_table(), stream.view());
+    original_repr->get_table_view(), clone1_repr->get_table_view(), stream.view());
   expect_cudf_tables_equal_on_stream(
-    original_repr->get_table(), clone2_repr->get_table(), stream.view());
+    original_repr->get_table_view(), clone2_repr->get_table_view(), stream.view());
   expect_cudf_tables_equal_on_stream(
-    original_repr->get_table(), clone3_repr->get_table(), stream.view());
+    original_repr->get_table_view(), clone3_repr->get_table_view(), stream.view());
 }
 
 TEST_CASE("data_batch clone with empty table", "[data_batch][gpu]")
@@ -1041,8 +1038,8 @@ TEST_CASE("data_batch clone with empty table", "[data_batch][gpu]")
 
   auto* cloned_repr = dynamic_cast<gpu_table_representation*>(cloned->get_data());
   REQUIRE(cloned_repr != nullptr);
-  REQUIRE(cloned_repr->get_table().num_rows() == 0);
-  REQUIRE(cloned_repr->get_table().num_columns() == 2);
+  REQUIRE(cloned_repr->get_table_view().num_rows() == 0);
+  REQUIRE(cloned_repr->get_table_view().num_columns() == 2);
 }
 
 TEST_CASE("data_batch clone with large table", "[data_batch][gpu]")
@@ -1064,18 +1061,18 @@ TEST_CASE("data_batch clone with large table", "[data_batch][gpu]")
   auto* cloned_repr   = dynamic_cast<gpu_table_representation*>(cloned->get_data());
 
   // Verify structure
-  REQUIRE(cloned_repr->get_table().num_rows() == 10000);
-  REQUIRE(cloned_repr->get_table().num_columns() == 2);
+  REQUIRE(cloned_repr->get_table_view().num_rows() == 10000);
+  REQUIRE(cloned_repr->get_table_view().num_columns() == 2);
 
   // Verify data integrity
   stream.synchronize();
   expect_cudf_tables_equal_on_stream(
-    original_repr->get_table(), cloned_repr->get_table(), stream.view());
+    original_repr->get_table_view(), cloned_repr->get_table_view(), stream.view());
 
   // Verify independence
-  for (cudf::size_type i = 0; i < original_repr->get_table().num_columns(); ++i) {
-    REQUIRE(original_repr->get_table().view().column(i).head() !=
-            cloned_repr->get_table().view().column(i).head());
+  for (cudf::size_type i = 0; i < original_repr->get_table_view().num_columns(); ++i) {
+    REQUIRE(original_repr->get_table_view().column(i).head() !=
+            cloned_repr->get_table_view().column(i).head());
   }
 }
 

--- a/test/data/test_data_representation.cpp
+++ b/test/data/test_data_representation.cpp
@@ -143,7 +143,7 @@ TEST_CASE("host_data_packed_representation converts to GPU and preserves content
   auto& gpu_repr = *gpu_any;
   // Compare using the same stream used for conversion to avoid cross-stream hazards
   cucascade::test::expect_cudf_tables_equal_on_stream(
-    original, gpu_repr.get_table(), pack_stream.view());
+    original, gpu_repr.get_table_view(), pack_stream.view());
 }
 
 // =============================================================================
@@ -205,7 +205,7 @@ TEST_CASE("gpu_table_representation get_table", "[gpu_data_representation]")
 
   gpu_table_representation repr(std::make_unique<cudf::table>(std::move(table)), *gpu_space);
 
-  const cudf::table& retrieved_table = repr.get_table();
+  const cudf::table_view& retrieved_table = repr.get_table_view();
   REQUIRE(retrieved_table.num_columns() == num_columns);
   REQUIRE(retrieved_table.num_rows() == 100);
 }
@@ -271,7 +271,7 @@ TEST_CASE("gpu->host->gpu roundtrip preserves cudf table contents", "[gpu_data_r
   auto& back = *gpu_any;
   chain_stream.synchronize();
   cucascade::test::expect_cudf_tables_equal_on_stream(
-    repr.get_table(), back.get_table(), chain_stream);
+    repr.get_table_view(), back.get_table_view(), chain_stream);
   // Stream is automatically managed - no explicit release needed
 }
 
@@ -323,7 +323,7 @@ TEST_CASE("gpu cross-device conversion when multiple GPUs are available",
 
   // Compare content equality using the same stream used for transfer
   cucascade::test::expect_cudf_tables_equal_on_stream(
-    src_repr.get_table(), dst_repr.get_table(), xfer_stream);
+    src_repr.get_table_view(), dst_repr.get_table_view(), xfer_stream);
 }
 // =============================================================================
 // idata_representation Interface Tests
@@ -345,7 +345,7 @@ TEST_CASE("idata_representation cast functionality",
     // Cast to derived type
     gpu_table_representation& casted = base_ptr->cast<gpu_table_representation>();
     REQUIRE(&casted == &repr);
-    REQUIRE(casted.get_table().num_rows() == 100);
+    REQUIRE(casted.get_table_view().num_rows() == 100);
   }
 }
 
@@ -365,7 +365,7 @@ TEST_CASE("idata_representation const cast functionality",
     // Const cast to derived type
     const gpu_table_representation& casted = base_ptr->cast<gpu_table_representation>();
     REQUIRE(&casted == &repr);
-    REQUIRE(casted.get_table().num_rows() == 100);
+    REQUIRE(casted.get_table_view().num_rows() == 100);
   }
 }
 
@@ -421,8 +421,8 @@ TEST_CASE("gpu_table_representation with single column", "[gpu_data_representati
   auto table = std::make_unique<cudf::table>(std::move(columns));
   gpu_table_representation repr(std::move(table), *gpu_space);
 
-  REQUIRE(repr.get_table().num_columns() == 1);
-  REQUIRE(repr.get_table().num_rows() == 100);
+  REQUIRE(repr.get_table_view().num_columns() == 1);
+  REQUIRE(repr.get_table_view().num_rows() == 100);
   REQUIRE(repr.get_size_in_bytes() >= 100 * 4);  // At least 100 rows * 4 bytes
 }
 
@@ -456,8 +456,8 @@ TEST_CASE("gpu_table_representation with multiple column types", "[gpu_data_repr
   auto table = std::make_unique<cudf::table>(std::move(columns));
   gpu_table_representation repr(std::move(table), *gpu_space);
 
-  REQUIRE(repr.get_table().num_columns() == 4);
-  REQUIRE(repr.get_table().num_rows() == 100);
+  REQUIRE(repr.get_table_view().num_columns() == 4);
+  REQUIRE(repr.get_table_view().num_rows() == 100);
   // Size should be at least 100 * (1 + 2 + 4 + 8) = 1500 bytes
   REQUIRE(repr.get_size_in_bytes() >= 1500);
 }
@@ -494,18 +494,16 @@ TEST_CASE("gpu_table_representation clone creates independent copy", "[gpu_data_
   REQUIRE(cloned->get_size_in_bytes() == repr.get_size_in_bytes());
 
   // Verify the tables have the same shape
-  REQUIRE(cloned->get_table().num_columns() == repr.get_table().num_columns());
-  REQUIRE(cloned->get_table().num_rows() == repr.get_table().num_rows());
+  REQUIRE(cloned->get_table_view().num_columns() == repr.get_table_view().num_columns());
+  REQUIRE(cloned->get_table_view().num_rows() == repr.get_table_view().num_rows());
 
   // Verify the data is equal
   cucascade::test::expect_cudf_tables_equal_on_stream(
-    repr.get_table(), cloned->get_table(), rmm::cuda_stream_default);
+    repr.get_table_view(), cloned->get_table_view(), rmm::cuda_stream_default);
 
   // Verify the tables are independent (different memory addresses)
-  REQUIRE(&cloned->get_table() != &repr.get_table());
-  for (cudf::size_type i = 0; i < repr.get_table().num_columns(); ++i) {
-    REQUIRE(repr.get_table().view().column(i).head() !=
-            cloned->get_table().view().column(i).head());
+  for (cudf::size_type i = 0; i < repr.get_table_view().num_columns(); ++i) {
+    REQUIRE(repr.get_table_view().column(i).head() != cloned->get_table_view().column(i).head());
   }
 }
 
@@ -521,7 +519,7 @@ TEST_CASE("gpu_table_representation clone empty table", "[gpu_data_representatio
 
   auto* cloned = dynamic_cast<gpu_table_representation*>(cloned_base.get());
   REQUIRE(cloned != nullptr);
-  REQUIRE(cloned->get_table().num_rows() == 0);
+  REQUIRE(cloned->get_table_view().num_rows() == 0);
   REQUIRE(cloned->get_size_in_bytes() == 0);
 }
 
@@ -570,7 +568,7 @@ TEST_CASE("host_data_packed_representation clone creates independent copy",
   stream.synchronize();
 
   cucascade::test::expect_cudf_tables_equal_on_stream(
-    orig_gpu->get_table(), cloned_gpu->get_table(), stream.view());
+    orig_gpu->get_table_view(), cloned_gpu->get_table_view(), stream.view());
 }
 
 //  */
@@ -1794,10 +1792,10 @@ TEST_CASE("Round-trip fast: INT32 column data preserved", "[fast][roundtrip]")
   stream.synchronize();
 
   REQUIRE(back != nullptr);
-  REQUIRE(back->get_table().num_columns() == 1);
-  REQUIRE(back->get_table().num_rows() == N);
+  REQUIRE(back->get_table_view().num_columns() == 1);
+  REQUIRE(back->get_table_view().num_rows() == N);
 
-  cudf::table_view back_tv = back->get_table().view();
+  cudf::table_view back_tv = back->get_table_view();
   auto bytes               = gpu_bytes(back_tv.column(0).data<uint8_t>(), N * sizeof(int32_t));
   REQUIRE(bytes[0] == 0xAB);
   REQUIRE(bytes[N * sizeof(int32_t) - 1] == 0xAB);
@@ -1830,8 +1828,8 @@ TEST_CASE("Round-trip fast: nullable INT64 null mask preserved", "[fast][roundtr
   auto back = fast_back_convert(*host, gpu_space, registry, stream.view());
   stream.synchronize();
 
-  REQUIRE(back->get_table().num_columns() == 1);
-  cudf::table_view back_tv = back->get_table().view();
+  REQUIRE(back->get_table_view().num_columns() == 1);
+  cudf::table_view back_tv = back->get_table_view();
   REQUIRE(back_tv.column(0).nullable());
   REQUIRE(back_tv.column(0).null_count() == 0);
 
@@ -1865,7 +1863,7 @@ TEST_CASE("Round-trip fast: FLOAT64 byte integrity", "[fast][roundtrip]")
   auto back = fast_back_convert(*host, gpu_space, registry, stream.view());
   stream.synchronize();
 
-  cudf::table_view back_tv = back->get_table().view();
+  cudf::table_view back_tv = back->get_table_view();
   auto data_bytes          = gpu_bytes(back_tv.column(0).data<uint8_t>(), N * sizeof(double));
   REQUIRE(data_bytes[0] == 0xCD);
   REQUIRE(data_bytes[N * sizeof(double) - 1] == 0xCD);
@@ -1912,9 +1910,9 @@ TEST_CASE("Round-trip fast: STRING column content preserved", "[fast][roundtrip]
   auto back = fast_back_convert(*host, gpu_space, registry, stream.view());
   stream.synchronize();
 
-  REQUIRE(back->get_table().num_columns() == 1);
-  REQUIRE(back->get_table().num_rows() == num_strings);
-  cudf::table_view back_tv = back->get_table().view();
+  REQUIRE(back->get_table_view().num_columns() == 1);
+  REQUIRE(back->get_table_view().num_rows() == num_strings);
+  cudf::table_view back_tv = back->get_table_view();
   REQUIRE(back_tv.column(0).type().id() == cudf::type_id::STRING);
   // Chars should be preserved
   auto char_bytes =
@@ -1966,8 +1964,8 @@ TEST_CASE("Round-trip fast: LIST<INT32> structure preserved", "[fast][roundtrip]
   auto back = fast_back_convert(*host, gpu_space, registry, stream.view());
   stream.synchronize();
 
-  REQUIRE(back->get_table().num_rows() == num_lists);
-  cudf::table_view back_tv = back->get_table().view();
+  REQUIRE(back->get_table_view().num_rows() == num_lists);
+  cudf::table_view back_tv = back->get_table_view();
   REQUIRE(back_tv.column(0).type().id() == cudf::type_id::LIST);
   REQUIRE(back_tv.column(0).num_children() == 2);
   // Values child bytes preserved
@@ -2016,8 +2014,8 @@ TEST_CASE("Round-trip fast: STRUCT<INT32,FLOAT64> fields preserved", "[fast][rou
   auto back = fast_back_convert(*host, gpu_space, registry, stream.view());
   stream.synchronize();
 
-  REQUIRE(back->get_table().num_rows() == N);
-  cudf::table_view back_tv = back->get_table().view();
+  REQUIRE(back->get_table_view().num_rows() == N);
+  cudf::table_view back_tv = back->get_table_view();
   REQUIRE(back_tv.column(0).type().id() == cudf::type_id::STRUCT);
   REQUIRE(back_tv.column(0).num_children() == 2);
 
@@ -2052,7 +2050,7 @@ TEST_CASE("Round-trip fast: empty table (0 rows)", "[fast][roundtrip]")
   stream.synchronize();
 
   REQUIRE(back != nullptr);
-  REQUIRE(back->get_table().num_columns() == 1);
-  REQUIRE(back->get_table().num_rows() == 0);
-  REQUIRE(back->get_table().view().column(0).type().id() == cudf::type_id::INT32);
+  REQUIRE(back->get_table_view().num_columns() == 1);
+  REQUIRE(back->get_table_view().num_rows() == 0);
+  REQUIRE(back->get_table_view().column(0).type().id() == cudf::type_id::INT32);
 }

--- a/test/data/test_data_representation.cpp
+++ b/test/data/test_data_representation.cpp
@@ -325,6 +325,76 @@ TEST_CASE("gpu cross-device conversion when multiple GPUs are available",
   cucascade::test::expect_cudf_tables_equal_on_stream(
     src_repr.get_table_view(), dst_repr.get_table_view(), xfer_stream);
 }
+
+// =============================================================================
+// gpu_table_representation built from cudf::table_view + shared_ptr<cudf::table>
+// =============================================================================
+
+TEST_CASE("gpu->host_packed->gpu roundtrip preserves contents (table_view+shared_ptr ctor)",
+          "[gpu_data_representation][table_view_ctor]")
+{
+  memory::memory_reservation_manager mgr(create_conversion_test_configs());
+  representation_converter_registry registry;
+  register_builtin_converters(registry);
+
+  const memory::memory_space* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
+  const memory::memory_space* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
+
+  auto chain_stream = gpu_space->acquire_stream();
+  auto table = create_simple_cudf_table(100, 2, gpu_space->get_default_allocator(), chain_stream);
+
+  auto shared_table = std::make_shared<cudf::table>(std::move(table));
+  auto view         = shared_table->view();
+  auto alloc_size   = shared_table->alloc_size();
+  gpu_table_representation repr(
+    view, std::move(shared_table), alloc_size, *const_cast<memory::memory_space*>(gpu_space));
+
+  auto cpu_any = registry.convert<host_data_packed_representation>(repr, host_space, chain_stream);
+  auto gpu_any = registry.convert<gpu_table_representation>(*cpu_any, gpu_space, chain_stream);
+
+  chain_stream.synchronize();
+  cucascade::test::expect_cudf_tables_equal_on_stream(
+    repr.get_table_view(), gpu_any->get_table_view(), chain_stream);
+}
+
+TEST_CASE("gpu->host_fast->gpu roundtrip preserves contents (table_view+shared_ptr ctor)",
+          "[gpu_data_representation][table_view_ctor]")
+{
+  memory::memory_reservation_manager mgr(create_conversion_test_configs());
+  representation_converter_registry registry;
+  register_builtin_converters(registry);
+
+  const memory::memory_space* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
+  const memory::memory_space* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
+
+  rmm::cuda_stream stream;
+  constexpr int N = 64;
+  auto col        = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                       N,
+                                       cudf::mask_state::UNALLOCATED,
+                                       stream.view(),
+                                       gpu_space->get_default_allocator());
+  CUCASCADE_CUDA_TRY(
+    cudaMemsetAsync(col->mutable_view().head(), 0xAB, N * sizeof(int32_t), stream.value()));
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(col));
+  auto shared_table = std::make_shared<cudf::table>(std::move(cols));
+  auto view         = shared_table->view();
+  auto alloc_size   = shared_table->alloc_size();
+  gpu_table_representation repr(
+    view, std::move(shared_table), alloc_size, *const_cast<memory::memory_space*>(gpu_space));
+
+  auto host = registry.convert<host_data_representation>(repr, host_space, stream.view());
+  auto back = registry.convert<gpu_table_representation>(*host, gpu_space, stream.view());
+  stream.synchronize();
+
+  REQUIRE(back->get_table_view().num_columns() == 1);
+  REQUIRE(back->get_table_view().num_rows() == N);
+  cucascade::test::expect_cudf_tables_equal_on_stream(
+    repr.get_table_view(), back->get_table_view(), stream.view());
+}
+
 // =============================================================================
 // idata_representation Interface Tests
 // =============================================================================

--- a/test/data/test_disk_host_converters.cpp
+++ b/test/data/test_disk_host_converters.cpp
@@ -101,7 +101,7 @@ void round_trip_test(std::unique_ptr<cudf::table> original_table)
 
   // Compare original (from gpu_rep) with round-tripped
   test::expect_cudf_tables_equal_on_stream(
-    gpu_rep->get_table(), gpu_rep2->get_table(), shared_stream());
+    gpu_rep->get_table_view(), gpu_rep2->get_table_view(), shared_stream());
 }
 
 /// Create a simple column of the given type with uninitialized data.

--- a/test/data/test_gpu_disk_converters.cpp
+++ b/test/data/test_gpu_disk_converters.cpp
@@ -85,7 +85,7 @@ void gpu_disk_round_trip_test(std::unique_ptr<cudf::table> original_table)
 
   // Compare original (from gpu_rep) with round-tripped
   test::expect_cudf_tables_equal_on_stream(
-    gpu_rep->get_table(), gpu_rep2->get_table(), shared_stream());
+    gpu_rep->get_table_view(), gpu_rep2->get_table_view(), shared_stream());
 }
 
 /// Create a simple column of the given type with uninitialized data.
@@ -630,7 +630,7 @@ TEST_CASE("gpu disk round-trip with explicit pipeline backend",
     registry.convert<gpu_table_representation>(*disk_rep, gpu_space.get(), shared_stream());
 
   test::expect_cudf_tables_equal_on_stream(
-    gpu_rep->get_table(), gpu_rep2->get_table(), shared_stream());
+    gpu_rep->get_table_view(), gpu_rep2->get_table_view(), shared_stream());
 }
 
 TEST_CASE("gpu disk round-trip pipeline with multiple types",
@@ -657,7 +657,7 @@ TEST_CASE("gpu disk round-trip pipeline with multiple types",
     registry.convert<gpu_table_representation>(*disk_rep, gpu_space.get(), shared_stream());
 
   test::expect_cudf_tables_equal_on_stream(
-    gpu_rep->get_table(), gpu_rep2->get_table(), shared_stream());
+    gpu_rep->get_table_view(), gpu_rep2->get_table_view(), shared_stream());
 }
 
 TEST_CASE("disk_data_representation get_uncompressed_data_size_in_bytes", "[disk][representation]")

--- a/test/data/test_representation_converter.cpp
+++ b/test/data/test_representation_converter.cpp
@@ -418,7 +418,7 @@ TEST_CASE("Built-in HOST to GPU conversion works", "[representation_converter][b
 
   REQUIRE(gpu_result != nullptr);
   REQUIRE(gpu_result->get_current_tier() == memory::Tier::GPU);
-  REQUIRE(gpu_result->get_table().num_rows() == 50);
+  REQUIRE(gpu_result->get_table_view().num_rows() == 50);
 }
 
 TEST_CASE("Built-in roundtrip GPU->HOST->GPU preserves data",
@@ -451,7 +451,7 @@ TEST_CASE("Built-in roundtrip GPU->HOST->GPU preserves data",
   // Verify data integrity
   REQUIRE(result_repr != nullptr);
   cucascade::test::expect_cudf_tables_equal_on_stream(
-    original_repr.get_table(), result_repr->get_table(), stream);
+    original_repr.get_table_view(), result_repr->get_table_view(), stream);
 }
 
 // =============================================================================

--- a/test/utils/cudf_test_utils.cpp
+++ b/test/utils/cudf_test_utils.cpp
@@ -22,6 +22,7 @@
 #include <cudf/null_mask.hpp>
 #include <cudf/strings/strings_column_view.hpp>
 #include <cudf/table/table.hpp>
+#include <cudf/table/table_view.hpp>
 #include <cudf/utilities/traits.hpp>
 
 #include <rmm/cuda_stream.hpp>
@@ -295,8 +296,8 @@ static bool columns_equal_recursive(const cudf::column_view& left,
 // Stream-aware comparison that recursively compares column content.
 // Handles all column types including compound types (STRING, LIST, STRUCT, DICTIONARY)
 // and tolerates INT32 vs INT64 offset differences in STRING/LIST columns.
-bool cudf_tables_have_equal_contents_on_stream(const cudf::table& left,
-                                               const cudf::table& right,
+bool cudf_tables_have_equal_contents_on_stream(const cudf::table_view& left,
+                                               const cudf::table_view& right,
                                                rmm::cuda_stream_view stream_view)
 {
   if (left.num_rows() != right.num_rows()) {
@@ -315,9 +316,8 @@ bool cudf_tables_have_equal_contents_on_stream(const cudf::table& left,
   stream_view.synchronize();
 
   for (int col_idx = 0; col_idx < left.num_columns(); ++col_idx) {
-    if (!columns_equal_recursive(left.view().column(col_idx),
-                                 right.view().column(col_idx),
-                                 "col[" + std::to_string(col_idx) + "]")) {
+    if (!columns_equal_recursive(
+          left.column(col_idx), right.column(col_idx), "col[" + std::to_string(col_idx) + "]")) {
       return false;
     }
   }
@@ -325,8 +325,8 @@ bool cudf_tables_have_equal_contents_on_stream(const cudf::table& left,
   return true;
 }
 
-void expect_cudf_tables_equal_on_stream(const cudf::table& left,
-                                        const cudf::table& right,
+void expect_cudf_tables_equal_on_stream(const cudf::table_view& left,
+                                        const cudf::table_view& right,
                                         rmm::cuda_stream_view stream_view)
 {
   REQUIRE(cudf_tables_have_equal_contents_on_stream(left, right, stream_view));

--- a/test/utils/cudf_test_utils.hpp
+++ b/test/utils/cudf_test_utils.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cudf/table/table.hpp>
+#include <cudf/table/table_view.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
 
@@ -25,11 +26,11 @@ namespace cucascade {
 namespace test {
 
 // Stream-aware variants to enforce stream ordering with async allocations
-bool cudf_tables_have_equal_contents_on_stream(const cudf::table& left,
-                                               const cudf::table& right,
+bool cudf_tables_have_equal_contents_on_stream(const cudf::table_view& left,
+                                               const cudf::table_view& right,
                                                rmm::cuda_stream_view stream_view);
-void expect_cudf_tables_equal_on_stream(const cudf::table& left,
-                                        const cudf::table& right,
+void expect_cudf_tables_equal_on_stream(const cudf::table_view& left,
+                                        const cudf::table_view& right,
                                         rmm::cuda_stream_view stream_view);
 
 }  // namespace test


### PR DESCRIPTION
this PR adds the ability to create a gpu_data_representation from a cudf::table_view, as long as it is accompanied by alloc_size and a reference to its owner.