### PR TITLE
Add data_batch::release_or_copy_table for refcount-checked table steal

### DIFF
--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -159,6 +159,35 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
    */
   [[nodiscard]] static std::shared_ptr<data_batch> to_idle(mutable_data_batch&& accessor);
 
+  /**
+   * @brief Steal the underlying cuDF table if @p batch is uniquely owned, otherwise deep-copy it.
+   *
+   * Consumes @p batch: the caller MUST std::move in its only handle. The function attempts to
+   * acquire the exclusive lock NON-BLOCKING:
+   *  - If the try succeeds, it drops the consumed reference and checks ownership. When the lock
+   *    accessor's internal pointer is the sole owner (use_count() == 1, i.e. no other
+   *    `shared_ptr<data_batch>` exists anywhere — other query branches, repositories, subscriber
+   *    bookkeeping, etc.), the table is moved out zero-copy via release_table(). Otherwise an
+   *    independent deep copy is returned (taken while holding the exclusive lock) and the batch is
+   *    left intact for the other owners.
+   *  - If the try FAILS, another owner is actively locking the batch, so it is definitely shared;
+   *    the table is deep-copied under a read lock (compatible with concurrent readers).
+   *
+   * The non-blocking try is deliberate: a blocking exclusive lock would stall — or deadlock — when
+   * a sibling branch is concurrently reading the same shared batch.
+   *
+   * Soundness: a thread can only lock a batch via a `shared_ptr` it already holds, and every such
+   * pointer is reflected in use_count(). Because the steal happens only while we hold the exclusive
+   * lock and use_count() == 1, no other reader exists or can appear, making it race-free.
+   *
+   * @param batch The batch to consume; pass with std::move. Must hold a gpu_table_representation.
+   * @param stream CUDA stream for the copy path (and the release_table view-materialization path).
+   * @return The owned cuDF table, either moved out (unique) or deep-copied (shared).
+   * @throws cucascade::logic_error if the batch's representation is not a gpu_table_representation.
+   */
+  [[nodiscard]] static std::unique_ptr<cudf::table> release_or_copy_table(
+    std::shared_ptr<data_batch> batch, rmm::cuda_stream_view stream);
+
   // -- Non-static transitions (via shared_from_this) --
   // The caller's shared_ptr is NOT consumed. These only work when the
   // data_batch is managed by a shared_ptr (throws bad_weak_ptr otherwise).

--- a/src/data/data_batch.cpp
+++ b/src/data/data_batch.cpp
@@ -16,6 +16,8 @@
  */
 
 #include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/gpu_data_representation.hpp>
+#include <cucascade/error.hpp>
 
 namespace cucascade {
 
@@ -82,6 +84,45 @@ std::shared_ptr<data_batch> data_batch::to_idle(mutable_data_batch&& accessor)
     auto _ = std::move(accessor);
   }  // destroy accessor, releasing exclusive lock
   return ptr;
+}
+
+std::unique_ptr<cudf::table> data_batch::release_or_copy_table(std::shared_ptr<data_batch> batch,
+                                                               rmm::cuda_stream_view stream)
+{
+  // Try to grab exclusive access WITHOUT blocking. A non-blocking try is essential: if another
+  // owner (e.g. a sibling query branch) is concurrently reading the batch, a blocking to_mutable()
+  // would stall — or deadlock — until they finish. A failed try is itself proof the batch is
+  // shared, so we copy in that case.
+  if (auto maybe_mut = batch->try_to_mutable()) {
+    auto mut = std::move(*maybe_mut);
+
+    // Drop the caller-provided reference; mut._batch is now the canonical handle. Its use_count()
+    // is 1 iff no other shared_ptr<data_batch> exists anywhere.
+    batch.reset();
+
+    auto* gpu = dynamic_cast<gpu_table_representation*>(mut._batch->get_data());
+    if (gpu == nullptr) {
+      CUCASCADE_FAIL("release_or_copy_table requires a gpu_table_representation");
+    }
+
+    if (mut._batch.use_count() == 1) {
+      // Sole owner: steal the columns zero-copy. The emptied representation is never observed
+      // because the batch is destroyed when `mut` drops the last reference at end of scope.
+      return gpu->release_table(stream);
+    }
+    // Shared with idle owners (none currently locked): copy while holding the exclusive lock so the
+    // source data is stable, then leave the live batch untouched for the other owners.
+    return std::make_unique<cudf::table>(gpu->get_table_view(), stream);
+  }
+
+  // Could not acquire exclusive access → the batch is actively locked by another owner, so it is
+  // definitely shared. Copy under a read lock (compatible with concurrent readers).
+  auto ro   = batch->to_read_only();
+  auto* gpu = dynamic_cast<gpu_table_representation*>(ro.get_data());
+  if (gpu == nullptr) {
+    CUCASCADE_FAIL("release_or_copy_table requires a gpu_table_representation");
+  }
+  return std::make_unique<cudf::table>(gpu->get_table_view(), stream);
 }
 
 // ========== Non-static transition methods ==========

