### PR TITLE
Remove data converter registry

### DIFF
--- a/benchmark/benchmark_disk_converter.cpp
+++ b/benchmark/benchmark_disk_converter.cpp
@@ -105,16 +105,6 @@ void drop_os_cache(const std::string& path)
   }
 }
 
-/**
- * @brief Create a converter registry with all built-in converters.
- */
-std::unique_ptr<representation_converter_registry> make_benchmark_registry()
-{
-  auto registry = std::make_unique<representation_converter_registry>();
-  register_builtin_converters(*registry);
-  return registry;
-}
-
 // For non-NUMA systems, this should be -1, causing the allocator to use cudaHostAlloc instead of
 // cudaHostRegister
 constexpr int hostDevId = -1;
@@ -415,8 +405,6 @@ void BM_ConvertGpuToDisk(benchmark::State& state)
 
   auto mgr = get_shared_memory_manager();
 
-  auto registry = make_benchmark_registry();
-
   const memory_space* gpu_space  = mgr->get_memory_space(Tier::GPU, 0);
   const memory_space* disk_space = mgr->get_memory_space(Tier::DISK, 0);
 
@@ -435,16 +423,14 @@ void BM_ConvertGpuToDisk(benchmark::State& state)
     std::make_unique<cudf::table>(std::move(warmup_table)),
     *const_cast<memory_space*>(gpu_space),
     stream.view());
-  auto warmup_result =
-    registry->convert<disk_data_representation>(*warmup_repr, disk_space, stream.view());
+  auto warmup_result = warmup_repr->convert_to<disk_data_representation>(disk_space, stream.view());
   stream.synchronize();
 
   size_t bytes_transferred = gpu_rep->get_size_in_bytes();
 
   for ([[maybe_unused]] auto _ : state) {
     // No cache eviction needed — pipeline uses O_DIRECT
-    auto disk_result =
-      registry->convert<disk_data_representation>(*gpu_rep, disk_space, stream.view());
+    auto disk_result = gpu_rep->convert_to<disk_data_representation>(disk_space, stream.view());
     stream.synchronize();
     drop_os_cache(disk_result->get_disk_table().file_path);
   }
@@ -470,8 +456,6 @@ void BM_ConvertDiskToGpu(benchmark::State& state)
 
   auto mgr = get_shared_memory_manager();
 
-  auto registry = make_benchmark_registry();
-
   const memory_space* gpu_space  = mgr->get_memory_space(Tier::GPU, 0);
   const memory_space* disk_space = mgr->get_memory_space(Tier::DISK, 0);
 
@@ -484,15 +468,14 @@ void BM_ConvertDiskToGpu(benchmark::State& state)
                                                *const_cast<memory_space*>(gpu_space),
                                                stream.view());
 
-  auto disk_rep = registry->convert<disk_data_representation>(*gpu_rep, disk_space, stream.view());
+  auto disk_rep = gpu_rep->convert_to<disk_data_representation>(disk_space, stream.view());
   stream.synchronize();
 
   size_t bytes_transferred = disk_rep->get_size_in_bytes();
 
   for ([[maybe_unused]] auto _ : state) {
     // No cache eviction needed — pipeline uses O_DIRECT
-    auto gpu_result =
-      registry->convert<gpu_table_representation>(*disk_rep, gpu_space, stream.view());
+    auto gpu_result = disk_rep->convert_to<gpu_table_representation>(gpu_space, stream.view());
     stream.synchronize();
   }
 
@@ -517,9 +500,6 @@ void BM_ConvertHostToDisk(benchmark::State& state)
 
   auto mgr = get_shared_memory_manager();
 
-  auto registry = std::make_unique<representation_converter_registry>();
-  register_builtin_converters(*registry);
-
   const memory_space* gpu_space  = mgr->get_memory_space(Tier::GPU, 0);
   const memory_space* host_space = mgr->get_memory_space(Tier::HOST, hostDevId);
   const memory_space* disk_space = mgr->get_memory_space(Tier::DISK, 0);
@@ -533,15 +513,14 @@ void BM_ConvertHostToDisk(benchmark::State& state)
                                                *const_cast<memory_space*>(gpu_space),
                                                stream.view());
 
-  auto host_rep = registry->convert<host_data_representation>(*gpu_rep, host_space, stream.view());
+  auto host_rep = gpu_rep->convert_to<host_data_representation>(host_space, stream.view());
   stream.synchronize();
 
   size_t bytes_transferred = host_rep->get_size_in_bytes();
 
   for ([[maybe_unused]] auto _ : state) {
     // No cache eviction needed — pipeline uses O_DIRECT
-    auto disk_result =
-      registry->convert<disk_data_representation>(*host_rep, disk_space, stream.view());
+    auto disk_result = host_rep->convert_to<disk_data_representation>(disk_space, stream.view());
     stream.synchronize();
     drop_os_cache(disk_result->get_disk_table().file_path);
   }
@@ -567,9 +546,6 @@ void BM_ConvertDiskToHost(benchmark::State& state)
 
   auto mgr = get_shared_memory_manager();
 
-  auto registry = std::make_unique<representation_converter_registry>();
-  register_builtin_converters(*registry);
-
   const memory_space* gpu_space  = mgr->get_memory_space(Tier::GPU, 0);
   const memory_space* host_space = mgr->get_memory_space(Tier::HOST, hostDevId);
   const memory_space* disk_space = mgr->get_memory_space(Tier::DISK, 0);
@@ -583,18 +559,17 @@ void BM_ConvertDiskToHost(benchmark::State& state)
                                                *const_cast<memory_space*>(gpu_space),
                                                stream.view());
 
-  auto host_rep = registry->convert<host_data_representation>(*gpu_rep, host_space, stream.view());
+  auto host_rep = gpu_rep->convert_to<host_data_representation>(host_space, stream.view());
   stream.synchronize();
 
-  auto disk_rep = registry->convert<disk_data_representation>(*host_rep, disk_space, stream.view());
+  auto disk_rep = host_rep->convert_to<disk_data_representation>(disk_space, stream.view());
   stream.synchronize();
 
   size_t bytes_transferred = disk_rep->get_size_in_bytes();
 
   for ([[maybe_unused]] auto _ : state) {
     // No cache eviction needed — pipeline uses O_DIRECT
-    auto host_result =
-      registry->convert<host_data_representation>(*disk_rep, host_space, stream.view());
+    auto host_result = disk_rep->convert_to<host_data_representation>(host_space, stream.view());
     stream.synchronize();
   }
 
@@ -623,8 +598,6 @@ void BM_ConvertGpuToDiskStringColumns(benchmark::State& state)
 
   auto mgr = get_shared_memory_manager();
 
-  auto registry = make_benchmark_registry();
-
   const memory_space* gpu_space  = mgr->get_memory_space(Tier::GPU, 0);
   const memory_space* disk_space = mgr->get_memory_space(Tier::DISK, 0);
 
@@ -640,8 +613,7 @@ void BM_ConvertGpuToDiskStringColumns(benchmark::State& state)
 
   for ([[maybe_unused]] auto _ : state) {
     // No cache eviction needed — pipeline uses O_DIRECT
-    auto disk_result =
-      registry->convert<disk_data_representation>(*gpu_rep, disk_space, stream.view());
+    auto disk_result = gpu_rep->convert_to<disk_data_representation>(disk_space, stream.view());
     stream.synchronize();
     drop_os_cache(disk_result->get_disk_table().file_path);
   }
@@ -667,8 +639,6 @@ void BM_ConvertGpuToDiskListColumns(benchmark::State& state)
 
   auto mgr = get_shared_memory_manager();
 
-  auto registry = make_benchmark_registry();
-
   const memory_space* gpu_space  = mgr->get_memory_space(Tier::GPU, 0);
   const memory_space* disk_space = mgr->get_memory_space(Tier::DISK, 0);
 
@@ -684,8 +654,7 @@ void BM_ConvertGpuToDiskListColumns(benchmark::State& state)
 
   for ([[maybe_unused]] auto _ : state) {
     // No cache eviction needed — pipeline uses O_DIRECT
-    auto disk_result =
-      registry->convert<disk_data_representation>(*gpu_rep, disk_space, stream.view());
+    auto disk_result = gpu_rep->convert_to<disk_data_representation>(disk_space, stream.view());
     stream.synchronize();
     drop_os_cache(disk_result->get_disk_table().file_path);
   }
@@ -711,8 +680,6 @@ void BM_ConvertGpuToDiskStructColumns(benchmark::State& state)
 
   auto mgr = get_shared_memory_manager();
 
-  auto registry = make_benchmark_registry();
-
   const memory_space* gpu_space  = mgr->get_memory_space(Tier::GPU, 0);
   const memory_space* disk_space = mgr->get_memory_space(Tier::DISK, 0);
 
@@ -728,8 +695,7 @@ void BM_ConvertGpuToDiskStructColumns(benchmark::State& state)
 
   for ([[maybe_unused]] auto _ : state) {
     // No cache eviction needed — pipeline uses O_DIRECT
-    auto disk_result =
-      registry->convert<disk_data_representation>(*gpu_rep, disk_space, stream.view());
+    auto disk_result = gpu_rep->convert_to<disk_data_representation>(disk_space, stream.view());
     stream.synchronize();
     drop_os_cache(disk_result->get_disk_table().file_path);
   }
@@ -825,9 +791,6 @@ void BM_ConvertGpuToDiskPipeline(benchmark::State& state)
 
   auto mgr = get_shared_memory_manager();
 
-  auto registry = std::make_unique<representation_converter_registry>();
-  register_builtin_converters(*registry);
-
   const memory_space* gpu_space  = mgr->get_memory_space(Tier::GPU, 0);
   const memory_space* disk_space = mgr->get_memory_space(Tier::DISK, 0);
 
@@ -843,8 +806,7 @@ void BM_ConvertGpuToDiskPipeline(benchmark::State& state)
 
   for ([[maybe_unused]] auto _ : state) {
     // No cache eviction needed — pipeline uses O_DIRECT
-    auto disk_result =
-      registry->convert<disk_data_representation>(*gpu_rep, disk_space, stream.view());
+    auto disk_result = gpu_rep->convert_to<disk_data_representation>(disk_space, stream.view());
     stream.synchronize();
     drop_os_cache(disk_result->get_disk_table().file_path);
   }
@@ -881,11 +843,9 @@ std::unique_ptr<disk_data_representation> write_table_to_disk(cudf::table&& tabl
                                                               const memory_space* disk_space,
                                                               rmm::cuda_stream_view stream)
 {
-  auto registry = make_benchmark_registry();
-
   auto gpu_rep = std::make_unique<gpu_table_representation>(
     std::make_unique<cudf::table>(std::move(table)), *const_cast<memory_space*>(gpu_space), stream);
-  auto disk_rep = registry->convert<disk_data_representation>(*gpu_rep, disk_space, stream);
+  auto disk_rep = gpu_rep->convert_to<disk_data_representation>(disk_space, stream);
   stream.synchronize();
   return disk_rep;
 }
@@ -908,15 +868,12 @@ void BM_ConvertDiskToGpuPipeline(benchmark::State& state)
                                       disk_space,
                                       stream.view());
 
-  auto registry = make_benchmark_registry();
-
   size_t bytes_transferred = disk_rep->get_size_in_bytes();
   const auto& disk_file    = disk_rep->get_disk_table().file_path;
 
   for ([[maybe_unused]] auto _ : state) {
     drop_os_cache(disk_file);
-    auto gpu_result =
-      registry->convert<gpu_table_representation>(*disk_rep, gpu_space, stream.view());
+    auto gpu_result = disk_rep->convert_to<gpu_table_representation>(gpu_space, stream.view());
     stream.synchronize();
   }
 
