### PR TITLE
Use pre-pinned HOST pool for cross-GPU host-staged copies

### DIFF
--- a/include/cucascade/memory/common.hpp
+++ b/include/cucascade/memory/common.hpp
@@ -204,6 +204,33 @@ make_default_host_memory_resource(int device_id, std::size_t capacity, bool make
 
 DeviceMemoryResourceFactoryFn make_default_allocator_for_tier(Tier tier);
 
+// Forward declaration — fixed_size_host_memory_resource.hpp is heavy.
+class fixed_size_host_memory_resource;
+
+/**
+ * @brief Register a HOST-tier `fixed_size_host_memory_resource` so cross-tier
+ * code paths (notably the peer-DMA-broken host-staging branch in
+ * representation_converter.cpp) can borrow blocks from the pre-pinned pool
+ * instead of calling cudaHostAlloc per transfer.
+ *
+ * Called by memory_space's HOST constructor; unregistered by its destructor.
+ * Idempotent on identical (numa_id, pool) re-registration; a different
+ * non-null pool for the same numa_id throws.
+ */
+void register_host_pool(int numa_id, fixed_size_host_memory_resource* pool);
+
+/**
+ * @brief Unregister a previously registered HOST pool. No-op if not present.
+ */
+void unregister_host_pool(int numa_id, fixed_size_host_memory_resource* pool) noexcept;
+
+/**
+ * @brief Look up a registered HOST pool. Tries the requested numa_id first,
+ * then any registered pool as fallback (cross-NUMA staging is suboptimal but
+ * correct). Returns nullptr if no HOST pool has been registered.
+ */
+[[nodiscard]] fixed_size_host_memory_resource* find_host_pool(int numa_id) noexcept;
+
 }  // namespace memory
 }  // namespace cucascade
 

--- a/include/cucascade/memory/common.hpp
+++ b/include/cucascade/memory/common.hpp
@@ -214,8 +214,9 @@ class fixed_size_host_memory_resource;
  * instead of calling cudaHostAlloc per transfer.
  *
  * Called by memory_space's HOST constructor; unregistered by its destructor.
- * Idempotent on identical (numa_id, pool) re-registration; a different
- * non-null pool for the same numa_id throws.
+ * Multiple pools may be registered against the same numa_id (test fixtures
+ * commonly create overlapping HOST memory_spaces); re-registering the same
+ * pointer is a no-op.
  */
 void register_host_pool(int numa_id, fixed_size_host_memory_resource* pool);
 
@@ -225,9 +226,10 @@ void register_host_pool(int numa_id, fixed_size_host_memory_resource* pool);
 void unregister_host_pool(int numa_id, fixed_size_host_memory_resource* pool) noexcept;
 
 /**
- * @brief Look up a registered HOST pool. Tries the requested numa_id first,
- * then any registered pool as fallback (cross-NUMA staging is suboptimal but
- * correct). Returns nullptr if no HOST pool has been registered.
+ * @brief Look up a registered HOST pool. Returns the most recently registered
+ * pool for the requested numa_id; falls back to any registered pool from any
+ * numa_id (cross-NUMA staging is suboptimal but correct). Returns nullptr if
+ * no HOST pool has been registered.
  */
 [[nodiscard]] fixed_size_host_memory_resource* find_host_pool(int numa_id) noexcept;
 

--- a/src/data/representation_converter.cpp
+++ b/src/data/representation_converter.cpp
@@ -24,8 +24,10 @@
 #include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/data/representation_converter.hpp>
 #include <cucascade/error.hpp>
+#include <cucascade/memory/common.hpp>
 #include <cucascade/memory/disk_access_limiter.hpp>
 #include <cucascade/memory/disk_table.hpp>
+#include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 #include <cucascade/memory/host_table.hpp>
 #include <cucascade/memory/host_table_packed.hpp>
 #include <cucascade/memory/numa_region_pinned_host_allocator.hpp>
@@ -55,8 +57,12 @@
 #include <cstring>
 #include <filesystem>
 #include <fstream>
+#include <functional>
+#include <mutex>
 #include <sstream>
 #include <stdexcept>
