### PR TITLE
allow release of fixed size buffers in cucascade

### DIFF
--- a/include/cucascade/memory/fixed_size_host_memory_resource.hpp
+++ b/include/cucascade/memory/fixed_size_host_memory_resource.hpp
@@ -139,6 +139,8 @@ class fixed_size_host_memory_resource : public chunked_resource_info {
 
     std::size_t size() const noexcept { return _blocks.size(); }
 
+    [[nodiscard]] std::vector<std::byte*> release_blocks() noexcept { return std::move(_blocks); }
+
     std::span<std::byte*> get_blocks() noexcept { return _blocks; }
 
     std::span<std::byte> operator[](std::size_t i) const


### PR DESCRIPTION
Allow release of chunks.

this is needed when we want to allocate a large number of chunks, but we can only release them in small parts. so we can release the buffers, form new blocks and release them back to cucascade. 

---

use case: fs cache built on top of cucascade.
where we allocate 600 MBs for a file, then some chunks in that file are requeted again in a different request, so we keep them around but return the left overs to cucascade/