### PR TITLE
Allow topology-only builds at configure time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,8 @@ option(CUCASCADE_BUILD_BENCHMARKS "Build the benchmark suite" ON)
 option(CUCASCADE_BUILD_SHARED_LIBS "Build shared library" ON)
 option(CUCASCADE_BUILD_STATIC_LIBS "Build static library" ON)
 option(CUCASCADE_NVTX "Enable NVTX range annotations" OFF)
+option(CUCASCADE_TOPOLOGY_ONLY
+       "Build only the topology discovery library (no cudf/rmm dependency)" OFF)
 
 # At least one library type must be built
 if(NOT CUCASCADE_BUILD_SHARED_LIBS AND NOT CUCASCADE_BUILD_STATIC_LIBS)
@@ -39,23 +41,32 @@ if(NOT CUCASCADE_BUILD_SHARED_LIBS AND NOT CUCASCADE_BUILD_STATIC_LIBS)
   )
 endif()
 
+# When topology-only, force off benchmarks (they require the full library)
+if(CUCASCADE_TOPOLOGY_ONLY)
+  set(CUCASCADE_BUILD_BENCHMARKS
+      OFF
+      CACHE BOOL "Build the benchmark suite" FORCE)
+endif()
+
 list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")
 
 # TODO: Remove vendored FindCUDAToolkit once we require CMake 4.4
 
 # Find required packages
 find_package(CUDAToolkit REQUIRED)
-find_package(Threads REQUIRED)
+if(NOT CUCASCADE_TOPOLOGY_ONLY)
+  find_package(Threads REQUIRED)
 
-# Find RMM from libcudf installation
-find_package(rmm REQUIRED CONFIG)
+  # Find RMM from libcudf installation
+  find_package(rmm REQUIRED CONFIG)
 
-# Find cudf for data representation support
-find_package(cudf REQUIRED CONFIG)
+  # Find cudf for data representation support
+  find_package(cudf REQUIRED CONFIG)
 
-# Find numa (provided by numactl-devel or libnuma-dev depending on the package
-# manager)
-find_library(NUMA_LIB numa REQUIRED)
+  # Find numa (provided by numactl-devel or libnuma-dev depending on the package
+  # manager)
+  find_library(NUMA_LIB numa REQUIRED)
+endif()
 
 # Set CUDA architectures
 if(NOT CMAKE_CUDA_ARCHITECTURES)
@@ -94,67 +105,79 @@ endforeach()
 # =============================================================================
 # NVTX support
 # =============================================================================
-if(CUCASCADE_NVTX)
+if(CUCASCADE_NVTX AND NOT CUCASCADE_TOPOLOGY_ONLY)
   find_package(nvtx3 REQUIRED)
 endif()
 
 # =============================================================================
 # Object library (compiles sources once, used by both static and shared libs)
 # =============================================================================
-add_library(cucascade_objects OBJECT)
 add_library(cucascade_topology_discovery_objects OBJECT)
 
-# Apply warning flags to object library
-target_compile_options(
-  cucascade_objects
-  PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${CUCASCADE_CXX_WARNING_FLAGS}>
-          ${CUCASCADE_CUDA_WARNING_FLAGS})
+if(NOT CUCASCADE_TOPOLOGY_ONLY)
+  add_library(cucascade_objects OBJECT)
+
+  # Apply warning flags to object library
+  target_compile_options(
+    cucascade_objects
+    PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${CUCASCADE_CXX_WARNING_FLAGS}>
+            ${CUCASCADE_CUDA_WARNING_FLAGS})
+endif()
+
 target_compile_options(
   cucascade_topology_discovery_objects
   PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${CUCASCADE_CXX_WARNING_FLAGS}>
           ${CUCASCADE_CUDA_WARNING_FLAGS})
 
 # NVTX compile definition
-if(CUCASCADE_NVTX)
+if(CUCASCADE_NVTX AND NOT CUCASCADE_TOPOLOGY_ONLY)
   target_compile_definitions(cucascade_objects PUBLIC CUCASCADE_NVTX)
   target_link_libraries(cucascade_objects PUBLIC nvtx3::nvtx3-cpp)
 endif()
 
 # Add source directories (they will add sources to cucascade_objects)
