### PR TITLE
Stop enabling C for C++ and CUDA builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 project(
   cuCascade
   VERSION 0.1.0
-  LANGUAGES C CXX CUDA
+  LANGUAGES CXX CUDA
   DESCRIPTION "GPU memory management and data representation library")
 
 # Options
@@ -63,7 +63,7 @@ endif()
 # =============================================================================
 option(CUCASCADE_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
 
-# Warning flags for C/C++
+# Warning flags for C++
 set(CUCASCADE_CXX_WARNING_FLAGS
     -Wall
     -Wextra
@@ -102,8 +102,7 @@ add_library(cucascade_objects OBJECT)
 # Apply warning flags to object library
 target_compile_options(
   cucascade_objects
-  PRIVATE $<$<COMPILE_LANGUAGE:C>:${CUCASCADE_CXX_WARNING_FLAGS}>
-          $<$<COMPILE_LANGUAGE:CXX>:${CUCASCADE_CXX_WARNING_FLAGS}>
+  PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${CUCASCADE_CXX_WARNING_FLAGS}>
           ${CUCASCADE_CUDA_WARNING_FLAGS})
 
 # NVTX compile definition

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -16,7 +16,6 @@
           "type": "PATH",
           "value": "$env{CMAKE_PREFIX_PATH}"
         },
-        "CMAKE_C_COMPILER_LAUNCHER": "sccache",
         "CMAKE_CXX_COMPILER_LAUNCHER": "sccache",
         "CMAKE_CUDA_COMPILER_LAUNCHER": "sccache"
       }

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -59,7 +59,6 @@ target_include_directories(
 target_compile_options(
   cucascade_benchmarks
   PRIVATE
-    $<$<COMPILE_LANGUAGE:C>:${CUCASCADE_CXX_WARNING_FLAGS}>
     $<$<COMPILE_LANGUAGE:CXX>:${CUCASCADE_CXX_WARNING_FLAGS};-Wno-null-dereference>
     ${CUCASCADE_CUDA_WARNING_FLAGS})
 


### PR DESCRIPTION
cuCascade only builds C++ and CUDA sources, so declaring C as a project language forces downstream builds to initialize and validate an unused compiler. That can break embedded package builds when the parent project has already initialized its C++ and CUDA toolchain state and a later C compiler check inherits incompatible launcher settings.

Drop the unused C language requirement so consumers only need the toolchains cuCascade actually uses. This keeps standalone builds working while avoiding unnecessary compiler checks in downstream integrations.