### PR TITLE
Implemented ability to rebind_stream

### DIFF
--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -432,6 +432,25 @@ class mutable_data_batch {
                   const memory::memory_space* target_memory_space,
                   rmm::cuda_stream_view stream);
 
+  /**
+   * @brief Rebind the held data's device buffers to use @p stream for future deallocation.
+   *
+   * Forwards to gpu_table_representation::rebind_stream when the held representation is a
+   * GPU table that owns its data; a no-op for every other representation (host, disk, or a
+   * GPU representation backed by an externally-owned table_view).
+   *
+   * Rebinding before an operation that may free the data (a GPU->host downgrade, or a pipeline
+   * task that consumes it) makes the buffers free on the active stream rather than the stream
+   * they were produced on, keeping RMM's per-stream free lists correct and avoiding the
+   * cross-stream premature-reuse hazard. Requires the exclusive (mutable) lock held by this
+   * accessor.
+   *
+   * @note Does NOT insert cross-stream ordering -- see gpu_table_representation::rebind_stream.
+   *
+   * @param stream Stream used for future asynchronous deallocation of the data's buffers.
+   */
+  void rebind_stream(rmm::cuda_stream_view stream);
+
   // -- Clone operations (CLONE-01/CLONE-02) --
 
   /**

--- a/include/cucascade/data/gpu_data_representation.hpp
+++ b/include/cucascade/data/gpu_data_representation.hpp
@@ -146,6 +146,26 @@ class gpu_table_representation : public idata_representation {
   std::unique_ptr<cudf::table> release_table(rmm::cuda_stream_view stream);
 
   /**
+   * @brief Rebind the owned table's device buffers to use @p stream for future deallocation.
+   *
+   * Applies cudf::rebind_stream to every column (recursively rebinding data buffers, null
+   * masks, and nested children) so that the buffers are freed on @p stream rather than on the
+   * stream they were originally allocated on. No device memory is copied and no kernels are
+   * launched.
+   *
+   * No-op when this representation holds an owning_table_view: that alternative references
+   * memory owned by an external (type-erased) owner, which is responsible for its own
+   * deallocation stream.
+   *
+   * @note This does NOT insert cross-stream ordering. The caller must ensure a happens-before
+   * relationship from any stream with in-flight work touching this table's memory to @p stream
+   * before the rebound memory is reused or freed. See cudf::rebind_stream.
+   *
+   * @param stream Stream used for future asynchronous deallocation of the table's buffers.
+   */
+  void rebind_stream(rmm::cuda_stream_view stream);
+
+  /**
    * @brief Record a CUDA event on @p writer_stream and store it as the writer event.
    *
    * STREAM-LINEAGE: any cross-stream / cross-device reader of this representation's

--- a/include/cucascade/memory/stream_pool.hpp
+++ b/include/cucascade/memory/stream_pool.hpp
@@ -22,6 +22,7 @@
 #include <rmm/cuda_stream_view.hpp>
 
 #include <condition_variable>
+#include <deque>
 #include <mutex>
 
 namespace cucascade {
@@ -99,7 +100,9 @@ class exclusive_stream_pool {
   std::condition_variable _cv;
   rmm::cuda_device_id _device_id;
   rmm::cuda_stream::flags _flags;
-  std::vector<rmm::cuda_stream> _streams;
+  // Streams are acquired from the front and returned to the back so the pool cycles through
+  // all streams round-robin, rather than repeatedly reusing the most-recently-returned one.
+  std::deque<rmm::cuda_stream> _streams;
 };
 
 }  // namespace memory

--- a/src/data/data_batch.cpp
+++ b/src/data/data_batch.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/gpu_data_representation.hpp>
 
 namespace cucascade {
 
@@ -259,6 +260,13 @@ mutable_data_batch::~mutable_data_batch()
   if (_batch) {
     // Transition state to idle. The _lock member destructor handles releasing the exclusive lock.
     _batch->_state.store(batch_state::idle);
+  }
+}
+
+void mutable_data_batch::rebind_stream(rmm::cuda_stream_view stream)
+{
+  if (auto* gpu = dynamic_cast<gpu_table_representation*>(_batch->get_data())) {
+    gpu->rebind_stream(stream);
   }
 }
 

--- a/src/data/gpu_data_representation.cpp
+++ b/src/data/gpu_data_representation.cpp
@@ -18,6 +18,7 @@
 #include <cucascade/data/gpu_data_representation.hpp>
 #include <cucascade/error.hpp>
 
+#include <cudf/column/column_stream.hpp>
 #include <cudf/copying.hpp>
 #include <cudf/utilities/traits.hpp>
 
@@ -81,6 +82,24 @@ std::unique_ptr<cudf::table> gpu_table_representation::release_table(
     _table = std::make_unique<cudf::table>(std::get<owning_table_view>(_table).view, stream);
   }
   return std::move(std::get<std::unique_ptr<cudf::table>>(_table));
+}
+
+void gpu_table_representation::rebind_stream(rmm::cuda_stream_view stream)
+{
+  // Only the owned-table alternative can be rebound: the owning_table_view alternative
+  // references memory owned by an external (type-erased) owner, which manages its own
+  // deallocation stream.
+  if (!std::holds_alternative<std::unique_ptr<cudf::table>>(_table)) { return; }
+  auto& table = std::get<std::unique_ptr<cudf::table>>(_table);
+  if (!table || table->num_columns() == 0) { return; }
+
+  // cudf::table move-assignment is deleted, so release the columns, rebind each, and rebuild
+  // the table in place. No device memory is copied and no kernels are launched.
+  auto columns = table->release();
+  for (auto& col : columns) {
+    col = cudf::rebind_stream(std::move(*col), stream);
+  }
+  table = std::make_unique<cudf::table>(std::move(columns));
 }
 
 std::unique_ptr<idata_representation> gpu_table_representation::clone(rmm::cuda_stream_view stream)

--- a/src/memory/stream_pool.cpp
+++ b/src/memory/stream_pool.cpp
@@ -68,7 +68,6 @@ exclusive_stream_pool::exclusive_stream_pool(rmm::cuda_device_id device_id,
   rmm::cuda_set_device_raii set_device{_device_id};
   if (pool_size == 0) { throw std::logic_error("Stream pool size must be greater than zero"); }
 
-  _streams.reserve(pool_size);
   for (std::size_t i = 0; i < pool_size; ++i) {
     _streams.emplace_back(rmm::cuda_stream(_flags));
   }
@@ -86,8 +85,11 @@ borrowed_stream exclusive_stream_pool::acquire_stream(stream_acquire_policy poli
       _cv.wait(lock, [this]() { return !_streams.empty(); });
     }
   }
-  auto stream = std::move(_streams.back());
-  _streams.pop_back();
+  // Acquire from the front; release_stream() returns to the back. This cycles through all
+  // streams round-robin so every stream's prior async work has maximal time to drain before
+  // it is handed out again, instead of hammering the most-recently-returned stream.
+  auto stream = std::move(_streams.front());
+  _streams.pop_front();
   return borrowed_stream(std::move(stream),
                          std::bind_front(&exclusive_stream_pool::release_stream, this));
 }


### PR DESCRIPTION
Currently all deallocations happen on the stream on which they allocations were made. This PR adds an API which allows for changing that stream, so that deallocations can be made to happen on the active stream.

It also changes the exclusive_stream_pool class so that it recycles streams more in a FIFO manner instead of LIFO. This way it cycles through all streams in a round robin fashion