### PR TITLE
Fix for: Invalid Error: reconstruct_column: STRING column metadata must have at least one child (offsets)

### DIFF
--- a/src/data/representation_converter.cpp
+++ b/src/data/representation_converter.cpp
@@ -734,6 +734,12 @@ static std::unique_ptr<cudf::column> reconstruct_column(
   const cudf::size_type null_count = meta.has_null_mask ? meta.null_count : 0;
 
   if (meta.type_id == cudf::type_id::STRING) {
+    // cudf::make_empty_column(STRING) produces a 0-row strings column with no children, and
+    // plan_column_copy faithfully records that. Reconstruct the canonical empty strings column
+    // here instead of failing the offsets-child check below.
+    if (meta.children.empty() && meta.num_rows == 0) {
+      return cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING});
+    }
     if (meta.children.size() < 1) {
       throw std::invalid_argument(
         "reconstruct_column: STRING column metadata must have at least one child (offsets)");
@@ -1341,6 +1347,11 @@ static std::unique_ptr<cudf::column> reconstruct_column_from_disk(
   const cudf::size_type null_count = meta.has_null_mask ? meta.null_count : 0;
 
   if (meta.type_id == cudf::type_id::STRING) {
+    // See reconstruct_column for the empty-strings-column rationale. cudf::make_empty_column(
+    // STRING) produces a column with no children; recreate it instead of erroring.
+    if (meta.children.empty() && meta.num_rows == 0) {
+      return cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING});
+    }
     if (meta.children.size() < 1) {
       throw std::invalid_argument(
         "reconstruct_column_from_disk: STRING column metadata must have at least one child "

--- a/test/data/test_disk_host_converters.cpp
+++ b/test/data/test_disk_host_converters.cpp
@@ -315,6 +315,29 @@ TEST_CASE("host_data disk round-trip string column", "[disk][converter][string]"
   round_trip_test(std::make_unique<cudf::table>(std::move(cols)));
 }
 
+// Regression: cudf::make_empty_column(STRING) returns a 0-row strings column with no children.
+// plan_column_copy faithfully records 0 children, and reconstruct_column previously rejected
+// that metadata. Empty-string batches show up in real pipelines (e.g. probe-side partition
+// outputs after a filter), get downgraded to host under memory pressure, and crash on
+// upgrade back to GPU.
+TEST_CASE("host_data disk round-trip empty strings column", "[disk][converter][string][empty]")
+{
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING}));
+  round_trip_test(std::make_unique<cudf::table>(std::move(cols)));
+}
+
+TEST_CASE("host_data disk round-trip empty strings column mixed with non-empty column",
+          "[disk][converter][string][empty]")
+{
+  // Mimic the in-pipeline shape: a 0-row table where one of the columns is an empty STRING.
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(cudf::make_empty_column(cudf::data_type{cudf::type_id::INT32}));
+  cols.push_back(cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING}));
+  cols.push_back(cudf::make_empty_column(cudf::data_type{cudf::type_id::INT64}));
+  round_trip_test(std::make_unique<cudf::table>(std::move(cols)));
+}
+
 TEST_CASE("host_data disk round-trip string column with nulls", "[disk][converter][string][null]")
 {
   std::vector<std::string> host_strings = {"alpha", "beta", "gamma", "delta"};

--- a/test/data/test_gpu_disk_converters.cpp
+++ b/test/data/test_gpu_disk_converters.cpp
@@ -299,6 +299,25 @@ TEST_CASE("gpu disk round-trip string column", "[disk][gpu-converter][string]")
   gpu_disk_round_trip_test(std::make_unique<cudf::table>(std::move(cols)));
 }
 
+// Regression: see test_disk_host_converters.cpp — same root cause, but here we exercise the
+// direct disk→GPU path through reconstruct_column_from_disk.
+TEST_CASE("gpu disk round-trip empty strings column", "[disk][gpu-converter][string][empty]")
+{
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING}));
+  gpu_disk_round_trip_test(std::make_unique<cudf::table>(std::move(cols)));
+}
+
+TEST_CASE("gpu disk round-trip empty strings column mixed with non-empty column",
+          "[disk][gpu-converter][string][empty]")
+{
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(cudf::make_empty_column(cudf::data_type{cudf::type_id::INT32}));
+  cols.push_back(cudf::make_empty_column(cudf::data_type{cudf::type_id::STRING}));
+  cols.push_back(cudf::make_empty_column(cudf::data_type{cudf::type_id::INT64}));
+  gpu_disk_round_trip_test(std::make_unique<cudf::table>(std::move(cols)));
+}
+
 TEST_CASE("gpu disk round-trip string column with nulls", "[disk][gpu-converter][string][null]")
 {
   std::vector<std::string> host_strings = {"alpha", "beta", "gamma", "delta"};


### PR DESCRIPTION
The cucascade conversion code does not properly handle empty string columns. It assumes that a string column with no children is invalid, which in fact it is valid if its an empty column.

This PR implements a check for string columns that have 0 rows and no children, to interpret this correctly as an empty string column instead of a bad column.