-add_subdirectory(src/cuda)
+if(NOT CUCASCADE_TOPOLOGY_ONLY)
+  add_subdirectory(src/cuda)
+endif()
 add_subdirectory(src/memory)
-add_subdirectory(src/data)
+if(NOT CUCASCADE_TOPOLOGY_ONLY)
+  add_subdirectory(src/data)
+endif()
 
 # Common usage requirements shared by the object library and installable targets
 set(CUCASCADE_PUBLIC_INCLUDE_DIRS
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
-set(CUCASCADE_PUBLIC_LINK_LIBS rmm::rmm cudf::cudf CUDA::cudart_static
-                               Threads::Threads ${NUMA_LIB})
+if(NOT CUCASCADE_TOPOLOGY_ONLY)
+  set(CUCASCADE_PUBLIC_LINK_LIBS rmm::rmm cudf::cudf CUDA::cudart_static
+                                 Threads::Threads ${NUMA_LIB})
 
-# Set include directories for the object library
-target_include_directories(cucascade_objects
-                           PUBLIC ${CUCASCADE_PUBLIC_INCLUDE_DIRS})
+  # Set include directories for the object library
+  target_include_directories(cucascade_objects
+                             PUBLIC ${CUCASCADE_PUBLIC_INCLUDE_DIRS})
+
+  # Link dependencies to object library
+  target_link_libraries(cucascade_objects PUBLIC ${CUCASCADE_PUBLIC_LINK_LIBS})
+
+  # cxx_std_20 is PUBLIC so consumers know they need C++20 to use our headers.
+  # cuda_std_20 is kept separate and applied PRIVATE to cucascade_objects to
+  # avoid propagating it to consumers that have no CUDA compiler requirement.
+  target_compile_features(cucascade_objects PUBLIC cxx_std_20)
+  target_compile_features(cucascade_objects PRIVATE cuda_std_20)
+
+  set_target_properties(
+    cucascade_objects PROPERTIES CXX_EXTENSIONS OFF POSITION_INDEPENDENT_CODE
+                                                    ON)
+endif()
+
 target_include_directories(cucascade_topology_discovery_objects
                            PUBLIC ${CUCASCADE_PUBLIC_INCLUDE_DIRS})
-
-# Link dependencies to object library
-target_link_libraries(cucascade_objects PUBLIC ${CUCASCADE_PUBLIC_LINK_LIBS})
 target_link_libraries(cucascade_topology_discovery_objects
                       PUBLIC CUDA::nvml_static)
-
-# cxx_std_20 is PUBLIC so consumers know they need C++20 to use our headers.
-# cuda_std_20 is kept separate and applied PRIVATE to cucascade_objects to avoid
-# propagating it to consumers that have no CUDA compiler requirement.
-target_compile_features(cucascade_objects PUBLIC cxx_std_20)
-target_compile_features(cucascade_objects PRIVATE cuda_std_20)
 target_compile_features(cucascade_topology_discovery_objects PUBLIC cxx_std_20)
 target_compile_features(cucascade_topology_discovery_objects
                         PRIVATE cuda_std_20)
-
-set_target_properties(cucascade_objects PROPERTIES CXX_EXTENSIONS OFF
-                                                   POSITION_INDEPENDENT_CODE ON)
 set_target_properties(
   cucascade_topology_discovery_objects PROPERTIES CXX_EXTENSIONS OFF
                                                   POSITION_INDEPENDENT_CODE ON)
@@ -183,19 +206,21 @@ if(CUCASCADE_BUILD_STATIC_LIBS)
     PROPERTIES OUTPUT_NAME cucascade_topology_discovery
                EXPORT_NAME cucascade_topology_discovery_static)
 
-  add_library(cucascade_static STATIC $<TARGET_OBJECTS:cucascade_objects>)
-  add_library(cuCascade::cucascade_static ALIAS cucascade_static)
+  if(NOT CUCASCADE_TOPOLOGY_ONLY)
+    add_library(cucascade_static STATIC $<TARGET_OBJECTS:cucascade_objects>)
+    add_library(cuCascade::cucascade_static ALIAS cucascade_static)
 
