### PR TITLE
Make host memory portable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ if(CUCASCADE_NVTX)
 endif()
 
 # Add source directories (they will add sources to cucascade_objects)
+add_subdirectory(src/cuda)
 add_subdirectory(src/memory)
 add_subdirectory(src/data)
 

--- a/include/cucascade/cuda/event.hpp
+++ b/include/cucascade/cuda/event.hpp
@@ -1,0 +1,67 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <chrono>
+
+namespace cucascade {
+namespace cuda {
+
+class cuda_event {
+ public:
+  enum class query_status { success, in_progress, error };
+
+  explicit cuda_event(unsigned int flags = cudaEventDisableTiming);
+  ~cuda_event() noexcept;
+
+  cuda_event(cuda_event const&)            = delete;
+  cuda_event& operator=(cuda_event const&) = delete;
+
+  cuda_event(cuda_event&& other) noexcept;
+  cuda_event& operator=(cuda_event&& other) noexcept;
+
+  [[nodiscard]] cudaEvent_t get() const noexcept;
+  [[nodiscard]] explicit operator cudaEvent_t() const noexcept;
+
+  void record(rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+  void wait(rmm::cuda_stream_view stream = rmm::cuda_stream_default) const;
+  void synchronize() const;
+
+  /**
+   * @brief Return elapsed time between `start` and this event.
+   *
+   * Both events must have been recorded, completed, and created with timing enabled.
+   */
+  [[nodiscard]] std::chrono::duration<float, std::milli> elapsed_time(
+    cuda_event const& start) const;
+
+  /**
+   * @brief Query whether the event has completed without blocking.
+   */
+  [[nodiscard]] query_status query() const noexcept;
+
+ private:
+  cudaEvent_t event_{nullptr};
+};
+
+}  // namespace cuda
+}  // namespace cucascade

--- a/include/cucascade/memory/common.hpp
+++ b/include/cucascade/memory/common.hpp
@@ -145,6 +145,9 @@ cuda::mr::any_resource<cuda::mr::device_accessible> make_default_gpu_memory_reso
 cuda::mr::any_resource<cuda::mr::device_accessible, cuda::mr::host_accessible>
 make_default_host_memory_resource(int device_id, std::size_t capacity);
 
+cuda::mr::any_resource<cuda::mr::device_accessible, cuda::mr::host_accessible>
+make_default_host_memory_resource(int device_id, std::size_t capacity, bool make_portable);
+
 DeviceMemoryResourceFactoryFn make_default_allocator_for_tier(Tier tier);
 
 }  // namespace memory