+#include <unordered_map>
+#include <vector>
 
 namespace cucascade {
 
@@ -618,11 +624,16 @@ static int resolve_gpu_numa_node(int device_id) noexcept
  * (see ensure_p2p_probed):
  *   - probe says peer DMA works → cudaMemcpyPeerAsync (direct device-to-device
  *     DMA over NVLink / supported PCIe)
- *   - probe says peer DMA broken → explicit host-staged copy through pinned
- *     host memory (consumer Intel chipsets etc. where cudaMemcpyPeer* silently
- *     no-ops). We do the staging ourselves rather than relying on the driver's
- *     auto-fallback, so the correctness path is identical and observable
- *     regardless of driver/CUDA version quirks.
+ *   - probe says peer DMA broken → explicit host-staged copy through the
+ *     pre-pinned HOST memory_space pool (registered by memory_space's HOST
+ *     constructor in register_host_pool). The staging copy chunks across the
+ *     pool's fixed block size (1 MB by default), exactly like
+ *     convert_gpu_to_host. We do the staging ourselves rather than relying on
+ *     the driver's auto-fallback, so the correctness path is identical and
+ *     observable regardless of driver/CUDA version quirks.
+ *
+ *   NEVER calls cudaHostAlloc per transfer — the pool is allocated once at
+ *   memory_reservation_manager construction time.
  */
 static rmm::device_buffer alloc_and_peer_copy_async(const void* src_ptr,
                                                     int src_device,
@@ -641,56 +652,98 @@ static rmm::device_buffer alloc_and_peer_copy_async(const void* src_ptr,
     return buf;
   }
 
-  // Peer DMA broken — explicitly stage through pinned host memory.
+  // Peer DMA broken — stage through the pre-pinned HOST pool.
   //
-  // Allocate as portable+mapped so the buffer is fast-path accessible from both
-  // src and dst CUDA contexts (plain cudaMallocHost only registers it with the
-  // context active at allocation time, which silently slows down the DtoH on
-  // src_device if it's not the current device). Bind pages to dst_device's NUMA
-  // node — HtoD into dst is the latency-critical leg and benefits most from
-  // local-socket pinned memory. -1 falls back to non-bound portable+mapped.
-  memory::numa_region_pinned_host_memory_resource pinned_mr(resolve_gpu_numa_node(dst_device),
-                                                            /*make_portable=*/true);
-  void* host_buf = pinned_mr.allocate_sync(size);
+  // Block layout: the host pool allocates non-contiguous fixed-size blocks
+  // (1 MB by default). We chunk the D2H and H2D legs across blocks just like
+  // convert_gpu_to_host does. Stream-ordering inside the loop preserves the
+  // same-stream invariant the original implementation relied on.
+  memory::fixed_size_host_memory_resource* host_pool =
+    memory::find_host_pool(resolve_gpu_numa_node(dst_device));
+  if (host_pool == nullptr) {
+    // No HOST memory_space has been registered. This should only happen in
+    // standalone test builds that exercise the converter without constructing
+    // a memory_reservation_manager. Fall back to a one-shot pinned allocation
+    // (slow path — preserves correctness, never reached in production Sirius).
+    memory::numa_region_pinned_host_memory_resource mr(resolve_gpu_numa_node(dst_device),
+                                                       /*make_portable=*/true);
+    void* host_buf = mr.allocate_sync(size);
+    {
+      rmm::cuda_set_device_raii src_guard{rmm::cuda_device_id{src_device}};
+      CUCASCADE_CUDA_TRY(
+        cudaMemcpyAsync(host_buf, src_ptr, size, cudaMemcpyDeviceToHost, target_stream.value()));
+      CUCASCADE_CUDA_TRY(cudaStreamSynchronize(target_stream.value()));
+    }
+    {
+      rmm::cuda_set_device_raii dst_guard{rmm::cuda_device_id{dst_device}};
+      CUCASCADE_CUDA_TRY(
+        cudaMemcpyAsync(buf.data(), host_buf, size, cudaMemcpyHostToDevice, target_stream.value()));
+      CUCASCADE_CUDA_TRY(cudaStreamSynchronize(target_stream.value()));
+    }
+    mr.deallocate_sync(host_buf, size);
+    return buf;
+  }
+
+  auto allocation            = host_pool->allocate_multiple_blocks(size);
+  const std::size_t block_sz = allocation->block_size();
+
+  // Pass 1: device-to-host, chunked across blocks. Issued on target_stream
+  // under the src_device CUDA context (matches the same-stream invariant
+  // the original implementation enforced).
   {
-    // Same-stream invariant: issue DtoH on target_stream (matching
-    // rmm::device_buffer::allocate_async at the top of this function) under
-    // cuda_set_device_raii(src_device) for src-side context. Mixing streams
-    // across the allocation/copy boundary trips stream-ordered races under
-    // compute-sanitizer.
     rmm::cuda_set_device_raii src_guard{rmm::cuda_device_id{src_device}};
-    CUCASCADE_CUDA_TRY(
-      cudaMemcpyAsync(host_buf, src_ptr, size, cudaMemcpyDeviceToHost, target_stream.value()));
+    std::size_t block_index  = 0;
+    std::size_t block_offset = 0;
+    std::size_t src_offset   = 0;
+    while (src_offset < size) {
+      const std::size_t remaining  = size - src_offset;
+      const std::size_t bytes_left = block_sz - block_offset;
+      const std::size_t to_copy    = std::min(remaining, bytes_left);
+      std::span<std::byte> block   = allocation->at(block_index);
+      CUCASCADE_CUDA_TRY(cudaMemcpyAsync(block.data() + block_offset,
+                                         static_cast<const std::uint8_t*>(src_ptr) + src_offset,
+                                         to_copy,
+                                         cudaMemcpyDeviceToHost,
+                                         target_stream.value()));
+      src_offset += to_copy;
+      block_offset += to_copy;
+      if (block_offset == block_sz) {
+        ++block_index;
+        block_offset = 0;
+      }
+    }
     CUCASCADE_CUDA_TRY(cudaStreamSynchronize(target_stream.value()));
-    // Sync inside the src_guard scope: cudaFreeHost (after the closing
-    // brace below) is host-synchronous and must not race with the DtoH
-    // read; the sync also ensures host_buf is fully populated before
-    // the HtoD enqueue executes on target_stream.
   }
+
+  // Pass 2: host-to-device, chunked across the same blocks. Switch the CUDA
+  // context to dst_device — same guard the original code documented as
+  // required when peer DMA is broken and the outer guard does not propagate
+  // through the column tree walk.
   {
-    // Set dst-device context active before the HtoD enqueue. The outer
-    // convert_gpu_to_gpu's target_guard{dst_device_id} does NOT propagate
-    // down through reconstruct_column_p2p -> alloc_and_peer_copy_async on
-    // the host-staging branch.
-    //
-    // Without this guard, cudaMemcpyAsync on hosts where peer DMA is
-    // broken (probe_peer_dma_works == false) fails with
-    // cudaErrorInvalidValue when the current device differs from
-    // dst_device (e.g., when called from gpu-to-gpu column-walk on
-    // 2 x RTX 6000 Ada). See 23-VERIFICATION.md gap #1 and
-    // 23-VERDICT.md Section E.
-    //
-    // Same-stream invariant preserved: target_stream is still used
-    // for both the DtoH (above) and HtoD (here) copies — this guard
-    // only sets the CUDA *context*, not the stream.
     rmm::cuda_set_device_raii dst_guard{rmm::cuda_device_id{dst_device}};
-    CUCASCADE_CUDA_TRY(
-      cudaMemcpyAsync(buf.data(), host_buf, size, cudaMemcpyHostToDevice, target_stream.value()));
+    std::size_t block_index  = 0;
+    std::size_t block_offset = 0;
+    std::size_t dst_offset   = 0;
+    while (dst_offset < size) {
+      const std::size_t remaining  = size - dst_offset;
+      const std::size_t bytes_left = block_sz - block_offset;
+      const std::size_t to_copy    = std::min(remaining, bytes_left);
+      std::span<std::byte> block   = allocation->at(block_index);
+      CUCASCADE_CUDA_TRY(cudaMemcpyAsync(static_cast<std::uint8_t*>(buf.data()) + dst_offset,
+                                         block.data() + block_offset,
+                                         to_copy,
+                                         cudaMemcpyHostToDevice,
+                                         target_stream.value()));
+      dst_offset += to_copy;
+      block_offset += to_copy;
+      if (block_offset == block_sz) {
+        ++block_index;
+        block_offset = 0;
+      }
+    }
     CUCASCADE_CUDA_TRY(cudaStreamSynchronize(target_stream.value()));
   }
-  // Same allocator that produced the buffer; dispatches cudaHostUnregister +
-  // numa_free (NUMA-bound path) or cudaFreeHost (-1 fallback path).
-  pinned_mr.deallocate_sync(host_buf, size);
+  // allocation's destructor returns blocks to the host pool — no cudaFreeHost.
   return buf;
 }
 

--- a/src/memory/common.cpp
+++ b/src/memory/common.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <cucascade/memory/common.hpp>
+#include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 #include <cucascade/memory/null_device_memory_resource.hpp>
 #include <cucascade/memory/numa_region_pinned_host_allocator.hpp>
 
@@ -23,6 +24,9 @@
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 
 #include <mutex>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
 
 namespace cucascade {
 
@@ -321,6 +325,61 @@ int disable_peer_access_where_broken(std::vector<cudaMemPool_t> const& pools_by_
     }
   }
   return disabled;
+}
+
+// =============================================================================
+// HOST pool registry — lets representation_converter's host-staging fallback
+// borrow blocks from the existing pre-pinned pool instead of calling
+// cudaHostAlloc per cross-GPU transfer.
+// =============================================================================
+namespace {
+std::mutex& host_pool_registry_mutex()
+{
+  static std::mutex m;
+  return m;
+}
+
+std::unordered_map<int, fixed_size_host_memory_resource*>& host_pool_registry()
+{
+  static std::unordered_map<int, fixed_size_host_memory_resource*> r;
+  return r;
+}
+}  // namespace
+
+void register_host_pool(int numa_id, fixed_size_host_memory_resource* pool)
+{
+  if (pool == nullptr) { return; }
+  std::lock_guard<std::mutex> g(host_pool_registry_mutex());
+  auto& reg = host_pool_registry();
+  auto it   = reg.find(numa_id);
+  if (it != reg.end()) {
+    if (it->second == pool) { return; }       // idempotent
+    if (it->second == nullptr) {              // recover slot
+      it->second = pool;
+      return;
+    }
+    throw std::runtime_error("cucascade::memory::register_host_pool: numa_id " +
+                             std::to_string(numa_id) + " already registered with a different pool");
+  }
+  reg.emplace(numa_id, pool);
+}
+
+void unregister_host_pool(int numa_id, fixed_size_host_memory_resource* pool) noexcept
+{
+  std::lock_guard<std::mutex> g(host_pool_registry_mutex());
+  auto& reg = host_pool_registry();
+  auto it   = reg.find(numa_id);
+  if (it != reg.end() && it->second == pool) { reg.erase(it); }
+}
+
+fixed_size_host_memory_resource* find_host_pool(int numa_id) noexcept
+{
+  std::lock_guard<std::mutex> g(host_pool_registry_mutex());
+  auto& reg = host_pool_registry();
+  if (auto it = reg.find(numa_id); it != reg.end()) { return it->second; }
+  // Cross-NUMA fallback: any registered pool. Suboptimal but correct.
+  if (!reg.empty()) { return reg.begin()->second; }
+  return nullptr;
 }
 
 }  // namespace memory

