### PR TITLE
Work around nvml bug in static library too

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,6 +173,10 @@ if(CUCASCADE_BUILD_STATIC_LIBS)
   target_include_directories(cucascade_topology_discovery_static
                              PUBLIC ${CUCASCADE_PUBLIC_INCLUDE_DIRS})
   target_compile_features(cucascade_topology_discovery_static PUBLIC cxx_std_20)
+  # Work around a bug in libnvidia-ml.so - it attempts to call back into the
+  # stub library (https://nvbugspro.nvidia.com/bug/6174166)
+  target_link_options(cucascade_topology_discovery_static INTERFACE
+                      "LINKER:--exclude-libs,libnvidia-ml")
 
   set_target_properties(
     cucascade_topology_discovery_static


### PR DESCRIPTION
We previously only provided the `--exclude-libs` option when building the shared library. Ensure that anything that consumes the static library gets this option too.