--- a/include/cucascade/memory/config.hpp
+++ b/include/cucascade/memory/config.hpp
@@ -67,6 +67,7 @@ struct host_memory_space_config {
   std::size_t block_size           = default_block_size;
   std::size_t pool_size            = default_pool_size;
   std::size_t initial_number_pools = default_initial_number_pools;
+  bool make_portable               = false;
 
   DeviceMemoryResourceFactoryFn mr_factory_fn{nullptr};
 

--- a/include/cucascade/memory/numa_region_pinned_host_allocator.hpp
+++ b/include/cucascade/memory/numa_region_pinned_host_allocator.hpp
@@ -27,7 +27,7 @@ namespace memory {
 
 class numa_region_pinned_host_memory_resource final {
  public:
-  explicit numa_region_pinned_host_memory_resource(int numa_node) : _numa_node(numa_node) {}
+  explicit numa_region_pinned_host_memory_resource(int numa_node, bool make_portable = false);
   ~numa_region_pinned_host_memory_resource()                                              = default;
   numa_region_pinned_host_memory_resource(numa_region_pinned_host_memory_resource const&) = default;
   numa_region_pinned_host_memory_resource(numa_region_pinned_host_memory_resource&&)      = default;
@@ -77,7 +77,10 @@ class numa_region_pinned_host_memory_resource final {
   }
 
  private:
+  static int cuda_host_flags(int numa_node, bool make_portable) noexcept;
+
   int _numa_node{-1};
+  int _cuda_host_flags{0};
 };
 
 }  // namespace memory

--- a/include/cucascade/memory/reservation_manager_configurator.hpp
+++ b/include/cucascade/memory/reservation_manager_configurator.hpp
@@ -23,6 +23,7 @@
 #include <cucascade/memory/topology_discovery.hpp>
 
 #include <list>
+#include <optional>
 #include <span>
 #include <unordered_map>
 #include <variant>
@@ -135,6 +136,9 @@ class reservation_manager_configurator {
   /// @param mr_fn Function to create CPU memory resource.
   builder_reference& set_host_memory_resource_factory(DeviceMemoryResourceFactoryFn mr_fn);
 
+  /// \brief override whether default host pinned memory allocations are portable across GPUs.
+  builder_reference& set_host_portability(bool make_portable);
+
   builder_reference& set_host_pool_features(std::size_t chunk_size,
                                             std::size_t block_size,
                                             std::size_t initial_block_count);
@@ -220,7 +224,8 @@ class reservation_manager_configurator {
   std::optional<std::size_t> initial_block_count;
   std::pair<double, double> downgrade_fractions_per_host_{0.85, 0.65};
   fraction_or_size _cpu_reservation{0.85};  // 75% limit per NUMA node by default
-  mutable DeviceMemoryResourceFactoryFn _cpu_mr_fn = make_default_host_memory_resource;
+  mutable DeviceMemoryResourceFactoryFn _cpu_mr_fn{};
+  std::optional<bool> _host_memory_portability;
 
   std::vector<std::tuple<int, std::size_t, std::string>> _disk_mounting_points{};
 };

--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -1,0 +1,18 @@
+# =============================================================================
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved. SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
+
+target_sources(cucascade_objects PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/event.cpp)

--- a/src/cuda/event.cpp
+++ b/src/cuda/event.cpp
@@ -1,0 +1,84 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cucascade/cuda/event.hpp>
+
+#include <cucascade/error.hpp>
+
+#include <utility>
+
+namespace cucascade {
+namespace cuda {
+
+cuda_event::cuda_event(unsigned int flags)
+{
+  CUCASCADE_CUDA_TRY(::cudaEventCreateWithFlags(&event_, flags));
+}
+
+cuda_event::~cuda_event() noexcept
+{
+  if (event_ != nullptr) { CUCASCADE_ASSERT_CUDA_SUCCESS(::cudaEventDestroy(event_)); }
+}
+
+cuda_event::cuda_event(cuda_event&& other) noexcept
+  : event_(std::exchange(other.event_, nullptr))
+{
+}
+
+cuda_event& cuda_event::operator=(cuda_event&& other) noexcept
+{
+  if (this != &other) {
+    if (event_ != nullptr) { CUCASCADE_ASSERT_CUDA_SUCCESS(::cudaEventDestroy(event_)); }
+    event_ = std::exchange(other.event_, nullptr);
+  }
+  return *this;
+}
+
+cudaEvent_t cuda_event::get() const noexcept { return event_; }
+
+cuda_event::operator cudaEvent_t() const noexcept { return event_; }
+
+void cuda_event::record(rmm::cuda_stream_view stream)
+{
+  CUCASCADE_CUDA_TRY(::cudaEventRecord(event_, stream.value()));
+}
+
+void cuda_event::wait(rmm::cuda_stream_view stream) const
+{
+  CUCASCADE_CUDA_TRY(::cudaStreamWaitEvent(stream.value(), event_, 0));
+}
+
+void cuda_event::synchronize() const { CUCASCADE_CUDA_TRY(::cudaEventSynchronize(event_)); }
+
+std::chrono::duration<float, std::milli> cuda_event::elapsed_time(
+  cuda_event const& start) const
+{
+  float ms{0.F};
+  CUCASCADE_CUDA_TRY(::cudaEventElapsedTime(&ms, start.get(), event_));
+  return std::chrono::duration<float, std::milli>{ms};
+}
+
+cuda_event::query_status cuda_event::query() const noexcept
+{
+  cudaError_t const status = ::cudaEventQuery(event_);
+  if (status == cudaSuccess) { return query_status::success; }
+  if (status == cudaErrorNotReady) { return query_status::in_progress; }
+  return query_status::error;
+}
+
+}  // namespace cuda
+}  // namespace cucascade

--- a/src/memory/common.cpp
+++ b/src/memory/common.cpp
@@ -40,7 +40,16 @@ cuda::mr::any_resource<cuda::mr::device_accessible> make_default_gpu_memory_reso
 cuda::mr::any_resource<cuda::mr::device_accessible, cuda::mr::host_accessible>
 make_default_host_memory_resource(int numa_node_id, [[maybe_unused]] size_t capacity)
 {
-  return {cucascade::memory::numa_region_pinned_host_memory_resource(numa_node_id)};
+  return make_default_host_memory_resource(numa_node_id, capacity, false);
+}
+
+cuda::mr::any_resource<cuda::mr::device_accessible, cuda::mr::host_accessible>
+make_default_host_memory_resource(int numa_node_id,
+                                  [[maybe_unused]] size_t capacity,
+                                  bool make_portable)
+{
+  return {cucascade::memory::numa_region_pinned_host_memory_resource(numa_node_id,
+                                                                     make_portable)};
 }
 
 DeviceMemoryResourceFactoryFn make_default_allocator_for_tier(Tier tier)
@@ -48,7 +57,9 @@ DeviceMemoryResourceFactoryFn make_default_allocator_for_tier(Tier tier)
   if (tier == Tier::GPU) {
     return make_default_gpu_memory_resource;
   } else if (tier == Tier::HOST) {
-    return make_default_host_memory_resource;
+    return [](int numa_node_id, size_t capacity) {
+      return make_default_host_memory_resource(numa_node_id, capacity);
+    };
   } else {
     return [](int, size_t) {
       return cuda::mr::any_resource<cuda::mr::device_accessible>{null_device_memory_resource{}};

--- a/src/memory/memory_space.cpp
+++ b/src/memory/memory_space.cpp
@@ -149,7 +149,9 @@ memory_space::memory_space(const host_memory_space_config& config)
     _stop_downgrading_memory_threshold(config.downgrade_stop_threshold()),
     _allocator(config.mr_factory_fn
                  ? config.mr_factory_fn(config.numa_id, config.memory_capacity)
-                 : make_default_host_memory_resource(config.numa_id, config.memory_capacity))
+                 : make_default_host_memory_resource(config.numa_id,
+                                                     config.memory_capacity,
+                                                     config.make_portable))
 {
   _reservation_allocator =
     std::make_unique<fixed_size_host_memory_resource>(_id.device_id,

--- a/src/memory/numa_region_pinned_host_allocator.cpp
+++ b/src/memory/numa_region_pinned_host_allocator.cpp
@@ -25,6 +25,25 @@
 namespace cucascade {
 namespace memory {
 
+numa_region_pinned_host_memory_resource::numa_region_pinned_host_memory_resource(
+  int numa_node, bool make_portable)
+  : _numa_node(numa_node), _cuda_host_flags(cuda_host_flags(numa_node, make_portable))
+{
+}
+
+int numa_region_pinned_host_memory_resource::cuda_host_flags(int numa_node,
+                                                             bool make_portable) noexcept
+{
+  if (!make_portable) {
+    return numa_node == -1 ? static_cast<int>(cudaHostAllocDefault)
+                           : static_cast<int>(cudaHostRegisterMapped);
+  }
+
+  return numa_node == -1
+           ? static_cast<int>(cudaHostAllocPortable | cudaHostAllocMapped)
+           : static_cast<int>(cudaHostRegisterPortable | cudaHostRegisterMapped);
+}
+
 void* numa_region_pinned_host_memory_resource::allocate([[maybe_unused]] cuda::stream_ref stream,
                                                         std::size_t bytes,
                                                         [[maybe_unused]] std::size_t alignment)
@@ -35,12 +54,14 @@ void* numa_region_pinned_host_memory_resource::allocate([[maybe_unused]] cuda::s
 
   if (_numa_node == -1) {
     void* ptr{nullptr};
-    CUCASCADE_CUDA_TRY_ALLOC(cudaHostAlloc(&ptr, bytes, cudaHostAllocDefault), bytes);
+    CUCASCADE_CUDA_TRY_ALLOC(
+      cudaHostAlloc(&ptr, bytes, static_cast<unsigned int>(_cuda_host_flags)), bytes);
     return ptr;
   } else {
     void* ptr = numa_alloc_onnode(bytes, _numa_node);
     if (ptr == nullptr) { throw rmm::bad_alloc(std::strerror(errno)); }
-    CUCASCADE_CUDA_TRY_ALLOC(cudaHostRegister(ptr, bytes, cudaHostRegisterMapped), bytes);
+    CUCASCADE_CUDA_TRY_ALLOC(
+      cudaHostRegister(ptr, bytes, static_cast<unsigned int>(_cuda_host_flags)), bytes);
     return ptr;
   }
 }
@@ -75,7 +96,8 @@ void numa_region_pinned_host_memory_resource::deallocate_sync(
 bool numa_region_pinned_host_memory_resource::operator==(
   numa_region_pinned_host_memory_resource const& other) const noexcept
 {
-  return this == &other && _numa_node == other._numa_node;
+  return this == &other && _numa_node == other._numa_node &&
+         _cuda_host_flags == other._cuda_host_flags;
 }
 
 }  // namespace memory

--- a/src/memory/reservation_manager_configurator.cpp
+++ b/src/memory/reservation_manager_configurator.cpp
@@ -176,6 +176,12 @@ builder_reference& reservation_manager_configurator::set_host_memory_resource_fa
   return *this;
 }
 
+builder_reference& reservation_manager_configurator::set_host_portability(bool make_portable)
+{
+  _host_memory_portability = make_portable;
+  return *this;
+}
+
 builder_reference& reservation_manager_configurator::set_disk_mounting_point(
   int uuid, std::size_t capacity, std::string mounting_point)
 {
@@ -198,6 +204,7 @@ std::vector<memory_space_config> reservation_manager_configurator::build(
 {
   auto gpus_info  = extract_gpu_ids(topology);
   auto host_infos = extract_host_ids(gpus_info, topology);
+  bool const make_host_portable = _host_memory_portability.value_or(gpus_info.size() > 1);
 
   std::vector<memory_space_config> configs;
   for (auto& info : gpus_info) {
@@ -227,13 +234,14 @@ std::vector<memory_space_config> reservation_manager_configurator::build(
     host_memory_space_config config;
     config.numa_id         = info.space_id;
     config.memory_capacity = per_host_capacity;
-    config.mr_factory_fn =
-      (info.space_id == info.numa_id)
-        ? _cpu_mr_fn
-        : [current_mr_fn = _cpu_mr_fn, numa_id = info.numa_id](
-            int, size_t capacity) -> cuda::mr::any_resource<cuda::mr::device_accessible> {
-      return current_mr_fn(numa_id, capacity);
+    config.make_portable   = make_host_portable;
+    DeviceMemoryResourceFactoryFn host_mr_fn =
+      [current_mr_fn = _cpu_mr_fn, numa_id = info.numa_id, make_host_portable](
+        int, size_t capacity) -> cuda::mr::any_resource<cuda::mr::device_accessible> {
+      if (current_mr_fn) { return current_mr_fn(numa_id, capacity); }
+      return make_default_host_memory_resource(numa_id, capacity, make_host_portable);
     };
+    config.mr_factory_fn = std::move(host_mr_fn);
     config.reservation_limit_fraction = _cpu_reservation.get_fraction(per_host_capacity);
     config.downgrade_trigger_fraction = downgrade_fractions_per_host_.first;
     config.downgrade_stop_fraction    = downgrade_fractions_per_host_.second;


### PR DESCRIPTION
[] Adds a CUDA event wrapper. 
[] Adds an option to make pinned memory portable for multiple GPUs. 
[] Adds support for portable pinned memory in the configurator (by default, it makes it portable if you have more than one GPU, unless specified otherwise).