-  target_include_directories(cucascade_static
-                             PUBLIC ${CUCASCADE_PUBLIC_INCLUDE_DIRS})
-  target_link_libraries(
-    cucascade_static PUBLIC ${CUCASCADE_PUBLIC_LINK_LIBS}
-                            cucascade_topology_discovery_static)
-  target_compile_features(cucascade_static PUBLIC cxx_std_20)
+    target_include_directories(cucascade_static
+                               PUBLIC ${CUCASCADE_PUBLIC_INCLUDE_DIRS})
+    target_link_libraries(
+      cucascade_static PUBLIC ${CUCASCADE_PUBLIC_LINK_LIBS}
+                              cucascade_topology_discovery_static)
+    target_compile_features(cucascade_static PUBLIC cxx_std_20)
 
-  set_target_properties(
-    cucascade_static PROPERTIES OUTPUT_NAME cucascade EXPORT_NAME
-                                                      cucascade_static)
+    set_target_properties(
+      cucascade_static PROPERTIES OUTPUT_NAME cucascade EXPORT_NAME
+                                                        cucascade_static)
+  endif()
 endif()
 
 # =============================================================================
@@ -220,35 +245,41 @@ if(CUCASCADE_BUILD_SHARED_LIBS)
   set_target_properties(cucascade_topology_discovery_shared
                         PROPERTIES OUTPUT_NAME cucascade_topology_discovery)
 
-  add_library(cucascade_shared SHARED $<TARGET_OBJECTS:cucascade_objects>)
-  add_library(cuCascade::cucascade_shared ALIAS cucascade_shared)
+  if(NOT CUCASCADE_TOPOLOGY_ONLY)
+    add_library(cucascade_shared SHARED $<TARGET_OBJECTS:cucascade_objects>)
+    add_library(cuCascade::cucascade_shared ALIAS cucascade_shared)
 
-  target_include_directories(cucascade_shared
-                             PUBLIC ${CUCASCADE_PUBLIC_INCLUDE_DIRS})
-  target_link_libraries(
-    cucascade_shared PUBLIC ${CUCASCADE_PUBLIC_LINK_LIBS}
-                            cucascade_topology_discovery_shared)
-  target_compile_features(cucascade_shared PUBLIC cxx_std_20)
+    target_include_directories(cucascade_shared
+                               PUBLIC ${CUCASCADE_PUBLIC_INCLUDE_DIRS})
+    target_link_libraries(
+      cucascade_shared PUBLIC ${CUCASCADE_PUBLIC_LINK_LIBS}
+                              cucascade_topology_discovery_shared)
+    target_compile_features(cucascade_shared PUBLIC cxx_std_20)
 
-  set_target_properties(cucascade_shared PROPERTIES OUTPUT_NAME cucascade)
+    set_target_properties(cucascade_shared PROPERTIES OUTPUT_NAME cucascade)
+  endif()
 endif()
 
 # =============================================================================
 # Default target alias (prefer shared if available, else static)
 # =============================================================================
 if(CUCASCADE_BUILD_SHARED_LIBS)
-  add_library(cuCascade::cucascade ALIAS cucascade_shared)
+  if(NOT CUCASCADE_TOPOLOGY_ONLY)
+    add_library(cuCascade::cucascade ALIAS cucascade_shared)
+    # For backwards compatibility, also create 'cucascade' as an alias
+    add_library(cucascade ALIAS cucascade_shared)
+  endif()
   add_library(cuCascade::cucascade_topology_discovery ALIAS
               cucascade_topology_discovery_shared)
-  # For backwards compatibility, also create 'cucascade' as an alias
-  add_library(cucascade ALIAS cucascade_shared)
   add_library(cucascade_topology_discovery ALIAS
               cucascade_topology_discovery_shared)
 elseif(CUCASCADE_BUILD_STATIC_LIBS)
-  add_library(cuCascade::cucascade ALIAS cucascade_static)
+  if(NOT CUCASCADE_TOPOLOGY_ONLY)
+    add_library(cuCascade::cucascade ALIAS cucascade_static)
+    add_library(cucascade ALIAS cucascade_static)
+  endif()
   add_library(cuCascade::cucascade_topology_discovery ALIAS
               cucascade_topology_discovery_static)
-  add_library(cucascade ALIAS cucascade_static)
   add_library(cucascade_topology_discovery ALIAS
               cucascade_topology_discovery_static)
 endif()