--- a/test/data/test_data_batch.cpp
+++ b/test/data/test_data_batch.cpp
@@ -1595,7 +1595,7 @@ TEST_CASE("release_or_copy_table steals when sole owner", "[data_batch][gpu]")
   auto gpu_space = make_mock_memory_space(memory::Tier::GPU, 0);
   rmm::cuda_stream stream;
 
-  auto batch = make_gpu_table_batch(*gpu_space, stream.view(), 100, 3);
+  auto batch = make_gpu_table_batch(*gpu_space, stream.view(), 100, 2);
 
   // Record the device pointers of the original columns before stealing.
   std::vector<void const*> original_heads;
@@ -1610,7 +1610,7 @@ TEST_CASE("release_or_copy_table steals when sole owner", "[data_batch][gpu]")
   stream.synchronize();
 
   REQUIRE(stolen != nullptr);
-  REQUIRE(stolen->num_columns() == 3);
+  REQUIRE(stolen->num_columns() == 2);
   REQUIRE(stolen->num_rows() == 100);
 
   // Zero-copy: the returned columns must reuse the original device memory.
@@ -1623,7 +1623,7 @@ TEST_CASE("release_or_copy_table copies when shared", "[data_batch][gpu]")
   auto gpu_space = make_mock_memory_space(memory::Tier::GPU, 0);
   rmm::cuda_stream stream;
 
-  auto batch = make_gpu_table_batch(*gpu_space, stream.view(), 100, 3);
+  auto batch = make_gpu_table_batch(*gpu_space, stream.view(), 100, 2);
 
   // A second owner keeps the batch alive — this models another query branch /
   // repository still referencing the same data.
@@ -1641,7 +1641,7 @@ TEST_CASE("release_or_copy_table copies when shared", "[data_batch][gpu]")
   stream.synchronize();
 
   REQUIRE(copied != nullptr);
-  REQUIRE(copied->num_columns() == 3);
+  REQUIRE(copied->num_columns() == 2);
   REQUIRE(copied->num_rows() == 100);
 
   // Deep copy: the returned columns must NOT alias the original device memory.
@@ -1654,7 +1654,7 @@ TEST_CASE("release_or_copy_table copies when shared", "[data_batch][gpu]")
   auto ro              = other_owner->to_read_only();
   auto* surviving_repr = dynamic_cast<gpu_table_representation*>(ro.get_data());
   REQUIRE(surviving_repr != nullptr);
-  REQUIRE(surviving_repr->get_table_view().num_columns() == 3);
+  REQUIRE(surviving_repr->get_table_view().num_columns() == 2);
   REQUIRE(surviving_repr->get_table_view().num_rows() == 100);
   expect_cudf_tables_equal_on_stream(
     surviving_repr->get_table_view(), copied->view(), stream.view());

--- a/test/data/test_data_batch.cpp
+++ b/test/data/test_data_batch.cpp
@@ -28,6 +28,7 @@
 
 #include <catch2/catch.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstring>
