### PR TITLE
Make NVML initialization fork-aware in topology discovery

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -24,7 +24,7 @@ unzip = "*"
 # CUDA 13
 [feature.cuda-13]
 system-requirements = { cuda = "13" }
-dependencies = { "cuda-version" = "13.*" }
+dependencies = { "cuda-version" = "13.2.*" }
 activation = { env = { CUDAARCHS = "75-real;80-real;86-real;90a-real;100f-real;120a-real;120" } }
 
 # CUDA 12

--- a/src/memory/topology_discovery.cpp
+++ b/src/memory/topology_discovery.cpp
@@ -19,6 +19,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <mutex>
 #include <sstream>
 #include <stdexcept>
 #include <unordered_map>
@@ -672,19 +673,39 @@ int count_numa_nodes()
   return count;
 }
 
+nvmlReturn_t initialize_nvml_for_current_process()
+{
+  static std::mutex mutex;
+  static pid_t initialized_pid    = -1;
+  static nvmlReturn_t init_result = NVML_ERROR_UNINITIALIZED;
+
+  std::lock_guard<std::mutex> lock(mutex);
+  pid_t const pid = getpid();
+  if (initialized_pid != pid) {
+    init_result     = nvmlInit_v2();
+    initialized_pid = pid;
+  }
+  return init_result;
+}
+
 }  // namespace
 
 bool topology_discovery::discover(NetworkDeviceVerification net_verification)
 {
   system_topology_info topology;
-  // NVML is initialized exactly once per process via this static-local. Calling
-  // nvmlInit_v2 + nvmlShutdown in sequence (which discover() used to do on every
-  // call) SEGVs on NVIDIA driver 595.58.03 — the second nvmlInit_v2 after a
-  // shutdown lands on a stale internal function pointer in libnvidia-ml.
+  // NVML is initialized exactly once per process. Calling nvmlInit_v2 +
+  // nvmlShutdown in sequence (which discover() used to do on every call)
+  // SEGVs on NVIDIA driver 595.58.03 - the second nvmlInit_v2 after a shutdown
+  // lands on a stale internal function pointer in libnvidia-ml.
+  //
+  // The cached init state is keyed by PID so a child process created with fork()
+  // re-initializes NVML before issuing queries. Without this, forked children
+  // can inherit the parent's initialized state and fail later NVML calls such as
+  // nvmlDeviceGetCount_v2().
+  //
   // The driver releases NVML resources at process exit via its own atexit hook,
   // so we never need to call nvmlShutdown explicitly.
-  static const nvmlReturn_t init_result = nvmlInit_v2();
-  nvmlReturn_t result                   = init_result;
+  nvmlReturn_t result = initialize_nvml_for_current_process();
   if (result != NVML_SUCCESS) {
     std::cerr << "Failed to initialize NVML: " << nvmlErrorString(result) << std::endl;
     // Continue anyway to report system info even without GPUs


### PR DESCRIPTION
https://github.com/NVIDIA/cuCascade/pull/115 introduced a change that `topology_discovery::discover()` caches the result of `nvmlInit_v2()` in a process-local static to avoid the driver issue caused by repeated `nvmlInit_v2()`/`nvmlShutdown()` cycles. However, after `fork()`, the child inherits that cached success result even though NVML state is not safely inherited. Subsequent NVML calls in the child can fail, causing topology discovery to report no GPUs.

The fix keeps the no-`nvmlShutdown()` behavior, but keys the cached NVML initialization result by PID. If discovery runs in a forked child, the PID change is detected and `nvmlInit_v2()` is called again in that process before issuing NVML queries.