--- a/src/memory/common.cpp
+++ b/src/memory/common.cpp
@@ -24,9 +24,8 @@
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 
 #include <mutex>
-#include <stdexcept>
-#include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace cucascade {
 
@@ -331,6 +330,10 @@ int disable_peer_access_where_broken(std::vector<cudaMemPool_t> const& pools_by_
 // HOST pool registry — lets representation_converter's host-staging fallback
 // borrow blocks from the existing pre-pinned pool instead of calling
 // cudaHostAlloc per cross-GPU transfer.
+//
+// Multiple pools may be registered against the same numa_id (test fixtures
+// commonly create overlapping HOST memory_spaces). Lookups return the most
+// recently registered pool for the requested numa_id.
 // =============================================================================
 namespace {
 std::mutex& host_pool_registry_mutex()
@@ -339,9 +342,9 @@ std::mutex& host_pool_registry_mutex()
   return m;
 }
 
-std::unordered_map<int, fixed_size_host_memory_resource*>& host_pool_registry()
+std::unordered_map<int, std::vector<fixed_size_host_memory_resource*>>& host_pool_registry()
 {
-  static std::unordered_map<int, fixed_size_host_memory_resource*> r;
+  static std::unordered_map<int, std::vector<fixed_size_host_memory_resource*>> r;
   return r;
 }
 }  // namespace