@@ -260,22 +291,31 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 # Install headers
-install(
-  DIRECTORY include/
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-  FILES_MATCHING
-  PATTERN "*.hpp"
-  PATTERN "*.h")
+if(CUCASCADE_TOPOLOGY_ONLY)
+  install(FILES include/cucascade/memory/topology_discovery.hpp
+          DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cucascade/memory)
+else()
+  install(
+    DIRECTORY include/
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+    FILES_MATCHING
+    PATTERN "*.hpp"
+    PATTERN "*.h")
+endif()
 
 # Collect targets to install
 set(CUCASCADE_INSTALL_TARGETS)
 if(CUCASCADE_BUILD_STATIC_LIBS)
-  list(APPEND CUCASCADE_INSTALL_TARGETS cucascade_static
-       cucascade_topology_discovery_static)
+  list(APPEND CUCASCADE_INSTALL_TARGETS cucascade_topology_discovery_static)
+  if(NOT CUCASCADE_TOPOLOGY_ONLY)
+    list(APPEND CUCASCADE_INSTALL_TARGETS cucascade_static)
+  endif()
 endif()
 if(CUCASCADE_BUILD_SHARED_LIBS)
-  list(APPEND CUCASCADE_INSTALL_TARGETS cucascade_shared
-       cucascade_topology_discovery_shared)
+  list(APPEND CUCASCADE_INSTALL_TARGETS cucascade_topology_discovery_shared)
+  if(NOT CUCASCADE_TOPOLOGY_ONLY)
+    list(APPEND CUCASCADE_INSTALL_TARGETS cucascade_shared)
+  endif()
 endif()
 
 # Install library targets
@@ -296,9 +336,16 @@ install(
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cuCascade)
 
 # Generate package config file
+if(CUCASCADE_TOPOLOGY_ONLY)
+  set(CUCASCADE_CONFIG_TEMPLATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cuCascadeTopologyOnlyConfig.cmake.in)
+else()
+  set(CUCASCADE_CONFIG_TEMPLATE
+      ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cuCascadeConfig.cmake.in)
+endif()
+
 configure_package_config_file(
-  ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cuCascadeConfig.cmake.in
-  ${CMAKE_CURRENT_BINARY_DIR}/cuCascadeConfig.cmake
+  ${CUCASCADE_CONFIG_TEMPLATE} ${CMAKE_CURRENT_BINARY_DIR}/cuCascadeConfig.cmake
   INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cuCascade)
 
 # Generate version file

--- a/cmake/cuCascadeTopologyOnlyConfig.cmake.in
+++ b/cmake/cuCascadeTopologyOnlyConfig.cmake.in
@@ -1,0 +1,22 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+# Find required dependencies (topology only needs CUDAToolkit for NVML)
+find_dependency(CUDAToolkit REQUIRED VERSION 12.9)
+
+# Include the targets file
+include("${CMAKE_CURRENT_LIST_DIR}/cuCascadeTargets.cmake")
+
+# Provide a default target alias for convenience
+if(TARGET cuCascade::cucascade_topology_discovery_shared)
+  if(NOT TARGET cuCascade::cucascade_topology_discovery)
+    add_library(cuCascade::cucascade_topology_discovery ALIAS cuCascade::cucascade_topology_discovery_shared)
+  endif()
+elseif(TARGET cuCascade::cucascade_topology_discovery_static)
+  if(NOT TARGET cuCascade::cucascade_topology_discovery)
+    add_library(cuCascade::cucascade_topology_discovery ALIAS cuCascade::cucascade_topology_discovery_static)
+  endif()
+endif()
+
+check_required_components(cuCascade)

--- a/src/memory/CMakeLists.txt
+++ b/src/memory/CMakeLists.txt
@@ -15,22 +15,24 @@
 # the License.
 # =============================================================================
 