@@ -1554,4 +1555,146 @@ TEST_CASE("read_only_data_batch copy then mutable after all copies released", "[
   auto mut = batch->to_mutable();
   REQUIRE(batch->get_state() == batch_state::mutable_locked);
   REQUIRE(mut.get_batch_id() == 1);
+}
+
+// =============================================================================
+// release_or_copy_table tests
+// =============================================================================
+
+namespace {
+
+// Build a single-batch shared_ptr<data_batch> wrapping a real GPU cuDF table.
+std::shared_ptr<data_batch> make_gpu_table_batch(cucascade::memory::memory_space& gpu_space,
+                                                 rmm::cuda_stream_view stream,
+                                                 cudf::size_type num_rows    = 100,
+                                                 cudf::size_type num_columns = 3)
+{
+  auto table =
+    create_simple_cudf_table(num_rows, num_columns, gpu_space.get_default_allocator(), stream);
+  auto gpu_repr = std::make_unique<gpu_table_representation>(
+    std::make_unique<cudf::table>(std::move(table)), gpu_space, stream);
+  return std::make_shared<data_batch>(1, std::move(gpu_repr));
+}
+
+// Collect the device data pointers of each column so we can prove zero-copy
+// (identical pointers) vs. deep-copy (different pointers).
+std::vector<void const*> column_heads(cudf::table_view view)
+{
+  std::vector<void const*> heads;
+  heads.reserve(static_cast<size_t>(view.num_columns()));
+  for (cudf::size_type i = 0; i < view.num_columns(); ++i) {
+    heads.push_back(view.column(i).head());
+  }
+  return heads;
+}
+
+}  // namespace
+
+TEST_CASE("release_or_copy_table steals when sole owner", "[data_batch][gpu]")
+{
+  auto gpu_space = make_mock_memory_space(memory::Tier::GPU, 0);
+  rmm::cuda_stream stream;
+
+  auto batch = make_gpu_table_batch(*gpu_space, stream.view(), 100, 3);
+
+  // Record the device pointers of the original columns before stealing.
+  std::vector<void const*> original_heads;
+  {
+    auto ro = batch->to_read_only();
+    original_heads =
+      column_heads(dynamic_cast<gpu_table_representation*>(ro.get_data())->get_table_view());
+  }
+
+  // batch is the only handle: std::move it in so the helper becomes the sole owner.
+  auto stolen = data_batch::release_or_copy_table(std::move(batch), stream.view());
+  stream.synchronize();
+
+  REQUIRE(stolen != nullptr);
+  REQUIRE(stolen->num_columns() == 3);
+  REQUIRE(stolen->num_rows() == 100);
+
+  // Zero-copy: the returned columns must reuse the original device memory.
+  auto stolen_heads = column_heads(stolen->view());
+  REQUIRE(stolen_heads == original_heads);
+}
+
+TEST_CASE("release_or_copy_table copies when shared", "[data_batch][gpu]")
+{
+  auto gpu_space = make_mock_memory_space(memory::Tier::GPU, 0);
+  rmm::cuda_stream stream;
+
+  auto batch = make_gpu_table_batch(*gpu_space, stream.view(), 100, 3);
+
+  // A second owner keeps the batch alive — this models another query branch /
+  // repository still referencing the same data.
+  auto other_owner = batch;
+  REQUIRE(batch.use_count() == 2);
+
+  std::vector<void const*> original_heads;
+  {
+    auto ro = other_owner->to_read_only();
+    original_heads =
+      column_heads(dynamic_cast<gpu_table_representation*>(ro.get_data())->get_table_view());
+  }
+
+  auto copied = data_batch::release_or_copy_table(std::move(batch), stream.view());
+  stream.synchronize();
+
+  REQUIRE(copied != nullptr);
+  REQUIRE(copied->num_columns() == 3);
+  REQUIRE(copied->num_rows() == 100);
+
+  // Deep copy: the returned columns must NOT alias the original device memory.
+  auto copied_heads = column_heads(copied->view());
+  for (auto* head : copied_heads) {
+    REQUIRE(std::find(original_heads.begin(), original_heads.end(), head) == original_heads.end());
+  }
+
+  // The surviving owner still serves valid, unmodified data.
+  auto ro              = other_owner->to_read_only();
+  auto* surviving_repr = dynamic_cast<gpu_table_representation*>(ro.get_data());
+  REQUIRE(surviving_repr != nullptr);
+  REQUIRE(surviving_repr->get_table_view().num_columns() == 3);
+  REQUIRE(surviving_repr->get_table_view().num_rows() == 100);
+  expect_cudf_tables_equal_on_stream(
+    surviving_repr->get_table_view(), copied->view(), stream.view());
+}
+
+TEST_CASE("release_or_copy_table throws on non-GPU representation", "[data_batch]")
+{
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::HOST, 1024);
+  auto batch = std::make_shared<data_batch>(1, std::move(data));
+
+  REQUIRE_THROWS_AS(data_batch::release_or_copy_table(std::move(batch), rmm::cuda_stream_view{}),
+                    cucascade::logic_error);
+}
+
+TEST_CASE("release_or_copy_table copies while a concurrent reader holds the batch",
+          "[data_batch][gpu]")
+{
+  auto gpu_space = make_mock_memory_space(memory::Tier::GPU, 0);
+  rmm::cuda_stream stream;
+
+  auto batch = make_gpu_table_batch(*gpu_space, stream.view(), 50, 2);
+
+  // A concurrent reader holds a read-only lock (and thus a shared_ptr) for the
+  // duration of the call. release_or_copy_table must observe use_count > 1 and
+  // deep-copy rather than steal out from under the reader.
+  auto reader_ro = std::make_unique<read_only_data_batch>(batch->to_read_only());
+
+  std::vector<void const*> original_heads =
+    column_heads(dynamic_cast<gpu_table_representation*>(reader_ro->get_data())->get_table_view());
+
+  auto result = data_batch::release_or_copy_table(std::move(batch), stream.view());
+  stream.synchronize();
+
+  auto result_heads = column_heads(result->view());
+  for (auto* head : result_heads) {
+    REQUIRE(std::find(original_heads.begin(), original_heads.end(), head) == original_heads.end());
+  }
+
+  // Reader's data is still intact.
+  auto* reader_repr = dynamic_cast<gpu_table_representation*>(reader_ro->get_data());
+  REQUIRE(reader_repr->get_table_view().num_columns() == 2);
+  REQUIRE(reader_repr->get_table_view().num_rows() == 50);
 }