@@ -350,18 +353,12 @@ void register_host_pool(int numa_id, fixed_size_host_memory_resource* pool)
 {
   if (pool == nullptr) { return; }
   std::lock_guard<std::mutex> g(host_pool_registry_mutex());
-  auto& reg = host_pool_registry();
-  auto it   = reg.find(numa_id);
-  if (it != reg.end()) {
-    if (it->second == pool) { return; }       // idempotent
-    if (it->second == nullptr) {              // recover slot
-      it->second = pool;
-      return;
-    }
-    throw std::runtime_error("cucascade::memory::register_host_pool: numa_id " +
-                             std::to_string(numa_id) + " already registered with a different pool");
+  auto& pools = host_pool_registry()[numa_id];
+  // Idempotent: same pool already registered → no-op.
+  for (auto* existing : pools) {
+    if (existing == pool) { return; }
   }
-  reg.emplace(numa_id, pool);
+  pools.push_back(pool);
 }
 
 void unregister_host_pool(int numa_id, fixed_size_host_memory_resource* pool) noexcept
@@ -369,16 +366,29 @@ void unregister_host_pool(int numa_id, fixed_size_host_memory_resource* pool) no
   std::lock_guard<std::mutex> g(host_pool_registry_mutex());
   auto& reg = host_pool_registry();
   auto it   = reg.find(numa_id);
-  if (it != reg.end() && it->second == pool) { reg.erase(it); }
+  if (it == reg.end()) { return; }
+  auto& pools = it->second;
+  // Remove the first matching pointer (most likely the only one).
+  for (auto pit = pools.begin(); pit != pools.end(); ++pit) {
+    if (*pit == pool) {
+      pools.erase(pit);
+      break;
+    }
+  }
+  if (pools.empty()) { reg.erase(it); }
 }
 
 fixed_size_host_memory_resource* find_host_pool(int numa_id) noexcept
 {
   std::lock_guard<std::mutex> g(host_pool_registry_mutex());
   auto& reg = host_pool_registry();
-  if (auto it = reg.find(numa_id); it != reg.end()) { return it->second; }
+  if (auto it = reg.find(numa_id); it != reg.end() && !it->second.empty()) {
+    return it->second.back();  // most recently registered
+  }
   // Cross-NUMA fallback: any registered pool. Suboptimal but correct.
-  if (!reg.empty()) { return reg.begin()->second; }
+  for (auto& entry : reg) {
+    if (!entry.second.empty()) { return entry.second.back(); }
+  }
   return nullptr;
 }
 

