### PR TITLE
Export numa via a bundled FindNuma module instead of an absolute path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,8 +64,10 @@ if(NOT CUCASCADE_TOPOLOGY_ONLY)
   find_package(cudf REQUIRED CONFIG)
 
   # Find numa (provided by numactl-devel or libnuma-dev depending on the package
-  # manager)
-  find_library(NUMA_LIB numa REQUIRED)
+  # manager). Uses the bundled FindNuma module, which produces the Numa::Numa
+  # imported target. The same module is installed with the package so consumers
+  # resolve libnuma on their own system rather than inheriting a hardcoded path.
+  find_package(Numa REQUIRED)
 endif()
 
 # Set CUDA architectures
@@ -151,7 +153,7 @@ set(CUCASCADE_PUBLIC_INCLUDE_DIRS
 
 if(NOT CUCASCADE_TOPOLOGY_ONLY)
   set(CUCASCADE_PUBLIC_LINK_LIBS rmm::rmm cudf::cudf CUDA::cudart_static
-                                 Threads::Threads ${NUMA_LIB})
+                                 Threads::Threads Numa::Numa)
 
   # Set include directories for the object library
   target_include_directories(cucascade_objects
@@ -358,6 +360,14 @@ write_basic_package_version_file(
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cuCascadeConfig.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/cuCascadeConfigVersion.cmake
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cuCascade)
+
+# Bundle the FindNuma module so consumers can rerun the same find logic (the
+# full library links the Numa::Numa target it produces). Not needed for
+# topology-only builds, which do not depend on libnuma.
+if(NOT CUCASCADE_TOPOLOGY_ONLY)
+  install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/FindNuma.cmake
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/cuCascade/Modules)
+endif()
 
 # =============================================================================
 # Tests

--- a/cmake/Modules/FindNuma.cmake
+++ b/cmake/Modules/FindNuma.cmake
@@ -50,8 +50,8 @@ find_path(Numa_INCLUDE_DIR NAMES numa.h)
 find_library(Numa_LIBRARY NAMES numa)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(
-  Numa REQUIRED_VARS Numa_LIBRARY Numa_INCLUDE_DIR)
+find_package_handle_standard_args(Numa REQUIRED_VARS Numa_LIBRARY
+                                                     Numa_INCLUDE_DIR)
 
 if(Numa_FOUND)
   set(Numa_LIBRARIES ${Numa_LIBRARY})
@@ -60,9 +60,8 @@ if(Numa_FOUND)
   if(NOT TARGET Numa::Numa)
     add_library(Numa::Numa UNKNOWN IMPORTED)
     set_target_properties(
-      Numa::Numa
-      PROPERTIES IMPORTED_LOCATION "${Numa_LIBRARY}"
-                 INTERFACE_INCLUDE_DIRECTORIES "${Numa_INCLUDE_DIR}")
+      Numa::Numa PROPERTIES IMPORTED_LOCATION "${Numa_LIBRARY}"
+                            INTERFACE_INCLUDE_DIRECTORIES "${Numa_INCLUDE_DIR}")
   endif()
 endif()
 

--- a/cmake/Modules/FindNuma.cmake
+++ b/cmake/Modules/FindNuma.cmake
@@ -1,0 +1,69 @@
+# =============================================================================
+# SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+# All rights reserved. SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License. You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations under
+# the License.
+# =============================================================================
+
+#[=======================================================================[.rst:
+FindNuma
+--------
+
+Finds libnuma (the NUMA policy library, provided by ``numactl-devel`` or
+``libnuma-dev`` depending on the package manager).
+
+This module is bundled with the installed cuCascade CMake package so that the
+same find logic runs for downstream consumers, locating libnuma at whatever
+path it lives on the consumer's system rather than embedding the build
+machine's absolute path into the exported targets.
+
+Imported Targets
+^^^^^^^^^^^^^^^^^
+
+``Numa::Numa``
+  The libnuma library, if found. Carries the include directory and library
+  location as usage requirements.
+
+Result Variables
+^^^^^^^^^^^^^^^^^
+
+``Numa_FOUND``
+  True if libnuma was found.
+``Numa_INCLUDE_DIRS``
+  Include directories needed to use libnuma.
+``Numa_LIBRARIES``
+  Libraries needed to link against libnuma.
+
+#]=======================================================================]
+
+find_path(Numa_INCLUDE_DIR NAMES numa.h)
+find_library(Numa_LIBRARY NAMES numa)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(
+  Numa REQUIRED_VARS Numa_LIBRARY Numa_INCLUDE_DIR)
+
+if(Numa_FOUND)
+  set(Numa_LIBRARIES ${Numa_LIBRARY})
+  set(Numa_INCLUDE_DIRS ${Numa_INCLUDE_DIR})
+
+  if(NOT TARGET Numa::Numa)
+    add_library(Numa::Numa UNKNOWN IMPORTED)
+    set_target_properties(
+      Numa::Numa
+      PROPERTIES IMPORTED_LOCATION "${Numa_LIBRARY}"
+                 INTERFACE_INCLUDE_DIRECTORIES "${Numa_INCLUDE_DIR}")
+  endif()
+endif()
+
+mark_as_advanced(Numa_INCLUDE_DIR Numa_LIBRARY)