@@ -954,8 +911,6 @@ void pipeline_write_benchmark(benchmark::State& state, TableFactory table_factor
 
   auto mgr = get_shared_memory_manager();
 
-  auto registry = make_benchmark_registry();
-
   const memory_space* gpu_space  = mgr->get_memory_space(Tier::GPU, 0);
   const memory_space* disk_space = mgr->get_memory_space(Tier::DISK, 0);
 
@@ -971,7 +926,7 @@ void pipeline_write_benchmark(benchmark::State& state, TableFactory table_factor
 
   for ([[maybe_unused]] auto _ : state) {
     auto disk_result =
-      registry->convert<disk_data_representation>(*gpu_rep, disk_space, stream.view());
+      gpu_rep->template convert_to<disk_data_representation>(disk_space, stream.view());
     stream.synchronize();
     drop_os_cache(disk_result->get_disk_table().file_path);
   }
@@ -1004,15 +959,13 @@ void pipeline_read_benchmark(benchmark::State& state, TableFactory table_factory
   auto disk_rep = write_table_to_disk(
     table_factory(total_bytes, num_columns), gpu_space, disk_space, stream.view());
 
-  auto registry = make_benchmark_registry();
-
   size_t bytes_transferred = disk_rep->get_size_in_bytes();
   const auto& disk_file    = disk_rep->get_disk_table().file_path;
 
   for ([[maybe_unused]] auto _ : state) {
     drop_os_cache(disk_file);
     auto gpu_result =
-      registry->convert<gpu_table_representation>(*disk_rep, gpu_space, stream.view());
+      disk_rep->template convert_to<gpu_table_representation>(gpu_space, stream.view());
     stream.synchronize();
   }
 

--- a/benchmark/benchmark_representation_converter.cpp
+++ b/benchmark/benchmark_representation_converter.cpp
@@ -175,9 +175,6 @@ void BM_ConvertGpuToHost(benchmark::State& state)
   // Use shared memory manager across all threads
   auto mgr = get_shared_memory_manager();
 
-  auto registry = std::make_unique<representation_converter_registry>();
-  register_builtin_converters(*registry);
-
   const memory_space* gpu_space  = mgr->get_memory_space(Tier::GPU, 0);
   const memory_space* host_space = mgr->get_memory_space(Tier::HOST, hostDevId);
 
@@ -202,7 +199,7 @@ void BM_ConvertGpuToHost(benchmark::State& state)
     *const_cast<memory_space*>(gpu_space),
     warmup_stream.view());
   auto warmup_result =
-    registry->convert<host_data_packed_representation>(*warmup_repr, host_space, warmup_stream);
+    warmup_repr->convert_to<host_data_packed_representation>(host_space, warmup_stream);
   warmup_stream.synchronize();
 
   size_t bytes_transferred = thread_gpu_reprs[0]->get_size_in_bytes() * thread_count;
@@ -215,8 +212,8 @@ void BM_ConvertGpuToHost(benchmark::State& state)
     // Create threads
     for (uint64_t t = 0; t < thread_count; ++t) {
       threads.emplace_back([&, t]() {
-        auto host_result = registry->convert<host_data_packed_representation>(
-          *thread_gpu_reprs[t], host_space, streams[t]);
+        auto host_result =
+          thread_gpu_reprs[t]->convert_to<host_data_packed_representation>(host_space, streams[t]);
         streams[t].synchronize();
       });
     }
@@ -250,9 +247,6 @@ void BM_ConvertHostToGpu(benchmark::State& state)
   // Use shared memory manager across all threads
   auto mgr = get_shared_memory_manager();
 
-  auto registry = std::make_unique<representation_converter_registry>();
-  register_builtin_converters(*registry);
-
   const memory_space* gpu_space  = mgr->get_memory_space(Tier::GPU, 0);
   const memory_space* host_space = mgr->get_memory_space(Tier::HOST, hostDevId);
 
@@ -269,7 +263,7 @@ void BM_ConvertHostToGpu(benchmark::State& state)
                                                  *const_cast<memory_space*>(gpu_space),
                                                  setup_stream.view());
     auto host_repr =
-      registry->convert<host_data_packed_representation>(*gpu_repr_temp, host_space, setup_stream);
+      gpu_repr_temp->convert_to<host_data_packed_representation>(host_space, setup_stream);
     setup_stream.synchronize();
     thread_host_reprs.push_back(std::move(host_repr));
   }
@@ -277,7 +271,7 @@ void BM_ConvertHostToGpu(benchmark::State& state)
   // Warm-up
   rmm::cuda_stream warmup_stream;
   auto warmup_result =
-    registry->convert<gpu_table_representation>(*thread_host_reprs[0], gpu_space, warmup_stream);
+    thread_host_reprs[0]->convert_to<gpu_table_representation>(gpu_space, warmup_stream);
   warmup_stream.synchronize();
 
   size_t bytes_transferred = thread_host_reprs[0]->get_size_in_bytes() * thread_count;
@@ -291,7 +285,7 @@ void BM_ConvertHostToGpu(benchmark::State& state)
     for (uint64_t t = 0; t < thread_count; ++t) {
       threads.emplace_back([&, t]() {
         auto gpu_result =
-          registry->convert<gpu_table_representation>(*thread_host_reprs[t], gpu_space, streams[t]);
+          thread_host_reprs[t]->convert_to<gpu_table_representation>(gpu_space, streams[t]);
         streams[t].synchronize();
       });
     }
@@ -328,9 +322,6 @@ void BM_ConvertGpuToHostFast(benchmark::State& state)
 
   auto mgr = get_shared_memory_manager();
 
-  auto registry = std::make_unique<representation_converter_registry>();
-  register_builtin_converters(*registry);
-
   const memory_space* gpu_space  = mgr->get_memory_space(Tier::GPU, 0);
   const memory_space* host_space = mgr->get_memory_space(Tier::HOST, hostDevId);
 
@@ -353,8 +344,7 @@ void BM_ConvertGpuToHostFast(benchmark::State& state)
     std::make_unique<cudf::table>(std::move(warmup_table)),
     *const_cast<memory_space*>(gpu_space),
     warmup_stream.view());
-  auto warmup_result =
-    registry->convert<host_data_representation>(*warmup_repr, host_space, warmup_stream);
+  auto warmup_result = warmup_repr->convert_to<host_data_representation>(host_space, warmup_stream);
   warmup_stream.synchronize();
 
   size_t bytes_transferred = thread_gpu_reprs[0]->get_size_in_bytes() * thread_count;
@@ -366,7 +356,7 @@ void BM_ConvertGpuToHostFast(benchmark::State& state)
     for (uint64_t t = 0; t < thread_count; ++t) {
       threads.emplace_back([&, t]() {
         auto host_result =
-          registry->convert<host_data_representation>(*thread_gpu_reprs[t], host_space, streams[t]);
+          thread_gpu_reprs[t]->convert_to<host_data_representation>(host_space, streams[t]);
         streams[t].synchronize();
       });
     }
@@ -397,9 +387,6 @@ void BM_ConvertHostFastToGpu(benchmark::State& state)
 
   auto mgr = get_shared_memory_manager();
 
-  auto registry = std::make_unique<representation_converter_registry>();
-  register_builtin_converters(*registry);
-
   const memory_space* gpu_space  = mgr->get_memory_space(Tier::GPU, 0);
   const memory_space* host_space = mgr->get_memory_space(Tier::HOST, hostDevId);
 
@@ -414,8 +401,7 @@ void BM_ConvertHostFastToGpu(benchmark::State& state)
       std::make_unique<gpu_table_representation>(std::make_unique<cudf::table>(std::move(table)),
                                                  *const_cast<memory_space*>(gpu_space),
                                                  setup_stream.view());
-    auto host_repr =
-      registry->convert<host_data_representation>(*gpu_repr_temp, host_space, setup_stream);
+    auto host_repr = gpu_repr_temp->convert_to<host_data_representation>(host_space, setup_stream);
     setup_stream.synchronize();
     thread_host_reprs.push_back(std::move(host_repr));
   }
@@ -423,7 +409,7 @@ void BM_ConvertHostFastToGpu(benchmark::State& state)
   // Warm-up
   rmm::cuda_stream warmup_stream;
   auto warmup_result =
-    registry->convert<gpu_table_representation>(*thread_host_reprs[0], gpu_space, warmup_stream);
+    thread_host_reprs[0]->convert_to<gpu_table_representation>(gpu_space, warmup_stream);
   warmup_stream.synchronize();
 
   size_t bytes_transferred = thread_host_reprs[0]->get_size_in_bytes() * thread_count;
@@ -435,7 +421,7 @@ void BM_ConvertHostFastToGpu(benchmark::State& state)
     for (uint64_t t = 0; t < thread_count; ++t) {
       threads.emplace_back([&, t]() {
         auto gpu_result =
-          registry->convert<gpu_table_representation>(*thread_host_reprs[t], gpu_space, streams[t]);
+          thread_host_reprs[t]->convert_to<gpu_table_representation>(gpu_space, streams[t]);
         streams[t].synchronize();
       });
     }