--- a/src/memory/memory_space.cpp
+++ b/src/memory/memory_space.cpp
@@ -164,6 +164,10 @@ memory_space::memory_space(const host_memory_space_config& config)
   auto& host_allocator =
     std::get<std::unique_ptr<fixed_size_host_memory_resource>>(_reservation_allocator);
   _reservation_allocator_resource.emplace(fixed_size_host_resource_ref{*host_allocator});
+  // Register so cross-tier code paths (e.g. representation_converter's
+  // peer-DMA-broken host-staging branch) can borrow blocks from this pool
+  // instead of calling cudaHostAlloc per transfer.
+  register_host_pool(config.numa_id, host_allocator.get());
 }
 
 memory_space::memory_space(const disk_memory_space_config& config)
@@ -202,7 +206,18 @@ memory_space::memory_space(const disk_memory_space_config& config,
     std::make_unique<disk_access_limiter>(_id, _memory_limit, _capacity, config.mount_paths);
 }
 
-memory_space::~memory_space() = default;
+memory_space::~memory_space()
+{
+  // Unregister this memory_space's HOST pool from the cross-tier registry.
+  // No-op for non-HOST tiers and for any partially-constructed instance whose
+  // _reservation_allocator never received a fixed_size_host_memory_resource.
+  if (_id.tier == Tier::HOST) {
+    if (auto* host_alloc =
+          std::get_if<std::unique_ptr<fixed_size_host_memory_resource>>(&_reservation_allocator)) {
+      unregister_host_pool(_id.device_id, host_alloc->get());
+    }
+  }
+}
 
 bool memory_space::operator==(const memory_space& other) const { return _id == other.get_id(); }
 


### PR DESCRIPTION
When peer DMA is broken (e.g. consumer Intel chipsets), the representation_converter falls back to host-staged copies for cross-GPU transfers. Previously this allocated fresh pinned memory via cudaHostAlloc on every transfer, which is slow and causes significant overhead at scale (SF100+).

Replace the per-transfer cudaHostAlloc with block borrowing from the existing fixed_size_host_memory_resource pool that memory_space already allocates at startup. The staging copy now chunks across the pool's fixed block size (1 MB default), matching the pattern used by convert_gpu_to_host.

Changes:
- Add host pool registry (register/unregister/find_host_pool) in memory/common.{hpp,cpp} so cross-tier code can look up the pre-pinned pool by NUMA ID with cross-NUMA fallback
- memory_space HOST constructor registers its pool; destructor unregisters it
- representation_converter's alloc_and_peer_copy_async uses allocate_multiple_blocks from the pool instead of cudaHostAlloc
- Fallback to one-shot pinned allocation preserved for standalone test builds without a memory_reservation_manager