### PR TITLE
Construct `io_worker` thread after all other fields

### DIFF
--- a/src/data/pipeline_io_backend.cpp
+++ b/src/data/pipeline_io_backend.cpp
@@ -106,13 +106,15 @@ class io_worker {
     }
   }
 
-  std::thread _thread;
   std::mutex _mutex;
   std::condition_variable _cv;
   std::function<void()> _pending_work;
   std::promise<void> _pending_promise;
   bool _has_task{false};
   bool _shutdown{false};
+
+  // This has to be constructed last to prevent constructor race conditions
+  std::thread _thread;
 };
 
 /// Each pinned buffer is 64 MB — matches NVMe optimal I/O size


### PR DESCRIPTION
When the thread was constructed first, it was potentially started before other fields had a chance to initialize, resulting in strange segfaults and other errors when it encountered invalid fields. In particular, two failure modes were observed:

1. The thread started before the mutex had a chance to initialize, and when it attempted to lock the mutex, an error was thrown.
2. The thread attempted to fetch the pending work function before it was initialized, and thus attempted to call a function in invalid memory, resulting in a segfault.

Construct the thread after all other fields to ensure that they are always valid when the thread starts.