--- a/cmake/cuCascadeConfig.cmake.in
+++ b/cmake/cuCascadeConfig.cmake.in
@@ -8,6 +8,12 @@ find_dependency(Threads REQUIRED)
 find_dependency(rmm REQUIRED CONFIG)
 find_dependency(cudf REQUIRED CONFIG)
 
+# The exported targets link the Numa::Numa imported target. Rerun the bundled
+# FindNuma module so it is reconstructed against the consumer's libnuma instead
+# of a path baked in at build time.
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/Modules")
+find_dependency(Numa REQUIRED)
+
 # Include the targets file
 include("${CMAKE_CURRENT_LIST_DIR}/cuCascadeTargets.cmake")
 


### PR DESCRIPTION
## Summary

Fixes #118.

`find_library(NUMA_LIB numa REQUIRED)` resolves `numa` to an absolute path (e.g. `/usr/lib64/libnuma.so`). That path was passed as a `PUBLIC` link dependency via `${NUMA_LIB}`, so CMake serialized it verbatim into the exported `cuCascadeTargets.cmake`. Consumers on systems where libnuma lives at a different path then fail to link — for example a manylinux-built wheel referencing `/usr/lib64/libnuma.so` consumed on Ubuntu arm64 (where it is at `/usr/lib/aarch64-linux-gnu/libnuma.so`):

```
ninja: error: '/usr/lib64/libnuma.so', needed by 'librapidsmpf.so', missing and no known rule to make it
```

## Changes

Rather than embed a library path in the export, this introduces a proper find module that produces an imported target, bundled with the package so the same find logic runs on both sides (per review feedback).

- **`cmake/Modules/FindNuma.cmake`** (new): locates `numa.h` and the `numa` library, validates via `find_package_handle_standard_args`, and produces a `Numa::Numa` imported target carrying both the include directory and the library location. This also propagates the `numa.h` include path, which a bare library reference did not.
- **`CMakeLists.txt`**: use `find_package(Numa REQUIRED)` and link the `Numa::Numa` target instead of a raw path; install `FindNuma.cmake` into the package's `cmake/cuCascade/Modules` dir (skipped for topology-only builds, which don't depend on libnuma).
- **`cmake/cuCascadeConfig.cmake.in`**: prepend the bundled `Modules` dir to `CMAKE_MODULE_PATH` and rerun `find_dependency(Numa REQUIRED)`, so consumers reconstruct `Numa::Numa` against their own libnuma — no path baked into the exported targets, and a clear configure-time error if libnuma is missing.

## Verification

Built, installed to a temp prefix, and configured a standalone consumer project against the install:

- Exported `cuCascadeTargets.cmake` references the target, not a path:
  ```
  INTERFACE_LINK_LIBRARIES "rmm::rmm;cudf::cudf;CUDA::cudart_static;Threads::Threads;Numa::Numa;..."
  ```
- `FindNuma.cmake` is installed under `lib/cmake/cuCascade/Modules/`.
- A consumer running `find_package(cuCascade)` reconstructs `Numa::Numa`, resolving libnuma at its own system path.

---

🤖 This PR was authored by an AI agent (Claude Code), under human review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)