-target_sources(
-  cucascade_objects
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/common.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/disk_access_limiter.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/fixed_size_host_memory_resource.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/memory_reservation.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/memory_reservation_manager.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/memory_space.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/notification_channel.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/null_device_memory_resource.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/numa_region_pinned_host_allocator.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/oom_handling_policy.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/reservation_aware_resource_adaptor.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/reservation_manager_configurator.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/small_pinned_host_memory_resource.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/stream_pool.cpp
-          ${CMAKE_CURRENT_SOURCE_DIR}/error.cpp)
+if(TARGET cucascade_objects)
+  target_sources(
+    cucascade_objects
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/common.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/disk_access_limiter.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/fixed_size_host_memory_resource.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/memory_reservation.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/memory_reservation_manager.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/memory_space.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/notification_channel.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/null_device_memory_resource.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/numa_region_pinned_host_allocator.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/oom_handling_policy.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/reservation_aware_resource_adaptor.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/reservation_manager_configurator.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/small_pinned_host_memory_resource.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/stream_pool.cpp
+            ${CMAKE_CURRENT_SOURCE_DIR}/error.cpp)
+endif()
 target_sources(cucascade_topology_discovery_objects
                PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/topology_discovery.cpp)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -23,43 +23,45 @@ FetchContent_Declare(
   GIT_TAG v2.13.10)
 FetchContent_MakeAvailable(Catch2)
 
-# Create test executable
-add_executable(
-  cucascade_tests
-  # Utils
-  utils/cudf_test_utils.cpp
-  # Memory tests
-  memory/test_memory_reservation_manager.cpp
-  memory/test_small_pinned_host_memory_resource.cpp
-  memory/test_gpu_kernels.cu
-  # Data tests
-  data/test_bandwidth_profiler.cpp
-  data/test_data_batch.cpp
-  data/test_data_repository.cpp
-  data/test_data_repository_manager.cpp
-  data/test_data_representation.cpp
-  data/test_disk_io_backend.cpp
-  data/test_io_worker.cpp
-  data/test_disk_host_converters.cpp
-  data/test_gpu_disk_converters.cpp
-  data/test_representation_converter.cpp
-  # Main test runner
-  unittest.cpp)
-set_target_properties(cucascade_tests PROPERTIES CUDA_STANDARD 20
-                                                 CUDA_STANDARD_REQUIRED ON)
+if(NOT CUCASCADE_TOPOLOGY_ONLY)
+  # Create test executable
+  add_executable(
+    cucascade_tests
+    # Utils
+    utils/cudf_test_utils.cpp
+    # Memory tests
+    memory/test_memory_reservation_manager.cpp
+    memory/test_small_pinned_host_memory_resource.cpp
+    memory/test_gpu_kernels.cu
+    # Data tests
+    data/test_bandwidth_profiler.cpp
+    data/test_data_batch.cpp
+    data/test_data_repository.cpp
+    data/test_data_repository_manager.cpp
+    data/test_data_representation.cpp
+    data/test_disk_io_backend.cpp
+    data/test_io_worker.cpp
+    data/test_disk_host_converters.cpp
+    data/test_gpu_disk_converters.cpp
+    data/test_representation_converter.cpp
+    # Main test runner
+    unittest.cpp)
+  set_target_properties(cucascade_tests PROPERTIES CUDA_STANDARD 20
+                                                   CUDA_STANDARD_REQUIRED ON)
 
-# Set include directories
-target_include_directories(
-  cucascade_tests
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/utils
-          ${Catch2_SOURCE_DIR}/single_include)
+  # Set include directories
+  target_include_directories(
+    cucascade_tests
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/utils
+            ${Catch2_SOURCE_DIR}/single_include)
 
-# Link dependencies
-target_link_libraries(cucascade_tests PRIVATE cucascade Catch2::Catch2
-                                              CUDA::cudart_static)
+  # Link dependencies
+  target_link_libraries(cucascade_tests PRIVATE cucascade Catch2::Catch2
+                                                CUDA::cudart_static)
 
-# Register tests with CTest
-add_test(NAME cucascade_tests COMMAND cucascade_tests)
+  # Register tests with CTest
+  add_test(NAME cucascade_tests COMMAND cucascade_tests)
+endif()
 
 # Create topology discovery test executable
 add_executable(


### PR DESCRIPTION
The topology split in https://github.com/NVIDIA/cuCascade/pull/126 prevented the build of non-topology components of cuCascade when they aren't needed, but it still configures assuming everything is built, which means that it tries to find rmm and cudf. That can still lead to more circular dependency issues depending on exactly how builds are done, so we need a heavier hammer to avoid that. This PR implements a CMake flag to turn off every part of the non-topology build when needed.