### PR DESCRIPTION
## Summary

Adds `data_batch::release_or_copy_table()`, a safe way to obtain an owning
`cudf::table` out of a GPU-resident batch that no longer assumes the caller is
the sole owner.

`gpu_table_representation::release_table()` unconditionally moves the columns
out of the representation. That is only correct when the caller is guaranteed
to be the unique owner of the batch — but `data_batch` is designed to be
shareable (multiple `shared_ptr<data_batch>` holders, e.g. sibling query
branches or repositories). Stealing in the shared case corrupts the data for
the other owners. This new method makes the decision at runtime.

## Behavior

`release_or_copy_table(std::shared_ptr<data_batch> batch, stream)` **consumes**
the caller's handle (pass with `std::move`) and:

1. Attempts a **non-blocking** `try_to_mutable()`.
   - On success, it drops the consumed reference and checks ownership:
     - `use_count() == 1` (sole owner) → **steals** the table zero-copy via
       `release_table()`.
     - otherwise (shared with idle owners) → returns an independent **deep
       copy**, taken while holding the exclusive lock, leaving the live batch
       intact.
   - On failure (another owner is actively locking the batch, so it is
     definitely shared) → returns a **deep copy** taken under a read lock
     (compatible with concurrent readers).

The non-blocking try is deliberate: a blocking exclusive lock would stall — or
deadlock — when a sibling branch is concurrently reading the same shared batch.

### Why the steal is race-free

A thread can only lock a batch via a `shared_ptr` it already holds, and every
such pointer is reflected in `use_count()`. Because the steal happens only while
we hold the exclusive lock *and* `use_count() == 1`, no other reader exists or
can appear.

## Tests

Added tests in `test/data/test_data_batch.cpp`:
- sole-owner steal — verifies zero-copy by asserting identical column device
  pointers;
- shared deep-copy — verifies distinct device pointers and that the surviving
  owner's data is byte-for-byte intact;
- concurrent-reader deep-copy — verifies no stall/deadlock and reader data
  integrity while a read lock is held;
- non-GPU representation → throws `cucascade::logic_error`.

## Notes

No API is removed; `release_table()` is unchanged. Downstream callers can
migrate to `release_or_copy_table()` incrementally.

Closes https://github.com/sirius-db/sirius/issues/925