--- a/include/cucascade/data/bandwidth_profiler.hpp
+++ b/include/cucascade/data/bandwidth_profiler.hpp
@@ -147,9 +147,10 @@ struct bandwidth_profile {
  * At least one GPU space must be present: it is used to materialize the canonical source
  * cudf table that seeds every pairwise transfer.
  *
+ * Conversions dispatch through the process-wide `representation_converter_registry::instance()`,
+ * which is lazily populated with the built-in converters on first use.
+ *
  * @param spaces   The memory spaces to profile.
- * @param registry Converter registry to dispatch through. Pass a registry populated by
- *                 `register_builtin_converters` plus any user-supplied converters.
  * @param config   Measurement knobs; defaults probe a size sweep.
  *
  * @return `bandwidth_profile` containing one `bandwidth_pair_result` per ordered pair considered.
@@ -157,7 +158,6 @@ struct bandwidth_profile {
  * @throws std::invalid_argument if no GPU space is present in `spaces`.
  */
 [[nodiscard]] bandwidth_profile measure_bandwidth(std::span<memory::memory_space* const> spaces,
-                                                  const representation_converter_registry& registry,
                                                   const bandwidth_profile_config& config = {});
 
 }  // namespace data

--- a/include/cucascade/data/common.hpp
+++ b/include/cucascade/data/common.hpp
@@ -24,8 +24,12 @@
 #include <concepts>
 #include <cstddef>
 #include <memory>
+#include <typeindex>
+#include <typeinfo>
 
 namespace cucascade {
+
+class representation_converter_registry;  // forward declaration for template methods below
 
 /**
  * @brief Interface representing a data representation residing in a specific memory tier.
@@ -43,8 +47,11 @@ class idata_representation {
    * @brief Construct a new idata_representation object
    *
    * @param memory_space The memory space where the data resides
+   * @param type_idx     The std::type_index of the most-derived class — subclasses must pass
+   *                     `typeid(SubclassName)`. Used as the source key for converter lookup.
    */
-  idata_representation(cucascade::memory::memory_space& memory_space) : _memory_space(memory_space)
+  idata_representation(cucascade::memory::memory_space& memory_space, std::type_index type_idx)
+    : _memory_space(memory_space), _type_index(type_idx)
   {
   }
 
@@ -52,6 +59,47 @@ class idata_representation {
    * @brief Virtual destructor to ensure proper cleanup of derived classes
    */
   virtual ~idata_representation() = default;
+
+  /**
+   * @brief Get the stored type identifier of the most-derived class.
+   *
+   * This is the source key used for converter lookup against the
+   * `representation_converter_registry`. Subclasses set it at construction.
+   */
+  [[nodiscard]] std::type_index get_type_index() const noexcept { return _type_index; }
+
+  /**
+   * @brief Convert this representation to a new `Dst` representation via the singleton registry.
+   *
+   * @tparam Dst The target representation type (must derive from `idata_representation`).
+   * @param target_memory_space The memory space the new representation lives in.
+   * @param stream              CUDA stream for memory operations.
+   * @return Owning pointer to the newly produced representation.
+   * @throws std::runtime_error if no converter is registered for `(this->get_type_index(), Dst)`.
+   *
+   * Definition lives in `representation_converter.hpp` (after the registry class is defined).
+   */
+  template <typename Dst>
+    requires std::derived_from<Dst, idata_representation>
+  std::unique_ptr<Dst> convert_to(const cucascade::memory::memory_space* target_memory_space,
+                                  rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+
+  /**
+   * @brief Equivalent to `convert_to<Dst>` at the representation level; provided for API symmetry
+   *        with `data_batch::clone_to`. Both return an independent new representation.
+   */
+  template <typename Dst>
+    requires std::derived_from<Dst, idata_representation>
+  std::unique_ptr<Dst> clone_to(const cucascade::memory::memory_space* target_memory_space,
+                                rmm::cuda_stream_view stream = rmm::cuda_stream_default);
+
+  /**
+   * @brief Check whether the singleton registry has a converter from this representation's
+   *        runtime type to `Dst`.
+   */
+  template <typename Dst>
+    requires std::derived_from<Dst, idata_representation>
+  [[nodiscard]] bool has_converter() const;
 
   /**
    * @brief Get the tier of memory that this representation resides in
@@ -142,6 +190,7 @@ class idata_representation {
 
  private:
   cucascade::memory::memory_space& _memory_space;  ///< The memory space where the data resides
+  std::type_index _type_index;  ///< Runtime type tag set by the most-derived ctor
 };
 
 }  // namespace cucascade

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -338,10 +338,9 @@ class read_only_data_batch {
    * @brief Create an independent deep copy with representation conversion.
    *
    * The clone has a new batch ID and its data is converted to TargetRepresentation
-   * using the provided converter registry.
+   * using the process-wide converter registry (`representation_converter_registry::instance()`).
    *
    * @tparam TargetRepresentation Target representation type.
-   * @param registry           Converter registry for type-keyed dispatch.
    * @param new_batch_id       Batch ID for the cloned batch.
    * @param target_memory_space Target memory space for the converted data.
    * @param stream              CUDA stream for memory operations.
@@ -349,7 +348,6 @@ class read_only_data_batch {
    */
   template <typename TargetRepresentation>
   [[nodiscard]] std::shared_ptr<data_batch> clone_to(
-    representation_converter_registry& registry,
     uint64_t new_batch_id,
     const memory::memory_space* target_memory_space,
     rmm::cuda_stream_view stream) const;
@@ -418,19 +416,17 @@ class mutable_data_batch {
   /**
    * @brief Convert the data representation in-place.
    *
-   * Replaces the held data with a new representation produced by the converter
-   * registry. If the conversion involves the GPU tier, synchronizes the stream
-   * before the old representation is destroyed to prevent use-after-free.
+   * Replaces the held data with a new representation produced by the process-wide
+   * converter registry (`representation_converter_registry::instance()`). If the
+   * conversion involves the GPU tier, synchronizes the stream before the old
+   * representation is destroyed to prevent use-after-free.
    *
    * @tparam TargetRepresentation Target representation type.
-   * @param registry           Converter registry for type-keyed dispatch.
    * @param target_memory_space Target memory space for the new representation.
    * @param stream              CUDA stream for memory operations.
    */
   template <typename TargetRepresentation>
-  void convert_to(representation_converter_registry& registry,
-                  const memory::memory_space* target_memory_space,
-                  rmm::cuda_stream_view stream);
+  void convert_to(const memory::memory_space* target_memory_space, rmm::cuda_stream_view stream);
 
   // -- Clone operations (CLONE-01/CLONE-02) --
 
@@ -452,10 +448,9 @@ class mutable_data_batch {
    * @brief Create an independent deep copy with representation conversion.
    *
    * The clone has a new batch ID and its data is converted to TargetRepresentation
-   * using the provided converter registry.
+   * using the process-wide converter registry (`representation_converter_registry::instance()`).
    *
    * @tparam TargetRepresentation Target representation type.
-   * @param registry           Converter registry for type-keyed dispatch.
    * @param new_batch_id       Batch ID for the cloned batch.
    * @param target_memory_space Target memory space for the converted data.
    * @param stream              CUDA stream for memory operations.
@@ -463,7 +458,6 @@ class mutable_data_batch {
    */
   template <typename TargetRepresentation>
   [[nodiscard]] std::shared_ptr<data_batch> clone_to(
-    representation_converter_registry& registry,
     uint64_t new_batch_id,
     const memory::memory_space* target_memory_space,
     rmm::cuda_stream_view stream) const;
@@ -501,25 +495,25 @@ class mutable_data_batch {
 
 template <typename TargetRepresentation>
 std::shared_ptr<data_batch> read_only_data_batch::clone_to(
-  representation_converter_registry& registry,
   uint64_t new_batch_id,
   const memory::memory_space* target_memory_space,
   rmm::cuda_stream_view stream) const
 {
   auto new_representation =
-    registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
+    representation_converter_registry::instance().convert<TargetRepresentation>(
+      *_batch->_data, target_memory_space, stream);
   return std::make_shared<data_batch>(new_batch_id, std::move(new_representation));
 }
 
 // -- mutable_data_batch::convert_to (in-place conversion) --
 
 template <typename TargetRepresentation>
-void mutable_data_batch::convert_to(representation_converter_registry& registry,
-                                    const memory::memory_space* target_memory_space,
+void mutable_data_batch::convert_to(const memory::memory_space* target_memory_space,
                                     rmm::cuda_stream_view stream)
 {
   auto new_representation =
-    registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
+    representation_converter_registry::instance().convert<TargetRepresentation>(
+      *_batch->_data, target_memory_space, stream);
   auto old_representation = std::move(_batch->_data);
   _batch->_data           = std::move(new_representation);
 
@@ -539,13 +533,13 @@ void mutable_data_batch::convert_to(representation_converter_registry& registry,
 
 template <typename TargetRepresentation>
 std::shared_ptr<data_batch> mutable_data_batch::clone_to(
-  representation_converter_registry& registry,
   uint64_t new_batch_id,
   const memory::memory_space* target_memory_space,
   rmm::cuda_stream_view stream) const
 {
   auto new_representation =
-    registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
+    representation_converter_registry::instance().convert<TargetRepresentation>(
+      *_batch->_data, target_memory_space, stream);
   return std::make_shared<data_batch>(new_batch_id, std::move(new_representation));
 }
 

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -500,8 +500,7 @@ std::shared_ptr<data_batch> read_only_data_batch::clone_to(
   rmm::cuda_stream_view stream) const
 {
   auto new_representation =
-    representation_converter_registry::instance().convert<TargetRepresentation>(
-      *_batch->_data, target_memory_space, stream);
+    _batch->_data->clone_to<TargetRepresentation>(target_memory_space, stream);
   return std::make_shared<data_batch>(new_batch_id, std::move(new_representation));
 }
 
@@ -512,8 +511,7 @@ void mutable_data_batch::convert_to(const memory::memory_space* target_memory_sp
                                     rmm::cuda_stream_view stream)
 {
   auto new_representation =
-    representation_converter_registry::instance().convert<TargetRepresentation>(
-      *_batch->_data, target_memory_space, stream);
+    _batch->_data->convert_to<TargetRepresentation>(target_memory_space, stream);
   auto old_representation = std::move(_batch->_data);
   _batch->_data           = std::move(new_representation);
 
@@ -538,8 +536,7 @@ std::shared_ptr<data_batch> mutable_data_batch::clone_to(
   rmm::cuda_stream_view stream) const
 {
   auto new_representation =
-    representation_converter_registry::instance().convert<TargetRepresentation>(
-      *_batch->_data, target_memory_space, stream);
+    _batch->_data->clone_to<TargetRepresentation>(target_memory_space, stream);
   return std::make_shared<data_batch>(new_batch_id, std::move(new_representation));
 }
 

--- a/include/cucascade/data/gpu_data_representation.hpp
+++ b/include/cucascade/data/gpu_data_representation.hpp
@@ -199,7 +199,7 @@ gpu_table_representation::gpu_table_representation(cudf::table_view table_view,
                                                    std::size_t alloc_size,
                                                    cucascade::memory::memory_space& memory_space,
                                                    rmm::cuda_stream_view writer_stream)
-  : idata_representation(memory_space),
+  : idata_representation(memory_space, typeid(gpu_table_representation)),
     _table(
       owning_table_view{std::make_any<Owner>(std::forward<Owner>(owner)), alloc_size, table_view})
 {

--- a/include/cucascade/data/representation_converter.hpp
+++ b/include/cucascade/data/representation_converter.hpp
@@ -24,7 +24,7 @@
 
 #include <functional>
 #include <memory>
-#include <mutex>
+#include <shared_mutex>
 #include <stdexcept>
 #include <typeindex>
 #include <unordered_map>
@@ -259,7 +259,7 @@ class representation_converter_registry {
     rmm::cuda_stream_view stream) const;
   bool unregister_converter_impl(const converter_key& key);
 
-  mutable std::mutex _mutex;
+  mutable std::shared_mutex _mutex;
   std::unordered_map<converter_key, representation_converter_fn, converter_key_hash> _converters;
 };
 

--- a/include/cucascade/data/representation_converter.hpp
+++ b/include/cucascade/data/representation_converter.hpp
@@ -174,7 +174,16 @@ class representation_converter_registry {
   template <typename TargetType>
   bool has_converter_for(const idata_representation& source) const
   {
-    converter_key key{std::type_index(typeid(source)), std::type_index(typeid(TargetType))};
+    converter_key key{source.get_type_index(), std::type_index(typeid(TargetType))};
+    return has_converter_impl(key);
+  }
+
+  /**
+   * @brief Check if a converter exists for the given pre-built key. Public so that
+   *        `idata_representation::has_converter<Dst>()` can look up by stored source type.
+   */
+  [[nodiscard]] bool has_converter(const converter_key& key) const
+  {
     return has_converter_impl(key);
   }
 
@@ -196,7 +205,7 @@ class representation_converter_registry {
                                       const memory::memory_space* target_memory_space,
                                       rmm::cuda_stream_view stream = rmm::cuda_stream_default) const
   {
-    converter_key key{std::type_index(typeid(source)), std::type_index(typeid(TargetType))};
+    converter_key key{source.get_type_index(), std::type_index(typeid(TargetType))};
     auto result = convert_impl(key, source, target_memory_space, stream);
     return std::unique_ptr<TargetType>(static_cast<TargetType*>(result.release()));
   }
@@ -264,5 +273,37 @@ class representation_converter_registry {
  * @param registry The converter registry to register converters with.
  */
 void register_builtin_converters(representation_converter_registry& registry);
+
+// =============================================================================
+// idata_representation template method definitions
+//
+// Declared in <cucascade/data/common.hpp>; defined here because they call into the
+// singleton registry, which is fully visible only after this header.
+// =============================================================================
+
+template <typename Dst>
+  requires std::derived_from<Dst, idata_representation>
+std::unique_ptr<Dst> idata_representation::convert_to(
+  const cucascade::memory::memory_space* target_memory_space, rmm::cuda_stream_view stream)
+{
+  return representation_converter_registry::instance().convert<Dst>(
+    *this, target_memory_space, stream);
+}
+
+template <typename Dst>
+  requires std::derived_from<Dst, idata_representation>
+std::unique_ptr<Dst> idata_representation::clone_to(
+  const cucascade::memory::memory_space* target_memory_space, rmm::cuda_stream_view stream)
+{
+  return convert_to<Dst>(target_memory_space, stream);
+}
+
+template <typename Dst>
+  requires std::derived_from<Dst, idata_representation>
+bool idata_representation::has_converter() const
+{
+  converter_key key{_type_index, std::type_index(typeid(Dst))};
+  return representation_converter_registry::instance().has_converter(key);
+}
 
 }  // namespace cucascade

--- a/include/cucascade/data/representation_converter.hpp
+++ b/include/cucascade/data/representation_converter.hpp
@@ -110,6 +110,16 @@ class representation_converter_registry {
   ~representation_converter_registry() = default;
 
   /**
+   * @brief Access the process-wide registry instance.
+   *
+   * On first call, the registry is populated with the built-in converters via
+   * `register_builtin_converters`. Subsequent calls return the same instance.
+   *
+   * @return Reference to the singleton registry.
+   */
+  static representation_converter_registry& instance();
+
+  /**
    * @brief Register a converter between two representation types.
    *
    * @code

--- a/src/data/bandwidth_profiler.cpp
+++ b/src/data/bandwidth_profiler.cpp
@@ -93,10 +93,7 @@ std::unique_ptr<cudf::table> make_gpu_table_of_size(std::size_t size_bytes,
 /// is a GPU other than the bootstrap, the GPU->GPU converter moves data across devices itself
 /// (it acquires a stream on the target GPU internally).
 std::unique_ptr<idata_representation> build_source_representation(
-  memory::memory_space* src_space,
-  memory::memory_space* bootstrap_gpu,
-  std::size_t size_bytes,
-  const representation_converter_registry& registry)
+  memory::memory_space* src_space, memory::memory_space* bootstrap_gpu, std::size_t size_bytes)
 {
   // The initial cudf table MUST be allocated with the bootstrap GPU as the current CUDA device,
   // otherwise cudf's scratch allocations land on the wrong GPU and we hit illegal-memory-access
@@ -110,12 +107,13 @@ std::unique_ptr<idata_representation> build_source_representation(
     std::make_unique<gpu_table_representation>(std::move(table), *bootstrap_gpu, bootstrap_stream);
   bootstrap_stream.synchronize();
 
-  // Step 2: land the data in the requested src space via the registry. The converter is
-  // responsible for switching device when moving data across GPUs.
+  // Step 2: land the data in the requested src space via the singleton registry. The converter
+  // is responsible for switching device when moving data across GPUs.
   if (src_space == bootstrap_gpu) { return gpu_rep; }
 
   auto src_type = canonical_type_for(src_space->get_tier());
-  auto result   = registry.convert(*gpu_rep, src_type, src_space, bootstrap_stream);
+  auto result   = representation_converter_registry::instance().convert(
+    *gpu_rep, src_type, src_space, bootstrap_stream);
   // The converter may have enqueued async GPU reads from `gpu_rep`'s table on
   // `bootstrap_stream`. Sync before `gpu_rep` goes out of scope — otherwise its cuDF table's
   // RMM deallocation races with the in-flight copy and corrupts the converted output.
@@ -151,17 +149,18 @@ void evict_page_cache(const std::string& path)
   ::close(fd);
 }
 
-/// Core per-pair probe — warmup + timed loop around `registry.convert(...)`.
+/// Core per-pair probe — warmup + timed loop around the singleton registry's `convert(...)`.
 bandwidth_sample measure_single_size(idata_representation& source,
                                      std::type_index target_type,
                                      memory::memory_space* dst_space,
-                                     const representation_converter_registry& registry,
                                      rmm::cuda_stream_view stream,
                                      std::size_t nominal_size_bytes,
                                      std::size_t warmup_iters,
                                      std::size_t timed_iters,
                                      bool drop_page_cache_between_iters)
 {
+  auto& registry = representation_converter_registry::instance();
+
   // Grab the disk source's file path once so we can evict its page cache between iterations.
   // For non-disk sources this stays empty and the evict call is skipped.
   std::string disk_source_path;
@@ -258,7 +257,6 @@ std::optional<bandwidth_sample> bandwidth_profile::sample(memory::memory_space_i
 // ---------------------------------------------------------------------------------------------
 
 bandwidth_profile measure_bandwidth(std::span<memory::memory_space* const> spaces,
-                                    const representation_converter_registry& registry,
                                     const bandwidth_profile_config& config)
 {
   bandwidth_profile profile;
@@ -310,7 +308,7 @@ bandwidth_profile measure_bandwidth(std::span<memory::memory_space* const> space
 
       for (auto size_bytes : config.test_sizes_bytes) {
         try {
-          auto source = build_source_representation(src, bootstrap_gpu, size_bytes, registry);
+          auto source = build_source_representation(src, bootstrap_gpu, size_bytes);
 
           // Pin the current CUDA context to the stream's device for the duration of the
           // measurement loop. Some converter and disk-backend code paths allocate scratch on
@@ -330,7 +328,6 @@ bandwidth_profile measure_bandwidth(std::span<memory::memory_space* const> space
           auto sample = measure_single_size(*source,
                                             target_type,
                                             dst,
-                                            registry,
                                             stream,
                                             size_bytes,
                                             config.warmup_iterations,

--- a/src/data/cpu_data_representation.cpp
+++ b/src/data/cpu_data_representation.cpp
@@ -216,7 +216,8 @@ std::unique_ptr<host_table_allocation> host_table_allocation::clone(memory_space
 
 host_data_representation::host_data_representation(
   std::unique_ptr<memory::host_table_allocation> host_table, memory::memory_space* memory_space)
-  : idata_representation(*memory_space), _host_table(std::move(host_table))
+  : idata_representation(*memory_space, typeid(host_data_representation)),
+    _host_table(std::move(host_table))
 {
 }
 
@@ -265,7 +266,8 @@ std::unique_ptr<idata_representation> host_data_representation::clone(
 host_data_packed_representation::host_data_packed_representation(
   std::unique_ptr<cucascade::memory::host_table_packed_allocation> host_table,
   cucascade::memory::memory_space* memory_space)
-  : idata_representation(*memory_space), _host_table(std::move(host_table))
+  : idata_representation(*memory_space, typeid(host_data_packed_representation)),
+    _host_table(std::move(host_table))
 {
 }
 

--- a/src/data/disk_data_representation.cpp
+++ b/src/data/disk_data_representation.cpp
@@ -34,7 +34,8 @@ namespace cucascade {
 
 disk_data_representation::disk_data_representation(
   std::unique_ptr<memory::disk_table_allocation> disk_table, memory::memory_space& memory_space)
-  : idata_representation(memory_space), _disk_table(std::move(disk_table))
+  : idata_representation(memory_space, typeid(disk_data_representation)),
+    _disk_table(std::move(disk_table))
 {
 }
 

--- a/src/data/gpu_data_representation.cpp
+++ b/src/data/gpu_data_representation.cpp
@@ -26,7 +26,7 @@ namespace cucascade {
 gpu_table_representation::gpu_table_representation(std::unique_ptr<cudf::table> table,
                                                    cucascade::memory::memory_space& memory_space,
                                                    rmm::cuda_stream_view writer_stream)
-  : idata_representation(memory_space), _table(std::move(table))
+  : idata_representation(memory_space, typeid(gpu_table_representation)), _table(std::move(table))
 {
   // STREAM-LINEAGE: record the writer event in the constructor body so every
   // representation is born with a recorded event. Skipping when the caller

--- a/src/data/representation_converter.cpp
+++ b/src/data/representation_converter.cpp
@@ -115,7 +115,7 @@ std::unique_ptr<idata_representation> representation_converter_registry::convert
   const memory::memory_space* target_memory_space,
   rmm::cuda_stream_view stream) const
 {
-  converter_key key{std::type_index(typeid(source)), target_type};
+  converter_key key{source.get_type_index(), target_type};
   return convert_impl(key, source, target_memory_space, stream);
 }
 

--- a/src/data/representation_converter.cpp
+++ b/src/data/representation_converter.cpp
@@ -131,6 +131,14 @@ void representation_converter_registry::clear()
   _converters.clear();
 }
 
+representation_converter_registry& representation_converter_registry::instance()
+{
+  static representation_converter_registry registry;
+  static std::once_flag init_flag;
+  std::call_once(init_flag, [&] { register_builtin_converters(registry); });
+  return registry;
+}
+
 // =============================================================================
 // Built-in converter implementations
 // =============================================================================

--- a/src/data/representation_converter.cpp
+++ b/src/data/representation_converter.cpp
@@ -55,6 +55,7 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <shared_mutex>
 #include <sstream>
 #include <stdexcept>
 
@@ -67,7 +68,7 @@ namespace cucascade {
 void representation_converter_registry::register_converter_impl(
   const converter_key& key, representation_converter_fn converter)
 {
-  std::lock_guard<std::mutex> lock(_mutex);
+  std::unique_lock<std::shared_mutex> lock(_mutex);
 
   if (_converters.find(key) != _converters.end()) {
     std::ostringstream oss;
@@ -81,7 +82,7 @@ void representation_converter_registry::register_converter_impl(
 
 bool representation_converter_registry::has_converter_impl(const converter_key& key) const
 {
-  std::lock_guard<std::mutex> lock(_mutex);
+  std::shared_lock<std::shared_mutex> lock(_mutex);
   return _converters.find(key) != _converters.end();
 }
 
@@ -93,7 +94,7 @@ std::unique_ptr<idata_representation> representation_converter_registry::convert
 {
   representation_converter_fn converter;
   {
-    std::lock_guard<std::mutex> lock(_mutex);
+    std::shared_lock<std::shared_mutex> lock(_mutex);
 
     auto it = _converters.find(key);
     if (it == _converters.end()) {
@@ -121,13 +122,13 @@ std::unique_ptr<idata_representation> representation_converter_registry::convert
 
 bool representation_converter_registry::unregister_converter_impl(const converter_key& key)
 {
-  std::lock_guard<std::mutex> lock(_mutex);
+  std::unique_lock<std::shared_mutex> lock(_mutex);
   return _converters.erase(key) > 0;
 }
 
 void representation_converter_registry::clear()
 {
-  std::lock_guard<std::mutex> lock(_mutex);
+  std::unique_lock<std::shared_mutex> lock(_mutex);
   _converters.clear();
 }
 

--- a/test/data/test_bandwidth_profiler.cpp
+++ b/test/data/test_bandwidth_profiler.cpp
@@ -106,15 +106,12 @@ TEST_CASE("chunked_resource_info is exposed by fixed_size_host_memory_resource",
 
 TEST_CASE("measure_bandwidth rejects input without a GPU space", "[bandwidth_profiler]")
 {
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   auto& host              = shared_host_space();
   auto& disk              = shared_disk_space();
   std::array spaces_array = {host.get(), disk.get()};
   std::span<memory::memory_space* const> spaces{spaces_array};
 
-  REQUIRE_THROWS_AS(measure_bandwidth(spaces, registry, tiny_config()), std::invalid_argument);
+  REQUIRE_THROWS_AS(measure_bandwidth(spaces, tiny_config()), std::invalid_argument);
 }
 
 // =============================================================================
@@ -124,9 +121,6 @@ TEST_CASE("measure_bandwidth rejects input without a GPU space", "[bandwidth_pro
 TEST_CASE("measure_bandwidth enumerates pairs with bidirectional entries and no disk-to-disk",
           "[bandwidth_profiler]")
 {
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   auto& gpu   = shared_gpu_space();
   auto& host  = shared_host_space();
   auto& disk  = shared_disk_space();
@@ -138,7 +132,7 @@ TEST_CASE("measure_bandwidth enumerates pairs with bidirectional entries and no 
   std::array spaces_array = {gpu.get(), host.get(), disk.get(), disk2.get()};
   std::span<memory::memory_space* const> spaces{spaces_array};
 
-  auto profile = measure_bandwidth(spaces, registry, tiny_config());
+  auto profile = measure_bandwidth(spaces, tiny_config());
 
   // No self-pair and no disk-to-disk.
   for (auto const& pair : profile.pairs) {
@@ -172,9 +166,6 @@ TEST_CASE("measure_bandwidth enumerates pairs with bidirectional entries and no 
 
 TEST_CASE("measure_bandwidth records only the configured sizes per pair", "[bandwidth_profiler]")
 {
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   auto& gpu             = shared_gpu_space();
   auto& host            = shared_host_space();
   std::array spaces_arr = {gpu.get(), host.get()};
@@ -186,7 +177,7 @@ TEST_CASE("measure_bandwidth records only the configured sizes per pair", "[band
   cfg.timed_iterations   = 2;
   cfg.measure_disk_pairs = false;
 
-  auto profile = measure_bandwidth(spaces, registry, cfg);
+  auto profile = measure_bandwidth(spaces, cfg);
 
   auto const* gh = profile.find(gpu->get_id(), host->get_id());
   REQUIRE(gh != nullptr);
@@ -205,15 +196,12 @@ TEST_CASE("measure_bandwidth records only the configured sizes per pair", "[band
 TEST_CASE("per-pair result records chunk size for chunked source/destination spaces",
           "[bandwidth_profiler][chunked_resource_info]")
 {
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   auto& gpu             = shared_gpu_space();
   auto& host            = shared_host_space();
   std::array spaces_arr = {gpu.get(), host.get()};
   std::span<memory::memory_space* const> spaces{spaces_arr};
 
-  auto profile = measure_bandwidth(spaces, registry, tiny_config());
+  auto profile = measure_bandwidth(spaces, tiny_config());
 
   // GPU allocator is contiguous; HOST allocator is fixed_size_host_memory_resource (chunked).
   // So for every pair the chunked byte count should be > 0 on the HOST side and 0 on the GPU side.
@@ -232,15 +220,26 @@ TEST_CASE("per-pair result records chunk size for chunked source/destination spa
 TEST_CASE("pairs without a registered converter are reported as unavailable",
           "[bandwidth_profiler]")
 {
-  // Empty registry — no converters registered.
-  representation_converter_registry registry;
+  // The singleton normally has built-ins via lazy init; wipe it for the duration of this
+  // test (then restore) so we can exercise the "no converter" path of measure_bandwidth.
+  struct singleton_scrub {
+    representation_converter_registry& r;
+    singleton_scrub() : r(representation_converter_registry::instance()) { r.clear(); }
+    ~singleton_scrub()
+    {
+      try {
+        register_builtin_converters(r);
+      } catch (...) {
+      }
+    }
+  } guard;
 
   auto& gpu             = shared_gpu_space();
   auto& host            = shared_host_space();
   std::array spaces_arr = {gpu.get(), host.get()};
   std::span<memory::memory_space* const> spaces{spaces_arr};
 
-  auto profile = measure_bandwidth(spaces, registry, tiny_config());
+  auto profile = measure_bandwidth(spaces, tiny_config());
 
   // All enumerated pairs should be marked unavailable with a non-empty reason.
   REQUIRE_FALSE(profile.pairs.empty());
@@ -302,9 +301,6 @@ std::string format_bytes(std::size_t bytes)
 
 TEST_CASE("print bandwidth matrix", "[.bandwidth_matrix]")
 {
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   int device_count = 0;
   cudaGetDeviceCount(&device_count);
 
@@ -334,7 +330,7 @@ TEST_CASE("print bandwidth matrix", "[.bandwidth_matrix]")
   cfg.measure_disk_pairs            = true;
   cfg.drop_page_cache_between_iters = true;
 
-  auto profile = measure_bandwidth(spaces, registry, cfg);
+  auto profile = measure_bandwidth(spaces, cfg);
 
   std::ostringstream out;
   out << "\n\n=== Bandwidth Profile ===\n";
@@ -416,15 +412,12 @@ TEST_CASE("print bandwidth matrix", "[.bandwidth_matrix]")
 TEST_CASE("measure_bandwidth produces positive gbps for GPU<->HOST with builtin converters",
           "[bandwidth_profiler][integration]")
 {
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   auto& gpu             = shared_gpu_space();
   auto& host            = shared_host_space();
   std::array spaces_arr = {gpu.get(), host.get()};
   std::span<memory::memory_space* const> spaces{spaces_arr};
 
-  auto profile = measure_bandwidth(spaces, registry, tiny_config());
+  auto profile = measure_bandwidth(spaces, tiny_config());
 
   auto const* gh = profile.find(gpu->get_id(), host->get_id());
   auto const* hg = profile.find(host->get_id(), gpu->get_id());

--- a/test/data/test_data_batch.cpp
+++ b/test/data/test_data_batch.cpp
@@ -841,7 +841,7 @@ class observed_gpu_representation : private cucascade::test::mock_memory_space_h
  public:
   observed_gpu_representation(rmm::device_buffer buf, conversion_sync_observer& observer)
     : mock_memory_space_holder(memory::Tier::GPU, 0),
-      idata_representation(*space),
+      idata_representation(*space, typeid(observed_gpu_representation)),
       _buf(std::move(buf)),
       _observer(observer)
   {
@@ -941,7 +941,7 @@ class observed_host_representation : private cucascade::test::mock_memory_space_
                                std::size_t size,
                                conversion_sync_observer& observer)
     : mock_memory_space_holder(memory::Tier::HOST, 0),
-      idata_representation(*space),
+      idata_representation(*space, typeid(observed_host_representation)),
       _pinned_ptr(pinned_ptr),
       _size(size),
       _observer(observer)

--- a/test/data/test_data_batch.cpp
+++ b/test/data/test_data_batch.cpp
@@ -887,7 +887,10 @@ TEST_CASE("convert_to synchronizes stream before destroying GPU source", "[data_
   // Register a converter that enqueues async work reading from the source GPU
   // buffer WITHOUT synchronizing.  convert_to must sync before destroying the
   // source.
-  representation_converter_registry registry;
+  // Singleton registry persists across tests, so drop any prior registration of
+  // this type-pair (captures from a previous test are dangling) before re-registering.
+  auto& registry = representation_converter_registry::instance();
+  registry.unregister_converter<observed_gpu_representation, mock_data_representation>();
   registry.register_converter<observed_gpu_representation, mock_data_representation>(
     [&](idata_representation& source,
         const memory::memory_space* /*target_space*/,
@@ -905,7 +908,7 @@ TEST_CASE("convert_to synchronizes stream before destroying GPU source", "[data_
   auto batch    = std::make_shared<data_batch>(1, std::move(gpu_data));
   {
     auto mut = batch->to_mutable();
-    mut.convert_to<mock_data_representation>(registry, host_space.get(), stream.view());
+    mut.convert_to<mock_data_representation>(host_space.get(), stream.view());
   }
 
   // With the fix: convert_to synchronizes the stream before the old GPU
@@ -982,7 +985,10 @@ TEST_CASE("convert_to synchronizes stream before destroying HOST source when tar
   // Register a converter that enqueues an async H2D copy reading from the
   // source HOST buffer WITHOUT synchronizing.  convert_to must sync before
   // destroying the source.
-  representation_converter_registry registry;
+  // Singleton registry persists across tests, so drop any prior registration of
+  // this type-pair (captures from a previous test are dangling) before re-registering.
+  auto& registry = representation_converter_registry::instance();
+  registry.unregister_converter<observed_host_representation, mock_data_representation>();
   registry.register_converter<observed_host_representation, mock_data_representation>(
     [&](idata_representation& source,
         const memory::memory_space* /*target_space*/,
@@ -1002,7 +1008,7 @@ TEST_CASE("convert_to synchronizes stream before destroying HOST source when tar
   auto batch     = std::make_shared<data_batch>(1, std::move(host_data));
   {
     auto mut = batch->to_mutable();
-    mut.convert_to<mock_data_representation>(registry, gpu_space.get(), stream.view());
+    mut.convert_to<mock_data_representation>(gpu_space.get(), stream.view());
   }
 
   // With the fix: convert_to synchronizes the stream before the old HOST
@@ -1040,7 +1046,10 @@ TEST_CASE("mutable_data_batch holds exclusive lock during convert_to stream sync
   // enter stream.synchronize() (which blocks for ~50 ms due to the host callback).
   std::atomic<bool> converter_returned{false};
 
-  representation_converter_registry registry;
+  // Singleton registry persists across tests, so drop any prior registration of
+  // this type-pair (captures from a previous test are dangling) before re-registering.
+  auto& registry = representation_converter_registry::instance();
+  registry.unregister_converter<observed_gpu_representation, mock_data_representation>();
   registry.register_converter<observed_gpu_representation, mock_data_representation>(
     [&](idata_representation& source,
         const memory::memory_space* /*target_space*/,
@@ -1063,7 +1072,7 @@ TEST_CASE("mutable_data_batch holds exclusive lock during convert_to stream sync
 
   std::thread convert_thread([&]() {
     auto mut = batch->to_mutable();
-    mut.convert_to<mock_data_representation>(registry, host_space.get(), stream.view());
+    mut.convert_to<mock_data_representation>(host_space.get(), stream.view());
   });
 
   // Spin until the converter function has returned — convert_to is now blocked

--- a/test/data/test_data_representation.cpp
+++ b/test/data/test_data_representation.cpp
@@ -93,9 +93,6 @@ TEST_CASE("host_data_packed_representation converts to GPU and preserves content
           "[cpu_data_representation][gpu_data_representation]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const memory::memory_space* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   const memory::memory_space* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
 
@@ -140,7 +137,7 @@ TEST_CASE("host_data_packed_representation converts to GPU and preserves content
 
   // Convert to GPU and compare cudf tables
   auto gpu_stream = gpu_space->acquire_stream();
-  auto gpu_any    = registry.convert<gpu_table_representation>(host_repr, gpu_space, pack_stream);
+  auto gpu_any    = host_repr.convert_to<gpu_table_representation>(gpu_space, pack_stream);
   pack_stream.synchronize();
   auto& gpu_repr = *gpu_any;
   // Compare using the same stream used for conversion to avoid cross-stream hazards
@@ -262,9 +259,6 @@ TEST_CASE("gpu_table_representation device_id", "[gpu_data_representation]")
 TEST_CASE("gpu->host->gpu roundtrip preserves cudf table contents", "[gpu_data_representation]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const memory::memory_space* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const memory::memory_space* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
 
@@ -276,8 +270,8 @@ TEST_CASE("gpu->host->gpu roundtrip preserves cudf table contents", "[gpu_data_r
                                 *const_cast<memory::memory_space*>(gpu_space),
                                 rmm::cuda_stream_view{});
 
-  auto cpu_any = registry.convert<host_data_packed_representation>(repr, host_space, chain_stream);
-  auto gpu_any = registry.convert<gpu_table_representation>(*cpu_any, gpu_space, chain_stream);
+  auto cpu_any = repr.convert_to<host_data_packed_representation>(host_space, chain_stream);
+  auto gpu_any = cpu_any->convert_to<gpu_table_representation>(gpu_space, chain_stream);
 
   auto& back = *gpu_any;
   chain_stream.synchronize();
@@ -312,10 +306,7 @@ TEST_CASE("gpu cross-device conversion when multiple GPUs are available",
   int dev_src = 0;
   int dev_dst = 1;
 
-  auto mgr = create_multi_gpu_manager(dev_src, dev_dst);
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
+  auto mgr                              = create_multi_gpu_manager(dev_src, dev_dst);
   const memory::memory_space* src_space = mgr->get_memory_space(memory::Tier::GPU, dev_src);
   const memory::memory_space* dst_space = mgr->get_memory_space(memory::Tier::GPU, dev_dst);
   REQUIRE(src_space != nullptr);
@@ -330,7 +321,7 @@ TEST_CASE("gpu cross-device conversion when multiple GPUs are available",
                                     *const_cast<memory::memory_space*>(src_space),
                                     rmm::cuda_stream_view{});
 
-  auto dst_any   = registry.convert<gpu_table_representation>(src_repr, dst_space, xfer_stream);
+  auto dst_any   = src_repr.convert_to<gpu_table_representation>(dst_space, xfer_stream);
   auto& dst_repr = *dst_any;
 
   // Compare content equality using the same stream used for transfer
@@ -346,9 +337,6 @@ TEST_CASE("gpu->host_packed->gpu roundtrip preserves contents (table_view+shared
           "[gpu_data_representation][table_view_ctor]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const memory::memory_space* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const memory::memory_space* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
 
@@ -364,8 +352,8 @@ TEST_CASE("gpu->host_packed->gpu roundtrip preserves contents (table_view+shared
                                 *const_cast<memory::memory_space*>(gpu_space),
                                 rmm::cuda_stream_view{});
 
-  auto cpu_any = registry.convert<host_data_packed_representation>(repr, host_space, chain_stream);
-  auto gpu_any = registry.convert<gpu_table_representation>(*cpu_any, gpu_space, chain_stream);
+  auto cpu_any = repr.convert_to<host_data_packed_representation>(host_space, chain_stream);
+  auto gpu_any = cpu_any->convert_to<gpu_table_representation>(gpu_space, chain_stream);
 
   chain_stream.synchronize();
   cucascade::test::expect_cudf_tables_equal_on_stream(
@@ -376,9 +364,6 @@ TEST_CASE("gpu->host_fast->gpu roundtrip preserves contents (table_view+shared_p
           "[gpu_data_representation][table_view_ctor]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const memory::memory_space* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const memory::memory_space* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
 
@@ -403,8 +388,8 @@ TEST_CASE("gpu->host_fast->gpu roundtrip preserves contents (table_view+shared_p
                                 *const_cast<memory::memory_space*>(gpu_space),
                                 rmm::cuda_stream_view{});
 
-  auto host = registry.convert<host_data_representation>(repr, host_space, stream.view());
-  auto back = registry.convert<gpu_table_representation>(*host, gpu_space, stream.view());
+  auto host = repr.convert_to<host_data_representation>(host_space, stream.view());
+  auto back = host->convert_to<gpu_table_representation>(gpu_space, stream.view());
   stream.synchronize();
 
   REQUIRE(back->get_table_view().num_columns() == 1);
@@ -621,9 +606,6 @@ TEST_CASE("host_data_packed_representation clone creates independent copy",
           "[cpu_data_representation]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const memory::memory_space* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   const memory::memory_space* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
 
@@ -636,8 +618,7 @@ TEST_CASE("host_data_packed_representation clone creates independent copy",
                                     *const_cast<memory::memory_space*>(gpu_space),
                                     rmm::cuda_stream_view{});
 
-  auto host_repr_ptr =
-    registry.convert<host_data_packed_representation>(gpu_repr, host_space, stream);
+  auto host_repr_ptr = gpu_repr.convert_to<host_data_packed_representation>(host_space, stream);
   stream.synchronize();
 
   // Clone the host representation
@@ -658,8 +639,8 @@ TEST_CASE("host_data_packed_representation clone creates independent copy",
           host_repr_ptr->get_host_table()->allocation.get());
 
   // Convert both back to GPU and verify data equality
-  auto cloned_gpu = registry.convert<gpu_table_representation>(*cloned, gpu_space, stream);
-  auto orig_gpu   = registry.convert<gpu_table_representation>(*host_repr_ptr, gpu_space, stream);
+  auto cloned_gpu = cloned->convert_to<gpu_table_representation>(gpu_space, stream);
+  auto orig_gpu   = host_repr_ptr->convert_to<gpu_table_representation>(gpu_space, stream);
   stream.synchronize();
 
   cucascade::test::expect_cudf_tables_equal_on_stream(
@@ -716,14 +697,13 @@ static gpu_table_representation wrap_column(
     std::make_unique<cudf::table>(std::move(cols)), gpu_space, writer_stream);
 }
 
-/// Convert a gpu_table_representation to host_data_representation via the registry.
+/// Convert a gpu_table_representation to host_data_representation via the singleton registry.
 static std::unique_ptr<host_data_representation> fast_convert(
   gpu_table_representation& src,
   const memory::memory_space* host_space,
-  representation_converter_registry& registry,
   rmm::cuda_stream_view stream)
 {
-  return registry.convert<host_data_representation>(src, host_space, stream);
+  return src.convert_to<host_data_representation>(host_space, stream);
 }
 
 // =============================================================================
@@ -733,9 +713,8 @@ static std::unique_ptr<host_data_representation> fast_convert(
 TEST_CASE("register_builtin_converters registers GPU->host_data_representation",
           "[fast][registration]")
 {
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-  REQUIRE(registry.has_converter<gpu_table_representation, host_data_representation>());
+  REQUIRE(representation_converter_registry::instance()
+            .has_converter<gpu_table_representation, host_data_representation>());
 }
 
 // =============================================================================
@@ -743,8 +722,7 @@ TEST_CASE("register_builtin_converters registers GPU->host_data_representation",
 // =============================================================================
 
 template <cudf::type_id TypeID, typename CppType>
-static void check_fixed_width_metadata(memory::memory_reservation_manager& mgr,
-                                       representation_converter_registry& registry)
+static void check_fixed_width_metadata(memory::memory_reservation_manager& mgr)
 {
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
@@ -760,7 +738,7 @@ static void check_fixed_width_metadata(memory::memory_reservation_manager& mgr,
 
   auto repr = wrap_column(
     std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(repr, host_space, registry, stream.view());
+  auto host = fast_convert(repr, host_space, stream.view());
   stream.synchronize();
 
   REQUIRE(host != nullptr);
@@ -780,21 +758,18 @@ static void check_fixed_width_metadata(memory::memory_reservation_manager& mgr,
 TEST_CASE("Fast converter metadata: fixed-width primitive types", "[fast][metadata]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   // clang-format off
-  SECTION("INT8")   { check_fixed_width_metadata<cudf::type_id::INT8,   int8_t  >(mgr, registry); }
-  SECTION("INT16")  { check_fixed_width_metadata<cudf::type_id::INT16,  int16_t >(mgr, registry); }
-  SECTION("INT32")  { check_fixed_width_metadata<cudf::type_id::INT32,  int32_t >(mgr, registry); }
-  SECTION("INT64")  { check_fixed_width_metadata<cudf::type_id::INT64,  int64_t >(mgr, registry); }
-  SECTION("UINT8")  { check_fixed_width_metadata<cudf::type_id::UINT8,  uint8_t >(mgr, registry); }
-  SECTION("UINT16") { check_fixed_width_metadata<cudf::type_id::UINT16, uint16_t>(mgr, registry); }
-  SECTION("UINT32") { check_fixed_width_metadata<cudf::type_id::UINT32, uint32_t>(mgr, registry); }
-  SECTION("UINT64") { check_fixed_width_metadata<cudf::type_id::UINT64, uint64_t>(mgr, registry); }
-  SECTION("FLOAT32"){ check_fixed_width_metadata<cudf::type_id::FLOAT32, float  >(mgr, registry); }
-  SECTION("FLOAT64"){ check_fixed_width_metadata<cudf::type_id::FLOAT64, double >(mgr, registry); }
-  SECTION("BOOL8")  { check_fixed_width_metadata<cudf::type_id::BOOL8,   bool   >(mgr, registry); }
+  SECTION("INT8")   { check_fixed_width_metadata<cudf::type_id::INT8,   int8_t  >(mgr); }
+  SECTION("INT16")  { check_fixed_width_metadata<cudf::type_id::INT16,  int16_t >(mgr); }
+  SECTION("INT32")  { check_fixed_width_metadata<cudf::type_id::INT32,  int32_t >(mgr); }
+  SECTION("INT64")  { check_fixed_width_metadata<cudf::type_id::INT64,  int64_t >(mgr); }
+  SECTION("UINT8")  { check_fixed_width_metadata<cudf::type_id::UINT8,  uint8_t >(mgr); }
+  SECTION("UINT16") { check_fixed_width_metadata<cudf::type_id::UINT16, uint16_t>(mgr); }
+  SECTION("UINT32") { check_fixed_width_metadata<cudf::type_id::UINT32, uint32_t>(mgr); }
+  SECTION("UINT64") { check_fixed_width_metadata<cudf::type_id::UINT64, uint64_t>(mgr); }
+  SECTION("FLOAT32"){ check_fixed_width_metadata<cudf::type_id::FLOAT32, float  >(mgr); }
+  SECTION("FLOAT64"){ check_fixed_width_metadata<cudf::type_id::FLOAT64, double >(mgr); }
+  SECTION("BOOL8")  { check_fixed_width_metadata<cudf::type_id::BOOL8,   bool   >(mgr); }
   // clang-format on
 }
 
@@ -805,9 +780,6 @@ TEST_CASE("Fast converter metadata: fixed-width primitive types", "[fast][metada
 TEST_CASE("Fast converter copies INT32 data bytes correctly", "[fast][data_integrity]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -824,7 +796,7 @@ TEST_CASE("Fast converter copies INT32 data bytes correctly", "[fast][data_integ
 
   auto repr = wrap_column(
     std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(repr, host_space, registry, stream.view());
+  auto host = fast_convert(repr, host_space, stream.view());
   stream.synchronize();
 
   const auto& meta = host->get_host_table()->columns[0];
@@ -837,9 +809,6 @@ TEST_CASE("Fast converter copies INT32 data bytes correctly", "[fast][data_integ
 TEST_CASE("Fast converter copies FLOAT64 data bytes correctly", "[fast][data_integrity]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -856,7 +825,7 @@ TEST_CASE("Fast converter copies FLOAT64 data bytes correctly", "[fast][data_int
 
   auto repr = wrap_column(
     std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(repr, host_space, registry, stream.view());
+  auto host = fast_convert(repr, host_space, stream.view());
   stream.synchronize();
 
   const auto& meta = host->get_host_table()->columns[0];
@@ -873,9 +842,6 @@ TEST_CASE("Fast converter copies FLOAT64 data bytes correctly", "[fast][data_int
 TEST_CASE("Fast converter: nullable INT32 — null mask metadata and bytes", "[fast][nullable]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -890,7 +856,7 @@ TEST_CASE("Fast converter: nullable INT32 — null mask metadata and bytes", "[f
 
   auto repr = wrap_column(
     std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(repr, host_space, registry, stream.view());
+  auto host = fast_convert(repr, host_space, stream.view());
   stream.synchronize();
 
   const auto& meta = host->get_host_table()->columns[0];
@@ -907,9 +873,6 @@ TEST_CASE("Fast converter: nullable INT64 — both null mask and data bytes are 
           "[fast][nullable]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -927,7 +890,7 @@ TEST_CASE("Fast converter: nullable INT64 — both null mask and data bytes are 
 
   auto repr = wrap_column(
     std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(repr, host_space, registry, stream.view());
+  auto host = fast_convert(repr, host_space, stream.view());
   stream.synchronize();
 
   const auto& meta = host->get_host_table()->columns[0];
@@ -950,9 +913,6 @@ TEST_CASE("Fast converter: nullable INT64 — both null mask and data bytes are 
 TEST_CASE("Fast converter: timestamp columns metadata", "[fast][timestamp]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -968,7 +928,7 @@ TEST_CASE("Fast converter: timestamp columns metadata", "[fast][timestamp]")
     stream.synchronize();
     auto repr = wrap_column(
       std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-    auto host = fast_convert(repr, host_space, registry, stream.view());
+    auto host = fast_convert(repr, host_space, stream.view());
     stream.synchronize();
     const auto& meta = host->get_host_table()->columns[0];
     REQUIRE(meta.type_id == cudf::type_id::TIMESTAMP_DAYS);
@@ -987,7 +947,7 @@ TEST_CASE("Fast converter: timestamp columns metadata", "[fast][timestamp]")
     stream.synchronize();
     auto repr = wrap_column(
       std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-    auto host = fast_convert(repr, host_space, registry, stream.view());
+    auto host = fast_convert(repr, host_space, stream.view());
     stream.synchronize();
     const auto& meta = host->get_host_table()->columns[0];
     REQUIRE(meta.type_id == cudf::type_id::TIMESTAMP_SECONDS);
@@ -1005,7 +965,7 @@ TEST_CASE("Fast converter: timestamp columns metadata", "[fast][timestamp]")
     stream.synchronize();
     auto repr = wrap_column(
       std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-    auto host = fast_convert(repr, host_space, registry, stream.view());
+    auto host = fast_convert(repr, host_space, stream.view());
     stream.synchronize();
     const auto& meta = host->get_host_table()->columns[0];
     REQUIRE(meta.type_id == cudf::type_id::TIMESTAMP_MICROSECONDS);
@@ -1016,9 +976,6 @@ TEST_CASE("Fast converter: timestamp columns metadata", "[fast][timestamp]")
 TEST_CASE("Fast converter: duration columns metadata", "[fast][duration]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -1034,7 +991,7 @@ TEST_CASE("Fast converter: duration columns metadata", "[fast][duration]")
     stream.synchronize();
     auto repr = wrap_column(
       std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-    auto host = fast_convert(repr, host_space, registry, stream.view());
+    auto host = fast_convert(repr, host_space, stream.view());
     stream.synchronize();
     const auto& meta = host->get_host_table()->columns[0];
     REQUIRE(meta.type_id == cudf::type_id::DURATION_DAYS);
@@ -1051,7 +1008,7 @@ TEST_CASE("Fast converter: duration columns metadata", "[fast][duration]")
     stream.synchronize();
     auto repr = wrap_column(
       std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-    auto host = fast_convert(repr, host_space, registry, stream.view());
+    auto host = fast_convert(repr, host_space, stream.view());
     stream.synchronize();
     const auto& meta = host->get_host_table()->columns[0];
     REQUIRE(meta.type_id == cudf::type_id::DURATION_MILLISECONDS);
@@ -1068,7 +1025,7 @@ TEST_CASE("Fast converter: duration columns metadata", "[fast][duration]")
     stream.synchronize();
     auto repr = wrap_column(
       std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-    auto host = fast_convert(repr, host_space, registry, stream.view());
+    auto host = fast_convert(repr, host_space, stream.view());
     stream.synchronize();
     const auto& meta = host->get_host_table()->columns[0];
     REQUIRE(meta.type_id == cudf::type_id::DURATION_NANOSECONDS);
@@ -1083,9 +1040,6 @@ TEST_CASE("Fast converter: duration columns metadata", "[fast][duration]")
 TEST_CASE("Fast converter: decimal columns store scale in metadata", "[fast][decimal]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -1101,7 +1055,7 @@ TEST_CASE("Fast converter: decimal columns store scale in metadata", "[fast][dec
     stream.synchronize();
     auto repr = wrap_column(
       std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-    auto host = fast_convert(repr, host_space, registry, stream.view());
+    auto host = fast_convert(repr, host_space, stream.view());
     stream.synchronize();
     const auto& meta = host->get_host_table()->columns[0];
     REQUIRE(meta.type_id == cudf::type_id::DECIMAL32);
@@ -1121,7 +1075,7 @@ TEST_CASE("Fast converter: decimal columns store scale in metadata", "[fast][dec
     stream.synchronize();
     auto repr = wrap_column(
       std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-    auto host = fast_convert(repr, host_space, registry, stream.view());
+    auto host = fast_convert(repr, host_space, stream.view());
     stream.synchronize();
     const auto& meta = host->get_host_table()->columns[0];
     REQUIRE(meta.type_id == cudf::type_id::DECIMAL64);
@@ -1139,7 +1093,7 @@ TEST_CASE("Fast converter: decimal columns store scale in metadata", "[fast][dec
     stream.synchronize();
     auto repr = wrap_column(
       std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-    auto host = fast_convert(repr, host_space, registry, stream.view());
+    auto host = fast_convert(repr, host_space, stream.view());
     stream.synchronize();
     const auto& meta = host->get_host_table()->columns[0];
     REQUIRE(meta.type_id == cudf::type_id::DECIMAL128);
@@ -1155,9 +1109,6 @@ TEST_CASE("Fast converter: decimal columns store scale in metadata", "[fast][dec
 TEST_CASE("Fast converter: STRING column metadata structure", "[fast][string]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -1191,7 +1142,7 @@ TEST_CASE("Fast converter: STRING column metadata structure", "[fast][string]")
 
   auto repr = wrap_column(
     std::move(strings_col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(repr, host_space, registry, stream.view());
+  auto host = fast_convert(repr, host_space, stream.view());
   stream.synchronize();
 
   const auto& meta = host->get_host_table()->columns[0];
@@ -1218,9 +1169,6 @@ TEST_CASE("Fast converter: STRING column metadata structure", "[fast][string]")
 TEST_CASE("Fast converter: LIST<INT32> column metadata structure", "[fast][list]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -1253,7 +1201,7 @@ TEST_CASE("Fast converter: LIST<INT32> column metadata structure", "[fast][list]
 
   auto repr = wrap_column(
     std::move(list_col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(repr, host_space, registry, stream.view());
+  auto host = fast_convert(repr, host_space, stream.view());
   stream.synchronize();
 
   const auto& meta = host->get_host_table()->columns[0];
@@ -1279,9 +1227,6 @@ TEST_CASE("Fast converter: LIST<INT32> column metadata structure", "[fast][list]
 TEST_CASE("Fast converter: nullable LIST<INT32> preserves parent null mask", "[fast][list]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -1316,7 +1261,7 @@ TEST_CASE("Fast converter: nullable LIST<INT32> preserves parent null mask", "[f
 
   auto repr = wrap_column(
     std::move(list_col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(repr, host_space, registry, stream.view());
+  auto host = fast_convert(repr, host_space, stream.view());
   stream.synchronize();
 
   const auto& meta = host->get_host_table()->columns[0];
@@ -1332,9 +1277,6 @@ TEST_CASE("Fast converter: nullable LIST<INT32> preserves parent null mask", "[f
 TEST_CASE("Fast converter: STRUCT<INT32, FLOAT64> column metadata structure", "[fast][struct]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -1359,7 +1301,7 @@ TEST_CASE("Fast converter: STRUCT<INT32, FLOAT64> column metadata structure", "[
 
   auto repr = wrap_column(
     std::move(struct_col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(repr, host_space, registry, stream.view());
+  auto host = fast_convert(repr, host_space, stream.view());
   stream.synchronize();
 
   const auto& meta = host->get_host_table()->columns[0];
@@ -1387,9 +1329,6 @@ TEST_CASE("Fast converter: STRUCT<INT32, FLOAT64> column metadata structure", "[
 TEST_CASE("Fast converter: LIST<LIST<INT32>> nested metadata", "[fast][nested]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -1443,7 +1382,7 @@ TEST_CASE("Fast converter: LIST<LIST<INT32>> nested metadata", "[fast][nested]")
 
   auto repr = wrap_column(
     std::move(outer_list), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(repr, host_space, registry, stream.view());
+  auto host = fast_convert(repr, host_space, stream.view());
   stream.synchronize();
 
   // Outer LIST
@@ -1484,9 +1423,6 @@ TEST_CASE("Fast converter: LIST<LIST<INT32>> nested metadata", "[fast][nested]")
 TEST_CASE("Fast converter: LIST<STRUCT<INT32,FLOAT64>> nested metadata", "[fast][nested]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -1532,7 +1468,7 @@ TEST_CASE("Fast converter: LIST<STRUCT<INT32,FLOAT64>> nested metadata", "[fast]
 
   auto repr = wrap_column(
     std::move(list_col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(repr, host_space, registry, stream.view());
+  auto host = fast_convert(repr, host_space, stream.view());
   stream.synchronize();
 
   // Outer: LIST
@@ -1576,9 +1512,6 @@ TEST_CASE("Fast converter: LIST<STRUCT<INT32,FLOAT64>> nested metadata", "[fast]
 TEST_CASE("Fast converter: STRUCT<LIST<INT32>,FLOAT64> nested metadata", "[fast][nested]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -1628,7 +1561,7 @@ TEST_CASE("Fast converter: STRUCT<LIST<INT32>,FLOAT64> nested metadata", "[fast]
 
   auto repr = wrap_column(
     std::move(struct_col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(repr, host_space, registry, stream.view());
+  auto host = fast_convert(repr, host_space, stream.view());
   stream.synchronize();
 
   // Top-level: STRUCT
@@ -1674,9 +1607,6 @@ TEST_CASE("Fast converter: STRUCT<LIST<INT32>,FLOAT64> nested metadata", "[fast]
 TEST_CASE("Fast converter: empty table (0 rows)", "[fast][empty]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -1700,7 +1630,7 @@ TEST_CASE("Fast converter: empty table (0 rows)", "[fast][empty]")
                                 *const_cast<memory::memory_space*>(gpu_space),
                                 rmm::cuda_stream_view{});
 
-  auto host = fast_convert(repr, host_space, registry, stream.view());
+  auto host = fast_convert(repr, host_space, stream.view());
   stream.synchronize();
 
   REQUIRE(host != nullptr);
@@ -1721,9 +1651,6 @@ TEST_CASE("Fast converter: empty table (0 rows)", "[fast][empty]")
 TEST_CASE("Fast converter: multi-column table with all primitive types", "[fast][multi_column]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -1759,7 +1686,7 @@ TEST_CASE("Fast converter: multi-column table with all primitive types", "[fast]
                                 *const_cast<memory::memory_space*>(gpu_space),
                                 rmm::cuda_stream_view{});
 
-  auto host = fast_convert(repr, host_space, registry, stream.view());
+  auto host = fast_convert(repr, host_space, stream.view());
   stream.synchronize();
 
   REQUIRE(host != nullptr);
@@ -1784,9 +1711,6 @@ TEST_CASE("Fast converter: multi-column table with all primitive types", "[fast]
 TEST_CASE("host_data_representation clone: same bytes, independent allocation", "[fast][clone]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -1802,7 +1726,7 @@ TEST_CASE("host_data_representation clone: same bytes, independent allocation", 
 
   auto repr = wrap_column(
     std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(repr, host_space, registry, stream.view());
+  auto host = fast_convert(repr, host_space, stream.view());
   stream.synchronize();
 
   auto cloned_base = host->clone(stream.view());
@@ -1840,9 +1764,6 @@ TEST_CASE("host_data_representation clone: same bytes, independent allocation", 
 TEST_CASE("host_data_representation clone: empty table", "[fast][clone]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -1856,7 +1777,7 @@ TEST_CASE("host_data_representation clone: empty table", "[fast][clone]")
 
   auto repr = wrap_column(
     std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(repr, host_space, registry, stream.view());
+  auto host = fast_convert(repr, host_space, stream.view());
   stream.synchronize();
 
   auto cloned_base = host->clone(stream.view());
@@ -1871,30 +1792,25 @@ TEST_CASE("host_data_representation clone: empty table", "[fast][clone]")
 // Round-trip: HOST FAST → GPU
 // =============================================================================
 
-/// Convert a host_data_representation back to gpu_table_representation via registry.
+/// Convert a host_data_representation back to gpu_table_representation via the singleton registry.
 static std::unique_ptr<gpu_table_representation> fast_back_convert(
   host_data_representation& src,
   const memory::memory_space* gpu_space,
-  representation_converter_registry& registry,
   rmm::cuda_stream_view stream)
 {
-  return registry.convert<gpu_table_representation>(src, gpu_space, stream);
+  return src.convert_to<gpu_table_representation>(gpu_space, stream);
 }
 
 TEST_CASE("register_builtin_converters registers host_data_representation->GPU",
           "[fast][registration]")
 {
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-  REQUIRE(registry.has_converter<host_data_representation, gpu_table_representation>());
+  REQUIRE(representation_converter_registry::instance()
+            .has_converter<host_data_representation, gpu_table_representation>());
 }
 
 TEST_CASE("Round-trip fast: INT32 column data preserved", "[fast][roundtrip]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -1910,10 +1826,10 @@ TEST_CASE("Round-trip fast: INT32 column data preserved", "[fast][roundtrip]")
 
   auto orig_repr = wrap_column(
     std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(orig_repr, host_space, registry, stream.view());
+  auto host = fast_convert(orig_repr, host_space, stream.view());
   stream.synchronize();
 
-  auto back = fast_back_convert(*host, gpu_space, registry, stream.view());
+  auto back = fast_back_convert(*host, gpu_space, stream.view());
   stream.synchronize();
 
   REQUIRE(back != nullptr);
@@ -1929,9 +1845,6 @@ TEST_CASE("Round-trip fast: INT32 column data preserved", "[fast][roundtrip]")
 TEST_CASE("Round-trip fast: nullable INT64 null mask preserved", "[fast][roundtrip]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -1948,10 +1861,10 @@ TEST_CASE("Round-trip fast: nullable INT64 null mask preserved", "[fast][roundtr
 
   auto orig_repr = wrap_column(
     std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(orig_repr, host_space, registry, stream.view());
+  auto host = fast_convert(orig_repr, host_space, stream.view());
   stream.synchronize();
 
-  auto back = fast_back_convert(*host, gpu_space, registry, stream.view());
+  auto back = fast_back_convert(*host, gpu_space, stream.view());
   stream.synchronize();
 
   REQUIRE(back->get_table_view().num_columns() == 1);
@@ -1966,9 +1879,6 @@ TEST_CASE("Round-trip fast: nullable INT64 null mask preserved", "[fast][roundtr
 TEST_CASE("Round-trip fast: FLOAT64 byte integrity", "[fast][roundtrip]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -1984,10 +1894,10 @@ TEST_CASE("Round-trip fast: FLOAT64 byte integrity", "[fast][roundtrip]")
 
   auto orig_repr = wrap_column(
     std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(orig_repr, host_space, registry, stream.view());
+  auto host = fast_convert(orig_repr, host_space, stream.view());
   stream.synchronize();
 
-  auto back = fast_back_convert(*host, gpu_space, registry, stream.view());
+  auto back = fast_back_convert(*host, gpu_space, stream.view());
   stream.synchronize();
 
   cudf::table_view back_tv = back->get_table_view();
@@ -1999,9 +1909,6 @@ TEST_CASE("Round-trip fast: FLOAT64 byte integrity", "[fast][roundtrip]")
 TEST_CASE("Round-trip fast: STRING column content preserved", "[fast][roundtrip]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -2031,10 +1938,10 @@ TEST_CASE("Round-trip fast: STRING column content preserved", "[fast][roundtrip]
 
   auto orig_repr = wrap_column(
     std::move(strings_col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(orig_repr, host_space, registry, stream.view());
+  auto host = fast_convert(orig_repr, host_space, stream.view());
   stream.synchronize();
 
-  auto back = fast_back_convert(*host, gpu_space, registry, stream.view());
+  auto back = fast_back_convert(*host, gpu_space, stream.view());
   stream.synchronize();
 
   REQUIRE(back->get_table_view().num_columns() == 1);
@@ -2051,9 +1958,6 @@ TEST_CASE("Round-trip fast: STRING column content preserved", "[fast][roundtrip]
 TEST_CASE("Round-trip fast: LIST<INT32> structure preserved", "[fast][roundtrip]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -2086,10 +1990,10 @@ TEST_CASE("Round-trip fast: LIST<INT32> structure preserved", "[fast][roundtrip]
 
   auto orig_repr = wrap_column(
     std::move(list_col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(orig_repr, host_space, registry, stream.view());
+  auto host = fast_convert(orig_repr, host_space, stream.view());
   stream.synchronize();
 
-  auto back = fast_back_convert(*host, gpu_space, registry, stream.view());
+  auto back = fast_back_convert(*host, gpu_space, stream.view());
   stream.synchronize();
 
   REQUIRE(back->get_table_view().num_rows() == num_lists);
@@ -2105,9 +2009,6 @@ TEST_CASE("Round-trip fast: LIST<INT32> structure preserved", "[fast][roundtrip]
 TEST_CASE("Round-trip fast: STRUCT<INT32,FLOAT64> fields preserved", "[fast][roundtrip]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -2136,10 +2037,10 @@ TEST_CASE("Round-trip fast: STRUCT<INT32,FLOAT64> fields preserved", "[fast][rou
 
   auto orig_repr = wrap_column(
     std::move(struct_col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(orig_repr, host_space, registry, stream.view());
+  auto host = fast_convert(orig_repr, host_space, stream.view());
   stream.synchronize();
 
-  auto back = fast_back_convert(*host, gpu_space, registry, stream.view());
+  auto back = fast_back_convert(*host, gpu_space, stream.view());
   stream.synchronize();
 
   REQUIRE(back->get_table_view().num_rows() == N);
@@ -2156,9 +2057,6 @@ TEST_CASE("Round-trip fast: STRUCT<INT32,FLOAT64> fields preserved", "[fast][rou
 TEST_CASE("Round-trip fast: empty table (0 rows)", "[fast][roundtrip]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -2172,10 +2070,10 @@ TEST_CASE("Round-trip fast: empty table (0 rows)", "[fast][roundtrip]")
 
   auto orig_repr = wrap_column(
     std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
-  auto host = fast_convert(orig_repr, host_space, registry, stream.view());
+  auto host = fast_convert(orig_repr, host_space, stream.view());
   stream.synchronize();
 
-  auto back = fast_back_convert(*host, gpu_space, registry, stream.view());
+  auto back = fast_back_convert(*host, gpu_space, stream.view());
   stream.synchronize();
 
   REQUIRE(back != nullptr);
@@ -2220,9 +2118,6 @@ TEST_CASE("host_data_representation::slice round-trip preserves selected columns
           "[fast][slice][roundtrip]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
   const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
   rmm::cuda_stream stream;
@@ -2236,7 +2131,7 @@ TEST_CASE("host_data_representation::slice round-trip preserves selected columns
   // GPU -> HOST
   gpu_table_representation gpu_repr(
     std::move(orig_table), *const_cast<memory::memory_space*>(gpu_space), stream.view());
-  auto host = fast_convert(gpu_repr, host_space, registry, stream.view());
+  auto host = fast_convert(gpu_repr, host_space, stream.view());
   stream.synchronize();
   REQUIRE(host->num_columns() == 4);
 
@@ -2251,7 +2146,7 @@ TEST_CASE("host_data_representation::slice round-trip preserves selected columns
     // Slice shares buffers with the source allocation.
     REQUIRE(sliced->get_host_table()->allocation.get() == host->get_host_table()->allocation.get());
 
-    auto back = fast_back_convert(*sliced, gpu_space, registry, stream.view());
+    auto back = fast_back_convert(*sliced, gpu_space, stream.view());
     stream.synchronize();
     REQUIRE(back != nullptr);
     REQUIRE(back->get_table_view().num_columns() == 2);
@@ -2267,7 +2162,7 @@ TEST_CASE("host_data_representation::slice round-trip preserves selected columns
     auto sliced = host->slice(std::span<const std::size_t>(kept.data(), kept.size()));
     REQUIRE(sliced->num_columns() == 3);
 
-    auto back = fast_back_convert(*sliced, gpu_space, registry, stream.view());
+    auto back = fast_back_convert(*sliced, gpu_space, stream.view());
     stream.synchronize();
     REQUIRE(back->get_table_view().num_columns() == 3);
 

--- a/test/data/test_disk_host_converters.cpp
+++ b/test/data/test_disk_host_converters.cpp
@@ -77,28 +77,22 @@ void round_trip_test(std::unique_ptr<cudf::table> original_table)
   auto& host_space = shared_host_space();
   auto& disk_space = shared_disk_space();
 
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   // Create GPU representation from the original table
   auto gpu_rep = std::make_unique<gpu_table_representation>(
     std::move(original_table), *gpu_space, rmm::cuda_stream_view{});
 
   // GPU -> host_data
-  auto host_rep =
-    registry.convert<host_data_representation>(*gpu_rep, host_space.get(), shared_stream());
+  auto host_rep = gpu_rep->convert_to<host_data_representation>(host_space.get(), shared_stream());
 
   // host_data -> disk
-  auto disk_rep =
-    registry.convert<disk_data_representation>(*host_rep, disk_space.get(), shared_stream());
+  auto disk_rep = host_rep->convert_to<disk_data_representation>(disk_space.get(), shared_stream());
 
   // disk -> host_data
   auto host_rep2 =
-    registry.convert<host_data_representation>(*disk_rep, host_space.get(), shared_stream());
+    disk_rep->convert_to<host_data_representation>(host_space.get(), shared_stream());
 
   // host_data -> GPU
-  auto gpu_rep2 =
-    registry.convert<gpu_table_representation>(*host_rep2, gpu_space.get(), shared_stream());
+  auto gpu_rep2 = host_rep2->convert_to<gpu_table_representation>(gpu_space.get(), shared_stream());
 
   // Compare original (from gpu_rep) with round-tripped
   test::expect_cudf_tables_equal_on_stream(

--- a/test/data/test_gpu_disk_converters.cpp
+++ b/test/data/test_gpu_disk_converters.cpp
@@ -69,20 +69,15 @@ void gpu_disk_round_trip_test(std::unique_ptr<cudf::table> original_table)
   auto& gpu_space  = shared_gpu_space();
   auto& disk_space = shared_disk_space();
 
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   // Create GPU representation from the original table
   auto gpu_rep = std::make_unique<gpu_table_representation>(
     std::move(original_table), *gpu_space, rmm::cuda_stream_view{});
 
   // GPU -> disk (direct via write/write_batch)
-  auto disk_rep =
-    registry.convert<disk_data_representation>(*gpu_rep, disk_space.get(), shared_stream());
+  auto disk_rep = gpu_rep->convert_to<disk_data_representation>(disk_space.get(), shared_stream());
 
   // disk -> GPU (direct via read)
-  auto gpu_rep2 =
-    registry.convert<gpu_table_representation>(*disk_rep, gpu_space.get(), shared_stream());
+  auto gpu_rep2 = disk_rep->convert_to<gpu_table_representation>(gpu_space.get(), shared_stream());
 
   // Compare original (from gpu_rep) with round-tripped
   test::expect_cudf_tables_equal_on_stream(
@@ -637,18 +632,13 @@ TEST_CASE("gpu disk round-trip with explicit pipeline backend",
   auto gpu_space  = test::make_mock_memory_space(memory::Tier::GPU, 0);
   auto disk_space = test::make_mock_memory_space(memory::Tier::DISK, 0);
 
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   // Simple INT32 column, 100 rows
   auto table   = make_typed_table(cudf::type_id::INT32, 100);
   auto gpu_rep = std::make_unique<gpu_table_representation>(
     std::move(table), *gpu_space, rmm::cuda_stream_view{});
 
-  auto disk_rep =
-    registry.convert<disk_data_representation>(*gpu_rep, disk_space.get(), shared_stream());
-  auto gpu_rep2 =
-    registry.convert<gpu_table_representation>(*disk_rep, gpu_space.get(), shared_stream());
+  auto disk_rep = gpu_rep->convert_to<disk_data_representation>(disk_space.get(), shared_stream());
+  auto gpu_rep2 = disk_rep->convert_to<gpu_table_representation>(gpu_space.get(), shared_stream());
 
   test::expect_cudf_tables_equal_on_stream(
     gpu_rep->get_table_view(), gpu_rep2->get_table_view(), shared_stream());
@@ -660,23 +650,18 @@ TEST_CASE("gpu disk round-trip pipeline with multiple types",
   auto gpu_space  = test::make_mock_memory_space(memory::Tier::GPU, 0);
   auto disk_space = test::make_mock_memory_space(memory::Tier::DISK, 0);
 
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   // Test with multiple numeric types
   auto type_id = GENERATE(cudf::type_id::INT32, cudf::type_id::INT64, cudf::type_id::FLOAT64);
   auto table   = make_typed_table(type_id, 1000);
   auto gpu_rep = std::make_unique<gpu_table_representation>(
     std::move(table), *gpu_space, rmm::cuda_stream_view{});
 
-  auto disk_rep =
-    registry.convert<disk_data_representation>(*gpu_rep, disk_space.get(), shared_stream());
+  auto disk_rep = gpu_rep->convert_to<disk_data_representation>(disk_space.get(), shared_stream());
 
   REQUIRE(disk_rep->get_size_in_bytes() > 0);
   REQUIRE(disk_rep->get_uncompressed_data_size_in_bytes() == disk_rep->get_size_in_bytes());
 
-  auto gpu_rep2 =
-    registry.convert<gpu_table_representation>(*disk_rep, gpu_space.get(), shared_stream());
+  auto gpu_rep2 = disk_rep->convert_to<gpu_table_representation>(gpu_space.get(), shared_stream());
 
   test::expect_cudf_tables_equal_on_stream(
     gpu_rep->get_table_view(), gpu_rep2->get_table_view(), shared_stream());
@@ -687,15 +672,11 @@ TEST_CASE("disk_data_representation get_uncompressed_data_size_in_bytes", "[disk
   auto gpu_space  = test::make_mock_memory_space(memory::Tier::GPU, 0);
   auto disk_space = test::make_mock_memory_space(memory::Tier::DISK, 0);
 
-  representation_converter_registry registry;
-  register_builtin_converters(registry);
-
   auto table   = make_typed_table(cudf::type_id::INT64, 1000);
   auto gpu_rep = std::make_unique<gpu_table_representation>(
     std::move(table), *gpu_space, rmm::cuda_stream_view{});
 
-  auto disk_rep =
-    registry.convert<disk_data_representation>(*gpu_rep, disk_space.get(), shared_stream());
+  auto disk_rep = gpu_rep->convert_to<disk_data_representation>(disk_space.get(), shared_stream());
 
   REQUIRE(disk_rep->get_size_in_bytes() > 0);
   REQUIRE(disk_rep->get_uncompressed_data_size_in_bytes() == disk_rep->get_size_in_bytes());

--- a/test/data/test_representation_converter.cpp
+++ b/test/data/test_representation_converter.cpp
@@ -43,7 +43,7 @@ using cucascade::test::make_mock_memory_space;
 class custom_test_representation : public idata_representation {
  public:
   custom_test_representation(int value, memory::memory_space& space)
-    : idata_representation(space), _value(value)
+    : idata_representation(space, typeid(custom_test_representation)), _value(value)
   {
   }
 
@@ -66,7 +66,7 @@ class custom_test_representation : public idata_representation {
 class another_test_representation : public idata_representation {
  public:
   another_test_representation(double value, memory::memory_space& space)
-    : idata_representation(space), _value(value)
+    : idata_representation(space, typeid(another_test_representation)), _value(value)
   {
   }
 

--- a/test/utils/mock_test_utils.hpp
+++ b/test/utils/mock_test_utils.hpp
@@ -114,7 +114,8 @@ class mock_data_representation : private mock_memory_space_holder, public idata_
   explicit mock_data_representation(memory::Tier tier, size_t size = 1024, size_t device_id = 0)
     : mock_memory_space_holder(tier, device_id)  // Construct holder first
       ,
-      idata_representation(*space)  // Pass reference to base class
+      idata_representation(*space,
+                           typeid(mock_data_representation))  // Pass reference to base class
       ,
       _size(size)
   {


### PR DESCRIPTION
remove data registry class. make APIs simpler, automatic conversion from idata_representaiton to other registred types.