### PR TITLE
Fix CMake dependency linkage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ cmake_minimum_required(VERSION 3.26.4 FATAL_ERROR)
 project(
   cuCascade
   VERSION 0.1.0
-  LANGUAGES C CXX CUDA
+  LANGUAGES CXX CUDA
   DESCRIPTION "GPU memory management and data representation library")
 
 # Options
@@ -63,7 +63,7 @@ endif()
 # =============================================================================
 option(CUCASCADE_WARNINGS_AS_ERRORS "Treat compiler warnings as errors" ON)
 
-# Warning flags for C/C++
+# Warning flags for C++
 set(CUCASCADE_CXX_WARNING_FLAGS
     -Wall
     -Wextra
@@ -77,7 +77,7 @@ set(CUCASCADE_CXX_WARNING_FLAGS
     -Wformat=2
     -Wimplicit-fallthrough)
 
-if(WARNINGS_AS_ERRORS)
+if(CUCASCADE_WARNINGS_AS_ERRORS)
   list(APPEND CUCASCADE_CXX_WARNING_FLAGS -Werror)
 endif()
 
@@ -103,8 +103,7 @@ add_library(cucascade_objects OBJECT)
 # Apply warning flags to object library
 target_compile_options(
   cucascade_objects
-  PRIVATE $<$<COMPILE_LANGUAGE:C>:${CUCASCADE_CXX_WARNING_FLAGS}>
-          $<$<COMPILE_LANGUAGE:CXX>:${CUCASCADE_CXX_WARNING_FLAGS}>
+  PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${CUCASCADE_CXX_WARNING_FLAGS}>
           ${CUCASCADE_CUDA_WARNING_FLAGS})
 
 # NVTX compile definition
@@ -122,7 +121,7 @@ set(CUCASCADE_PUBLIC_INCLUDE_DIRS
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
-set(CUCASCADE_PUBLIC_LINK_LIBS rmm::rmm cudf::cudf CUDA::cudart CUDA::nvml
+set(CUCASCADE_PUBLIC_LINK_LIBS rmm::rmm cudf::cudf CUDA::cudart_static
                                Threads::Threads ${NUMA_LIB})
 
 # Set include directories for the object library

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -59,8 +59,9 @@ target_compile_options(
           ${CUCASCADE_CUDA_WARNING_FLAGS})
 
 # Link dependencies
-target_link_libraries(cucascade_benchmarks
-                      PRIVATE cucascade benchmark::benchmark CUDA::cudart)
+target_link_libraries(
+  cucascade_benchmarks PRIVATE cucascade benchmark::benchmark
+                               CUDA::cudart_static)
 
 # Add custom target to run benchmarks
 add_custom_target(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,7 +58,7 @@ target_include_directories(
 
 # Link dependencies
 target_link_libraries(cucascade_tests PRIVATE cucascade Catch2::Catch2
-                                              CUDA::cudart)
+                                              CUDA::cudart_static)
 
 # Register tests with CTest
 add_test(NAME cucascade_tests COMMAND cucascade_tests)


### PR DESCRIPTION
## Summary
- Stop enabling the unused C language.
- Honor `CUCASCADE_WARNINGS_AS_ERRORS`.
- Link `CUDA::cudart_static` instead of the dynamic cudart target.

cuCascade uses cuDF directly. I did not find direct cuCascade source usage of KvikIO or nvCOMP, so this PR does not add either as a cuCascade dependency.

## Testing
- `env CPM_cuCascade_SOURCE="/home/coder/rapidsmpf/cuCascade" build-rapidsmpf-cpp -j0`