### PR TITLE
Pass memory::reservation into HOST converter allocations

### DIFF
--- a/docs/data-management.md
+++ b/docs/data-management.md
@@ -297,7 +297,10 @@ The `representation_converter_registry` stores conversion functions indexed by `
 ```cpp
 // Register a custom converter
 registry.register_converter<gpu_table_representation, host_data_representation>(
-    [](idata_representation& source, const memory_space* target, rmm::cuda_stream_view stream)
+    [](idata_representation& source,
+       const memory_space* target,
+       rmm::cuda_stream_view stream,
+       memory::reservation* reservation)
         -> std::unique_ptr<idata_representation> {
         // Convert GPU table to host (direct copy)
         return ...;
@@ -307,6 +310,10 @@ registry.register_converter<gpu_table_representation, host_data_representation>(
 // Convert data
 auto host_data = registry.convert<host_data_representation>(
     *gpu_data, target_host_space, stream);
+
+// Convert using a caller-owned target reservation
+auto reserved_host_data = registry.convert<host_data_representation>(
+    *gpu_data, target_reservation, stream);
 ```
 
 The registry is thread-safe (all operations guarded by `std::mutex`).

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -347,6 +347,9 @@ class read_only_data_batch {
    * @param new_batch_id       Batch ID for the cloned batch.
    * @param target_memory_space Target memory space for the converted data.
    * @param stream              CUDA stream for memory operations.
+   * @param reservation         Optional caller-owned reservation on the target space; threaded into
+   *                            the converter so the target allocation draws from it.
+   * @param probe               Optional probe for the cloned batch.
    * @return A new data_batch wrapped in shared_ptr.
    */
   template <typename TargetRepresentation>
@@ -355,6 +358,7 @@ class read_only_data_batch {
     uint64_t new_batch_id,
     const memory::memory_space* target_memory_space,
     rmm::cuda_stream_view stream,
+    memory::reservation* reservation         = nullptr,
     std::unique_ptr<idata_batch_probe> probe = std::make_unique<idata_batch_probe>()) const;
 
   // -- Move support --
@@ -429,11 +433,15 @@ class mutable_data_batch {
    * @param registry           Converter registry for type-keyed dispatch.
    * @param target_memory_space Target memory space for the new representation.
    * @param stream              CUDA stream for memory operations.
+   * @param reservation         Optional caller-owned reservation on the target space; threaded into
+   *                            the converter so the target allocation draws from it instead of
+   *                            committing fresh capacity (avoids double-counting on the HOST tier).
    */
   template <typename TargetRepresentation>
   void convert_to(representation_converter_registry& registry,
                   const memory::memory_space* target_memory_space,
-                  rmm::cuda_stream_view stream);
+                  rmm::cuda_stream_view stream,
+                  memory::reservation* reservation = nullptr);
 
   /**
    * @brief Rebind the held data's device buffers to use @p stream for future deallocation.
@@ -482,6 +490,9 @@ class mutable_data_batch {
    * @param new_batch_id       Batch ID for the cloned batch.
    * @param target_memory_space Target memory space for the converted data.
    * @param stream              CUDA stream for memory operations.
+   * @param reservation         Optional caller-owned reservation on the target space; threaded into
+   *                            the converter so the target allocation draws from it.
+   * @param probe               Optional probe for the cloned batch.
    * @return A new data_batch wrapped in shared_ptr.
    */
   template <typename TargetRepresentation>
@@ -490,6 +501,7 @@ class mutable_data_batch {
     uint64_t new_batch_id,
     const memory::memory_space* target_memory_space,
     rmm::cuda_stream_view stream,
+    memory::reservation* reservation         = nullptr,
     std::unique_ptr<idata_batch_probe> probe = std::make_unique<idata_batch_probe>()) const;
 
   // -- Move-only --
@@ -561,10 +573,11 @@ std::shared_ptr<data_batch> read_only_data_batch::clone_to(
   uint64_t new_batch_id,
   const memory::memory_space* target_memory_space,
   rmm::cuda_stream_view stream,
+  memory::reservation* reservation,
   std::unique_ptr<idata_batch_probe> probe) const
 {
-  auto new_representation =
-    registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
+  auto new_representation = registry.convert<TargetRepresentation>(
+    *_batch->_data, target_memory_space, stream, reservation);
   return data_batch::make(new_batch_id, std::move(new_representation), std::move(probe));
 }
 
@@ -573,7 +586,8 @@ std::shared_ptr<data_batch> read_only_data_batch::clone_to(
 template <typename TargetRepresentation>
 void mutable_data_batch::convert_to(representation_converter_registry& registry,
                                     const memory::memory_space* target_memory_space,
-                                    rmm::cuda_stream_view stream)
+                                    rmm::cuda_stream_view stream,
+                                    memory::reservation* reservation)
 {
   _batch->_probe->conversion_started(*(_batch->_data), target_memory_space);
   bool conversion_succeeded = false;
@@ -592,8 +606,8 @@ void mutable_data_batch::convert_to(representation_converter_registry& registry,
     .success = conversion_succeeded,
   };
 
-  auto new_representation =
-    registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
+  auto new_representation = registry.convert<TargetRepresentation>(
+    *_batch->_data, target_memory_space, stream, reservation);
   auto old_representation = std::move(_batch->_data);
   _batch->_data           = std::move(new_representation);
 
@@ -617,10 +631,11 @@ std::shared_ptr<data_batch> mutable_data_batch::clone_to(
   uint64_t new_batch_id,
   const memory::memory_space* target_memory_space,
   rmm::cuda_stream_view stream,
+  memory::reservation* reservation,
   std::unique_ptr<idata_batch_probe> probe) const
 {
-  auto new_representation =
-    registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
+  auto new_representation = registry.convert<TargetRepresentation>(
+    *_batch->_data, target_memory_space, stream, reservation);
   return data_batch::make(new_batch_id, std::move(new_representation), std::move(probe));
 }
 

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -347,8 +347,6 @@ class read_only_data_batch {
    * @param new_batch_id       Batch ID for the cloned batch.
    * @param target_memory_space Target memory space for the converted data.
    * @param stream              CUDA stream for memory operations.
-   * @param reservation         Optional caller-owned reservation on the target space; threaded into
-   *                            the converter so the target allocation draws from it.
    * @param probe               Optional probe for the cloned batch.
    * @return A new data_batch wrapped in shared_ptr.
    */
@@ -358,7 +356,28 @@ class read_only_data_batch {
     uint64_t new_batch_id,
     const memory::memory_space* target_memory_space,
     rmm::cuda_stream_view stream,
-    memory::reservation* reservation         = nullptr,
+    std::unique_ptr<idata_batch_probe> probe = std::make_unique<idata_batch_probe>()) const;
+
+  /**
+   * @brief Deep copy + conversion, drawing the target allocation from a reservation.
+   *
+   * Like the memory_space overload, but the target space is derived from @p reservation and the
+   * allocation draws down that reservation instead of committing fresh capacity.
+   *
+   * @tparam TargetRepresentation Target representation type.
+   * @param registry     Converter registry for type-keyed dispatch.
+   * @param new_batch_id Batch ID for the cloned batch.
+   * @param reservation  Caller-owned reservation on the target memory space.
+   * @param stream       CUDA stream for memory operations.
+   * @param probe        Optional probe for the cloned batch.
+   * @return A new data_batch wrapped in shared_ptr.
+   */
+  template <typename TargetRepresentation>
+  [[nodiscard]] std::shared_ptr<data_batch> clone_to(
+    representation_converter_registry& registry,
+    uint64_t new_batch_id,
+    memory::reservation& reservation,
+    rmm::cuda_stream_view stream,
     std::unique_ptr<idata_batch_probe> probe = std::make_unique<idata_batch_probe>()) const;
 
   // -- Move support --
@@ -433,15 +452,30 @@ class mutable_data_batch {
    * @param registry           Converter registry for type-keyed dispatch.
    * @param target_memory_space Target memory space for the new representation.
    * @param stream              CUDA stream for memory operations.
-   * @param reservation         Optional caller-owned reservation on the target space; threaded into
-   *                            the converter so the target allocation draws from it instead of
-   *                            committing fresh capacity (avoids double-counting on the HOST tier).
    */
   template <typename TargetRepresentation>
   void convert_to(representation_converter_registry& registry,
                   const memory::memory_space* target_memory_space,
-                  rmm::cuda_stream_view stream,
-                  memory::reservation* reservation = nullptr);
+                  rmm::cuda_stream_view stream);
+
+  /**
+   * @brief Convert the data representation in-place, drawing the target allocation from a
+   * reservation.
+   *
+   * Like the memory_space overload, but the target space is derived from @p reservation and the
+   * allocation draws down that reservation instead of committing fresh capacity (avoids
+   * double-counting on the HOST tier). If the conversion involves the GPU tier, synchronizes the
+   * stream before the old representation is destroyed to prevent use-after-free.
+   *
+   * @tparam TargetRepresentation Target representation type.
+   * @param registry    Converter registry for type-keyed dispatch.
+   * @param reservation Caller-owned reservation on the target memory space.
+   * @param stream      CUDA stream for memory operations.
+   */
+  template <typename TargetRepresentation>
+  void convert_to(representation_converter_registry& registry,
+                  memory::reservation& reservation,
+                  rmm::cuda_stream_view stream);
 
   /**
    * @brief Rebind the held data's device buffers to use @p stream for future deallocation.
@@ -490,8 +524,6 @@ class mutable_data_batch {
    * @param new_batch_id       Batch ID for the cloned batch.
    * @param target_memory_space Target memory space for the converted data.
    * @param stream              CUDA stream for memory operations.
-   * @param reservation         Optional caller-owned reservation on the target space; threaded into
-   *                            the converter so the target allocation draws from it.
    * @param probe               Optional probe for the cloned batch.
    * @return A new data_batch wrapped in shared_ptr.
    */
@@ -501,7 +533,28 @@ class mutable_data_batch {
     uint64_t new_batch_id,
     const memory::memory_space* target_memory_space,
     rmm::cuda_stream_view stream,
-    memory::reservation* reservation         = nullptr,
+    std::unique_ptr<idata_batch_probe> probe = std::make_unique<idata_batch_probe>()) const;
+
+  /**
+   * @brief Deep copy + conversion, drawing the target allocation from a reservation.
+   *
+   * Like the memory_space overload, but the target space is derived from @p reservation and the
+   * allocation draws down that reservation instead of committing fresh capacity.
+   *
+   * @tparam TargetRepresentation Target representation type.
+   * @param registry     Converter registry for type-keyed dispatch.
+   * @param new_batch_id Batch ID for the cloned batch.
+   * @param reservation  Caller-owned reservation on the target memory space.
+   * @param stream       CUDA stream for memory operations.
+   * @param probe        Optional probe for the cloned batch.
+   * @return A new data_batch wrapped in shared_ptr.
+   */
+  template <typename TargetRepresentation>
+  [[nodiscard]] std::shared_ptr<data_batch> clone_to(
+    representation_converter_registry& registry,
+    uint64_t new_batch_id,
+    memory::reservation& reservation,
+    rmm::cuda_stream_view stream,
     std::unique_ptr<idata_batch_probe> probe = std::make_unique<idata_batch_probe>()) const;
 
   // -- Move-only --
@@ -521,6 +574,26 @@ class mutable_data_batch {
    * @param lock   Exclusive lock already acquired on the parent's mutex.
    */
   mutable_data_batch(std::shared_ptr<data_batch> parent, std::unique_lock<std::shared_mutex> lock);
+
+  /**
+   * @brief Swap in a freshly converted representation, synchronizing @p stream first when the
+   * conversion touched the GPU tier.
+   *
+   * Shared tail of both convert_to overloads. A GPU conversion may still have async work on
+   * @p stream reading the old representation's buffers; synchronize before the old representation
+   * is destroyed to avoid use-after-free.
+   */
+  void install_converted_representation(std::unique_ptr<idata_representation> new_representation,
+                                        rmm::cuda_stream_view stream)
+  {
+    auto old_representation = std::move(_batch->_data);
+    _batch->_data           = std::move(new_representation);
+
+    bool needs_sync = old_representation != nullptr &&
+                      (old_representation->get_current_tier() == memory::Tier::GPU ||
+                       _batch->_data->get_current_tier() == memory::Tier::GPU);
+    if (needs_sync) { stream.synchronize(); }
+  }
 
   // INVARIANT: _batch must be declared before _lock -- destruction order is load-bearing.
   // When destroyed, _lock releases the exclusive lock first, then _batch drops the parent
@@ -573,11 +646,23 @@ std::shared_ptr<data_batch> read_only_data_batch::clone_to(
   uint64_t new_batch_id,
   const memory::memory_space* target_memory_space,
   rmm::cuda_stream_view stream,
-  memory::reservation* reservation,
   std::unique_ptr<idata_batch_probe> probe) const
 {
-  auto new_representation = registry.convert<TargetRepresentation>(
-    *_batch->_data, target_memory_space, stream, reservation);
+  auto new_representation =
+    registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
+  return data_batch::make(new_batch_id, std::move(new_representation), std::move(probe));
+}
+
+template <typename TargetRepresentation>
+std::shared_ptr<data_batch> read_only_data_batch::clone_to(
+  representation_converter_registry& registry,
+  uint64_t new_batch_id,
+  memory::reservation& reservation,
+  rmm::cuda_stream_view stream,
+  std::unique_ptr<idata_batch_probe> probe) const
+{
+  auto new_representation =
+    registry.convert<TargetRepresentation>(*_batch->_data, reservation, stream);
   return data_batch::make(new_batch_id, std::move(new_representation), std::move(probe));
 }
 
@@ -586,8 +671,7 @@ std::shared_ptr<data_batch> read_only_data_batch::clone_to(
 template <typename TargetRepresentation>
 void mutable_data_batch::convert_to(representation_converter_registry& registry,
                                     const memory::memory_space* target_memory_space,
-                                    rmm::cuda_stream_view stream,
-                                    memory::reservation* reservation)
+                                    rmm::cuda_stream_view stream)
 {
   _batch->_probe->conversion_started(*(_batch->_data), target_memory_space);
   bool conversion_succeeded = false;
@@ -606,22 +690,35 @@ void mutable_data_batch::convert_to(representation_converter_registry& registry,
     .success = conversion_succeeded,
   };
 
-  auto new_representation = registry.convert<TargetRepresentation>(
-    *_batch->_data, target_memory_space, stream, reservation);
-  auto old_representation = std::move(_batch->_data);
-  _batch->_data           = std::move(new_representation);
+  install_converted_representation(
+    registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream), stream);
+  conversion_succeeded = true;  // ref used by on_scope_exit helper.
+}
 
-  bool needs_sync =
-    old_representation != nullptr && (old_representation->get_current_tier() == memory::Tier::GPU ||
-                                      _batch->_data->get_current_tier() == memory::Tier::GPU);
+template <typename TargetRepresentation>
+void mutable_data_batch::convert_to(representation_converter_registry& registry,
+                                    memory::reservation& reservation,
+                                    rmm::cuda_stream_view stream)
+{
+  _batch->_probe->conversion_started(*(_batch->_data), &reservation.get_memory_space());
+  bool conversion_succeeded = false;
+  // small helper that gets called when this scope is exited (including during exceptions)
+  struct OnScopeExit {
+    const std::unique_ptr<idata_batch_probe>& probe;
+    // a ref to the unique ptr so when data is updated,
+    // that new data is supplied with the notification.
+    const std::unique_ptr<idata_representation>& data;
+    const bool& success;
 
-  if (needs_sync) {
-    // Conversions involving GPU may enqueue async operations on the provided
-    // stream that read from the source memory.  Synchronize before the old
-    // representation is destroyed to avoid use-after-free.
-    stream.synchronize();
-  }
+    ~OnScopeExit() { probe->conversion_completed(*data, success); }
+  } on_scope_exit{
+    .probe   = _batch->_probe,
+    .data    = _batch->_data,
+    .success = conversion_succeeded,
+  };
 
+  install_converted_representation(
+    registry.convert<TargetRepresentation>(*_batch->_data, reservation, stream), stream);
   conversion_succeeded = true;  // ref used by on_scope_exit helper.
 }
 
@@ -631,11 +728,23 @@ std::shared_ptr<data_batch> mutable_data_batch::clone_to(
   uint64_t new_batch_id,
   const memory::memory_space* target_memory_space,
   rmm::cuda_stream_view stream,
-  memory::reservation* reservation,
   std::unique_ptr<idata_batch_probe> probe) const
 {
-  auto new_representation = registry.convert<TargetRepresentation>(
-    *_batch->_data, target_memory_space, stream, reservation);
+  auto new_representation =
+    registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
+  return data_batch::make(new_batch_id, std::move(new_representation), std::move(probe));
+}
+
+template <typename TargetRepresentation>
+std::shared_ptr<data_batch> mutable_data_batch::clone_to(
+  representation_converter_registry& registry,
+  uint64_t new_batch_id,
+  memory::reservation& reservation,
+  rmm::cuda_stream_view stream,
+  std::unique_ptr<idata_batch_probe> probe) const
+{
+  auto new_representation =
+    registry.convert<TargetRepresentation>(*_batch->_data, reservation, stream);
   return data_batch::make(new_batch_id, std::move(new_representation), std::move(probe));
 }
 

--- a/include/cucascade/data/representation_converter.hpp
+++ b/include/cucascade/data/representation_converter.hpp
@@ -42,12 +42,20 @@ namespace cucascade {
  * @param source The source data representation to convert from
  * @param target_memory_space The memory space where the target representation will be allocated
  * @param stream CUDA stream for asynchronous memory operations
+ * @param reservation Optional caller-owned reservation on the target memory space. When non-null,
+ *        the converter draws its target allocation down from this reservation instead of committing
+ *        fresh capacity, preventing double-counting against the target pool. May be nullptr.
  * @return A new idata_representation of the registered target type (always unique_ptr)
+ *
+ * @note Because std::function cannot carry default arguments, every registered converter must
+ *       accept this parameter. Converters whose target tier does not honor reservations (GPU/DISK)
+ *       ignore it.
  */
 using representation_converter_fn = std::function<std::unique_ptr<idata_representation>(
   idata_representation& source,
   const memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view stream)>;
+  rmm::cuda_stream_view stream,
+  memory::reservation* reservation)>;
 
 /**
  * @brief Key for looking up converters in the registry.
@@ -118,7 +126,8 @@ class representation_converter_registry {
    * registry.register_converter<SourceType, TargetType>(
    *   [](idata_representation& source,
    *      const memory::memory_space* target_memory_space,
-   *      rmm::cuda_stream_view stream) -> std::unique_ptr<idata_representation> {
+   *      rmm::cuda_stream_view stream,
+   *      memory::reservation* reservation) -> std::unique_ptr<idata_representation> {
    *     auto& src = source.cast<SourceType>();
    *     // ... conversion logic ...
    *     return std::make_unique<TargetType>(...);
@@ -177,6 +186,8 @@ class representation_converter_registry {
    * @param source The source data representation
    * @param target_memory_space The target memory space for the new representation
    * @param stream CUDA stream for memory operations
+   * @param reservation Optional caller-owned reservation on the target space; threaded into the
+   *        converter so the target allocation draws from it instead of committing fresh capacity.
    * @return std::unique_ptr<TargetType> The converted representation
    * @throws std::runtime_error if no converter is registered for the type pair
    *
@@ -186,10 +197,11 @@ class representation_converter_registry {
   template <typename TargetType>
   std::unique_ptr<TargetType> convert(idata_representation& source,
                                       const memory::memory_space* target_memory_space,
-                                      rmm::cuda_stream_view stream = rmm::cuda_stream_default) const
+                                      rmm::cuda_stream_view stream     = rmm::cuda_stream_default,
+                                      memory::reservation* reservation = nullptr) const
   {
     converter_key key{std::type_index(typeid(source)), std::type_index(typeid(TargetType))};
-    auto result = convert_impl(key, source, target_memory_space, stream);
+    auto result = convert_impl(key, source, target_memory_space, stream, reservation);
     return std::unique_ptr<TargetType>(static_cast<TargetType*>(result.release()));
   }
 
@@ -202,6 +214,8 @@ class representation_converter_registry {
    * @param target_type The target representation type index
    * @param target_memory_space The target memory space for the new representation
    * @param stream CUDA stream for memory operations
+   * @param reservation Optional caller-owned reservation on the target space; threaded into the
+   *        converter so the target allocation draws from it instead of committing fresh capacity.
    * @return std::unique_ptr<idata_representation> The converted representation
    * @throws std::runtime_error if no converter is registered for the type pair
    */
@@ -209,7 +223,8 @@ class representation_converter_registry {
     idata_representation& source,
     std::type_index target_type,
     const memory::memory_space* target_memory_space,
-    rmm::cuda_stream_view stream = rmm::cuda_stream_default) const;
+    rmm::cuda_stream_view stream     = rmm::cuda_stream_default,
+    memory::reservation* reservation = nullptr) const;
 
   /**
    * @brief Unregister a converter for the given type pair.
@@ -239,7 +254,8 @@ class representation_converter_registry {
     const converter_key& key,
     idata_representation& source,
     const memory::memory_space* target_memory_space,
-    rmm::cuda_stream_view stream) const;
+    rmm::cuda_stream_view stream,
+    memory::reservation* reservation) const;
   bool unregister_converter_impl(const converter_key& key);
 
   mutable std::shared_mutex _mutex;

--- a/include/cucascade/data/representation_converter.hpp
+++ b/include/cucascade/data/representation_converter.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include <cucascade/data/common.hpp>
+#include <cucascade/memory/memory_reservation.hpp>
 #include <cucascade/memory/memory_space.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
@@ -186,8 +187,6 @@ class representation_converter_registry {
    * @param source The source data representation
    * @param target_memory_space The target memory space for the new representation
    * @param stream CUDA stream for memory operations
-   * @param reservation Optional caller-owned reservation on the target space; threaded into the
-   *        converter so the target allocation draws from it instead of committing fresh capacity.
    * @return std::unique_ptr<TargetType> The converted representation
    * @throws std::runtime_error if no converter is registered for the type pair
    *
@@ -197,11 +196,35 @@ class representation_converter_registry {
   template <typename TargetType>
   std::unique_ptr<TargetType> convert(idata_representation& source,
                                       const memory::memory_space* target_memory_space,
-                                      rmm::cuda_stream_view stream     = rmm::cuda_stream_default,
-                                      memory::reservation* reservation = nullptr) const
+                                      rmm::cuda_stream_view stream = rmm::cuda_stream_default) const
   {
     converter_key key{std::type_index(typeid(source)), std::type_index(typeid(TargetType))};
-    auto result = convert_impl(key, source, target_memory_space, stream, reservation);
+    auto result = convert_impl(key, source, target_memory_space, stream, nullptr);
+    return std::unique_ptr<TargetType>(static_cast<TargetType*>(result.release()));
+  }
+
+  /**
+   * @brief Convert a data representation, drawing the target allocation from a reservation.
+   *
+   * The target memory space is derived from the reservation (reservation::get_memory_space()) and
+   * the reservation is threaded into the converter so the target allocation draws down the
+   * reservation instead of committing fresh capacity. Use this overload whenever the caller has
+   * already reserved capacity on the target space (avoids double-counting on the HOST tier).
+   *
+   * @tparam TargetType The target representation type
+   * @param source The source data representation
+   * @param reservation Caller-owned reservation on the target memory space
+   * @param stream CUDA stream for memory operations
+   * @return std::unique_ptr<TargetType> The converted representation
+   * @throws std::runtime_error if no converter is registered for the type pair
+   */
+  template <typename TargetType>
+  std::unique_ptr<TargetType> convert(idata_representation& source,
+                                      memory::reservation& reservation,
+                                      rmm::cuda_stream_view stream = rmm::cuda_stream_default) const
+  {
+    converter_key key{std::type_index(typeid(source)), std::type_index(typeid(TargetType))};
+    auto result = convert_impl(key, source, &reservation.get_memory_space(), stream, &reservation);
     return std::unique_ptr<TargetType>(static_cast<TargetType*>(result.release()));
   }
 
@@ -214,17 +237,17 @@ class representation_converter_registry {
    * @param target_type The target representation type index
    * @param target_memory_space The target memory space for the new representation
    * @param stream CUDA stream for memory operations
-   * @param reservation Optional caller-owned reservation on the target space; threaded into the
-   *        converter so the target allocation draws from it instead of committing fresh capacity.
    * @return std::unique_ptr<idata_representation> The converted representation
    * @throws std::runtime_error if no converter is registered for the type pair
+   *
+   * @note This runtime-typed overload always allocates without a reservation. Callers that hold a
+   *       reservation should use the templated convert<TargetType>(source, reservation, stream).
    */
   std::unique_ptr<idata_representation> convert(
     idata_representation& source,
     std::type_index target_type,
     const memory::memory_space* target_memory_space,
-    rmm::cuda_stream_view stream     = rmm::cuda_stream_default,
-    memory::reservation* reservation = nullptr) const;
+    rmm::cuda_stream_view stream = rmm::cuda_stream_default) const;
 
   /**
    * @brief Unregister a converter for the given type pair.

--- a/src/cudf/representation_converter_builtins.cpp
+++ b/src/cudf/representation_converter_builtins.cpp
@@ -89,7 +89,8 @@ inline cudf::type_id as_cudf_type_id(int32_t type_id)
 std::unique_ptr<idata_representation> convert_gpu_to_gpu(
   idata_representation& source,
   const memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view stream);
+  rmm::cuda_stream_view stream,
+  [[maybe_unused]] memory::reservation* reservation);
 
 /**
  * @brief Convert gpu_table_representation to host_data_packed_representation
@@ -97,7 +98,8 @@ std::unique_ptr<idata_representation> convert_gpu_to_gpu(
 std::unique_ptr<idata_representation> convert_gpu_to_host(
   idata_representation& source,
   const memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view stream)
+  rmm::cuda_stream_view stream,
+  memory::reservation* reservation)
 {
   // Synchronize the stream to ensure any prior operations (like table creation)
   // are complete before we read from the source table
@@ -107,7 +109,7 @@ std::unique_ptr<idata_representation> convert_gpu_to_host(
   auto packed_data = cudf::pack(gpu_source.get_table_view(), stream);
 
   auto mr = target_memory_space->get_memory_resource_as<memory::fixed_size_host_memory_resource>();
-  auto allocation = mr->allocate_multiple_blocks(packed_data.gpu_data->size());
+  auto allocation = mr->allocate_multiple_blocks(packed_data.gpu_data->size(), reservation);
 
   size_t block_index      = 0;
   size_t block_offset     = 0;
@@ -144,7 +146,8 @@ std::unique_ptr<idata_representation> convert_gpu_to_host(
 std::unique_ptr<idata_representation> convert_host_to_gpu(
   idata_representation& source,
   const memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view stream)
+  rmm::cuda_stream_view stream,
+  [[maybe_unused]] memory::reservation* reservation)
 {
   auto& host_source    = source.cast<host_data_packed_representation>();
   auto& host_table     = host_source.get_host_table();
@@ -199,7 +202,8 @@ std::unique_ptr<idata_representation> convert_host_to_gpu(
 std::unique_ptr<idata_representation> convert_host_to_host(
   idata_representation& source,
   const memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view /*stream*/)
+  rmm::cuda_stream_view /*stream*/,
+  memory::reservation* reservation)
 {
   auto& host_source    = source.cast<host_data_packed_representation>();
   auto& host_table     = host_source.get_host_table();
@@ -211,7 +215,7 @@ std::unique_ptr<idata_representation> convert_host_to_host(
     throw std::runtime_error(
       "Target HOST memory_space does not have a fixed_size_host_memory_resource");
   }
-  auto dst_allocation         = mr->allocate_multiple_blocks(data_size);
+  auto dst_allocation         = mr->allocate_multiple_blocks(data_size, reservation);
   size_t src_block_index      = 0;
   size_t src_block_offset     = 0;
   size_t dst_block_index      = 0;
@@ -490,7 +494,8 @@ static void collect_column_d2h_ops(
 std::unique_ptr<idata_representation> convert_gpu_to_host_fast(
   idata_representation& source,
   const memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view stream)
+  rmm::cuda_stream_view stream,
+  memory::reservation* reservation)
 {
   auto& gpu_source            = source.cast<gpu_table_representation>();
   const cudf::table_view view = gpu_source.get_table_view();
@@ -506,7 +511,7 @@ std::unique_ptr<idata_representation> convert_gpu_to_host_fast(
 
   // --- Pass 2: allocate pinned host blocks ---
   auto mr = target_memory_space->get_memory_resource_as<memory::fixed_size_host_memory_resource>();
-  auto allocation = mr->allocate_multiple_blocks(total_size);
+  auto allocation = mr->allocate_multiple_blocks(total_size, reservation);
 
   // --- Pass 3: collect all D→H copy ops, then fire one batched call ---
   BatchCopyAccumulator batch;
@@ -858,7 +863,8 @@ static std::unique_ptr<cudf::column> reconstruct_column_p2p(const cudf::column_v
 std::unique_ptr<idata_representation> convert_gpu_to_gpu(
   idata_representation& source,
   const memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view stream)
+  rmm::cuda_stream_view stream,
+  [[maybe_unused]] memory::reservation* reservation)
 {
   // Sync the caller's stream so the source table's buffers are stable on the source
   // device before we issue peer copies. The caller's stream is the one that produced
@@ -1158,7 +1164,8 @@ static std::unique_ptr<cudf::column> reconstruct_column(
 std::unique_ptr<idata_representation> convert_host_fast_to_gpu(
   idata_representation& source,
   const memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view stream)
+  rmm::cuda_stream_view stream,
+  [[maybe_unused]] memory::reservation* reservation)
 {
   auto& fast_source      = source.cast<host_data_representation>();
   const auto& fast_table = fast_source.get_host_table();
@@ -1208,7 +1215,8 @@ std::unique_ptr<idata_representation> convert_host_fast_to_gpu(
 std::unique_ptr<idata_representation> convert_host_fast_to_host_fast(
   idata_representation& source,
   const memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view /*stream*/)
+  rmm::cuda_stream_view /*stream*/,
+  memory::reservation* reservation)
 {
   auto& host_source    = source.cast<host_data_representation>();
   auto& host_table     = host_source.get_host_table();
@@ -1220,7 +1228,7 @@ std::unique_ptr<idata_representation> convert_host_fast_to_host_fast(
     throw std::runtime_error(
       "Target HOST memory_space does not have a fixed_size_host_memory_resource");
   }
-  auto dst_allocation         = mr->allocate_multiple_blocks(data_size);
+  auto dst_allocation         = mr->allocate_multiple_blocks(data_size, reservation);
   size_t src_block_index      = 0;
   size_t src_block_offset     = 0;
   size_t dst_block_index      = 0;
@@ -1483,7 +1491,8 @@ static void read_column_buffers(
 static std::unique_ptr<idata_representation> convert_host_data_to_disk(
   idata_representation& source,
   const memory::memory_space* target_memory_space,
-  [[maybe_unused]] rmm::cuda_stream_view stream)
+  [[maybe_unused]] rmm::cuda_stream_view stream,
+  [[maybe_unused]] memory::reservation* reservation)
 {
   auto& backend          = target_memory_space->get_io_backend();
   auto& host_source      = source.cast<host_data_representation>();
@@ -1528,7 +1537,8 @@ static std::unique_ptr<idata_representation> convert_host_data_to_disk(
 static std::unique_ptr<idata_representation> convert_disk_to_host_data(
   idata_representation& source,
   const memory::memory_space* target_memory_space,
-  [[maybe_unused]] rmm::cuda_stream_view stream)
+  [[maybe_unused]] rmm::cuda_stream_view stream,
+  memory::reservation* reservation)
 {
   auto& backend          = source.get_memory_space().get_io_backend();
   auto& disk_source      = source.cast<disk_data_representation>();
@@ -1553,7 +1563,7 @@ static std::unique_ptr<idata_representation> convert_disk_to_host_data(
     throw std::runtime_error(
       "Target HOST memory_space does not have a fixed_size_host_memory_resource");
   }
-  auto allocation = mr->allocate_multiple_blocks(total_host_size);
+  auto allocation = mr->allocate_multiple_blocks(total_host_size, reservation);
 
   // Read column data from file into host blocks
   for (std::size_t i = 0; i < disk_columns.size(); ++i) {
@@ -1601,7 +1611,8 @@ static void collect_gpu_column_io_entries(const cudf::column_view& col,
 static std::unique_ptr<idata_representation> convert_gpu_to_disk(
   idata_representation& source,
   const memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view stream)
+  rmm::cuda_stream_view stream,
+  [[maybe_unused]] memory::reservation* reservation)
 {
   auto& backend       = target_memory_space->get_io_backend();
   auto& gpu_source    = source.cast<gpu_table_representation>();
@@ -1786,7 +1797,8 @@ static std::unique_ptr<cudf::column> reconstruct_column_from_disk(
 static std::unique_ptr<idata_representation> convert_disk_to_gpu(
   idata_representation& source,
   const memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view stream)
+  rmm::cuda_stream_view stream,
+  [[maybe_unused]] memory::reservation* reservation)
 {
   auto& backend          = source.get_memory_space().get_io_backend();
   auto& disk_source      = source.cast<disk_data_representation>();

--- a/src/data/representation_converter.cpp
+++ b/src/data/representation_converter.cpp
@@ -58,7 +58,8 @@ std::unique_ptr<idata_representation> representation_converter_registry::convert
   const converter_key& key,
   idata_representation& source,
   const memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view stream) const
+  rmm::cuda_stream_view stream,
+  memory::reservation* reservation) const
 {
   representation_converter_fn converter;
   {
@@ -75,17 +76,18 @@ std::unique_ptr<idata_representation> representation_converter_registry::convert
     converter = it->second;
   }
 
-  return converter(source, target_memory_space, stream);
+  return converter(source, target_memory_space, stream, reservation);
 }
 
 std::unique_ptr<idata_representation> representation_converter_registry::convert(
   idata_representation& source,
   std::type_index target_type,
   const memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view stream) const
+  rmm::cuda_stream_view stream,
+  memory::reservation* reservation) const
 {
   converter_key key{std::type_index(typeid(source)), target_type};
-  return convert_impl(key, source, target_memory_space, stream);
+  return convert_impl(key, source, target_memory_space, stream, reservation);
 }
 
 bool representation_converter_registry::unregister_converter_impl(const converter_key& key)

--- a/src/data/representation_converter.cpp
+++ b/src/data/representation_converter.cpp
@@ -83,11 +83,10 @@ std::unique_ptr<idata_representation> representation_converter_registry::convert
   idata_representation& source,
   std::type_index target_type,
   const memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view stream,
-  memory::reservation* reservation) const
+  rmm::cuda_stream_view stream) const
 {
   converter_key key{std::type_index(typeid(source)), target_type};
-  return convert_impl(key, source, target_memory_space, stream, reservation);
+  return convert_impl(key, source, target_memory_space, stream, nullptr);
 }
 
 bool representation_converter_registry::unregister_converter_impl(const converter_key& key)

--- a/test/data/test_data_batch.cpp
+++ b/test/data/test_data_batch.cpp
@@ -890,7 +890,8 @@ TEST_CASE("convert_to synchronizes stream before destroying GPU source", "[data_
   registry.register_converter<observed_gpu_representation, mock_data_representation>(
     [&](idata_representation& source,
         const memory::memory_space* /*target_space*/,
-        rmm::cuda_stream_view s) -> std::unique_ptr<idata_representation> {
+        rmm::cuda_stream_view s,
+        memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
       auto& gpu_src = source.cast<observed_gpu_representation>();
       CUCASCADE_CUDA_TRY(
         cudaMemcpyAsync(pinned_host, gpu_src.data(), buf_size, cudaMemcpyDeviceToHost, s.value()));
@@ -986,7 +987,8 @@ TEST_CASE("convert_to synchronizes stream before destroying HOST source when tar
   registry.register_converter<observed_host_representation, mock_data_representation>(
     [&](idata_representation& source,
         const memory::memory_space* /*target_space*/,
-        rmm::cuda_stream_view s) -> std::unique_ptr<idata_representation> {
+        rmm::cuda_stream_view s,
+        memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
       auto& host_src = source.cast<observed_host_representation>();
       rmm::device_buffer gpu_buf(buf_size, s);
       CUCASCADE_CUDA_TRY(cudaMemcpyAsync(
@@ -1044,7 +1046,8 @@ TEST_CASE("mutable_data_batch holds exclusive lock during convert_to stream sync
   registry.register_converter<observed_gpu_representation, mock_data_representation>(
     [&](idata_representation& source,
         const memory::memory_space* /*target_space*/,
-        rmm::cuda_stream_view s) -> std::unique_ptr<idata_representation> {
+        rmm::cuda_stream_view s,
+        memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
       auto& gpu_src = source.cast<observed_gpu_representation>();
       CUCASCADE_CUDA_TRY(
         cudaMemcpyAsync(pinned_host, gpu_src.data(), buf_size, cudaMemcpyDeviceToHost, s.value()));

--- a/test/data/test_data_representation.cpp
+++ b/test/data/test_data_representation.cpp
@@ -467,11 +467,11 @@ TEST_CASE("HOST converter draws from caller reservation (no double-count)",
   const std::size_t committed_after_reserve = host_mr->get_total_allocated_bytes();
   REQUIRE(committed_after_reserve - committed_before >= alloc_size);
 
-  // Convert GPU -> HOST, threading the caller's reservation through the converter
-  // API. This must NOT throw rmm::out_of_memory and must NOT commit a second N.
+  // Convert GPU -> HOST via the reservation overload, so the target space is derived from the
+  // reservation and the allocation draws it down. This must NOT throw rmm::out_of_memory and
+  // must NOT commit a second N.
   std::unique_ptr<host_data_representation> host_rep;
-  REQUIRE_NOTHROW(host_rep = registry.convert<host_data_representation>(
-                    repr, host_space, stream.view(), res.get()));
+  REQUIRE_NOTHROW(host_rep = registry.convert<host_data_representation>(repr, *res, stream.view()));
   stream.synchronize();
   REQUIRE(host_rep != nullptr);
 

--- a/test/data/test_data_representation.cpp
+++ b/test/data/test_data_representation.cpp
@@ -37,6 +37,7 @@
 #include <cudf/types.hpp>
 #include <cudf/utilities/type_dispatcher.hpp>
 
+#include <rmm/aligned.hpp>
 #include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/device_buffer.hpp>
@@ -412,6 +413,78 @@ TEST_CASE("gpu->host_fast->gpu roundtrip preserves contents (table_view+shared_p
   REQUIRE(back->get_table_view().num_rows() == N);
   cucascade::test::expect_cudf_tables_equal_on_stream(
     repr.get_table_view(), back->get_table_view(), stream.view());
+}
+
+TEST_CASE("HOST converter draws from caller reservation (no double-count)",
+          "[cpu_data_representation][gpu_data_representation][reservation]")
+{
+  memory::memory_reservation_manager mgr(create_conversion_test_configs());
+  representation_converter_registry registry;
+  register_builtin_converters(registry);
+
+  const memory::memory_space* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
+  const memory::memory_space* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
+
+  auto* host_mr = host_space->get_memory_resource_as<memory::fixed_size_host_memory_resource>();
+  REQUIRE(host_mr != nullptr);
+
+  // Build a GPU table large enough that a double-count would be unmistakable.
+  rmm::cuda_stream stream;
+  constexpr cudf::size_type num_rows = 1 << 20;  // ~4 MiB of INT32 payload
+  auto col = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                       num_rows,
+                                       cudf::mask_state::UNALLOCATED,
+                                       stream.view(),
+                                       gpu_space->get_default_allocator());
+  CUCASCADE_CUDA_TRY(
+    cudaMemsetAsync(col->mutable_view().head(), 0xAB, num_rows * sizeof(int32_t), stream.value()));
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(col));
+  auto shared_table = std::make_shared<cudf::table>(std::move(cols));
+  auto view         = shared_table->view();
+  auto alloc_size   = shared_table->alloc_size();
+  gpu_table_representation repr(view,
+                                std::move(shared_table),
+                                alloc_size,
+                                *const_cast<memory::memory_space*>(gpu_space),
+                                rmm::cuda_stream_view{});
+  stream.synchronize();
+
+  // The converter rounds the host allocation up to the block size, so reserve that
+  // much plus one block of headroom to guarantee the conversion fits entirely inside
+  // the reservation (the upstream_tracked_bytes == 0 branch) even if its planned
+  // layout size differs from cudf's alloc_size by alignment padding.
+  const std::size_t block_size    = host_mr->get_block_size();
+  const std::size_t reserve_bytes = rmm::align_up(alloc_size, block_size) + block_size;
+
+  const std::size_t committed_before = host_mr->get_total_allocated_bytes();
+
+  // Reserve N up front -- this commits ~N against the pool capacity counter.
+  std::unique_ptr<memory::reservation> res =
+    const_cast<memory::memory_space*>(host_space)->make_reservation_or_null(reserve_bytes);
+  REQUIRE(res != nullptr);
+
+  const std::size_t committed_after_reserve = host_mr->get_total_allocated_bytes();
+  REQUIRE(committed_after_reserve - committed_before >= alloc_size);
+
+  // Convert GPU -> HOST, threading the caller's reservation through the converter
+  // API. This must NOT throw rmm::out_of_memory and must NOT commit a second N.
+  std::unique_ptr<host_data_representation> host_rep;
+  REQUIRE_NOTHROW(host_rep = registry.convert<host_data_representation>(
+                    repr, host_space, stream.view(), res.get()));
+  stream.synchronize();
+  REQUIRE(host_rep != nullptr);
+
+  // Total committed bytes after the conversion must stay ~= the reservation (N),
+  // NOT ~2N. Allow only block-size rounding slack on top of the reservation.
+  const std::size_t committed_after_convert = host_mr->get_total_allocated_bytes();
+  const std::size_t reservation_commit      = committed_after_reserve - committed_before;
+  const std::size_t conversion_extra        = committed_after_convert - committed_after_reserve;
+
+  // The conversion fits inside the reservation, so it must add (essentially) nothing.
+  CHECK(conversion_extra <= block_size);
+  // Guard against the double-count: total committed must be far below 2N.
+  CHECK(committed_after_convert < committed_before + 2 * reservation_commit);
 }
 
 // =============================================================================

--- a/test/data/test_representation_converter.cpp
+++ b/test/data/test_representation_converter.cpp
@@ -102,7 +102,8 @@ TEST_CASE("representation_converter_registry register custom converter",
       registry.register_converter<custom_test_representation, another_test_representation>(
         [](idata_representation& source,
            const memory::memory_space* target_space,
-           rmm::cuda_stream_view /*stream*/) -> std::unique_ptr<idata_representation> {
+           rmm::cuda_stream_view /*stream*/,
+           memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
           auto& src = source.cast<custom_test_representation>();
           return std::make_unique<another_test_representation>(
             static_cast<double>(src.get_value()), *const_cast<memory::memory_space*>(target_space));
@@ -115,7 +116,8 @@ TEST_CASE("representation_converter_registry register custom converter",
     registry.register_converter<custom_test_representation, another_test_representation>(
       [](idata_representation& source,
          const memory::memory_space* target_space,
-         rmm::cuda_stream_view /*stream*/) -> std::unique_ptr<idata_representation> {
+         rmm::cuda_stream_view /*stream*/,
+         memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
         auto& src = source.cast<custom_test_representation>();
         return std::make_unique<another_test_representation>(
           static_cast<double>(src.get_value()), *const_cast<memory::memory_space*>(target_space));
@@ -127,7 +129,10 @@ TEST_CASE("representation_converter_registry register custom converter",
       registry.register_converter<custom_test_representation, another_test_representation>(
         [](idata_representation&,
            const memory::memory_space*,
-           rmm::cuda_stream_view) -> std::unique_ptr<idata_representation> { return nullptr; });
+           rmm::cuda_stream_view,
+           memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
+          return nullptr;
+        });
     };
     REQUIRE_THROWS_AS(duplicate_register(), std::runtime_error);
   }
@@ -149,7 +154,8 @@ TEST_CASE("representation_converter_registry has_converter", "[representation_co
     registry.register_converter<custom_test_representation, another_test_representation>(
       [](idata_representation& source,
          const memory::memory_space* target_space,
-         rmm::cuda_stream_view /*stream*/) -> std::unique_ptr<idata_representation> {
+         rmm::cuda_stream_view /*stream*/,
+         memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
         auto& src = source.cast<custom_test_representation>();
         return std::make_unique<another_test_representation>(
           static_cast<double>(src.get_value()), *const_cast<memory::memory_space*>(target_space));
@@ -163,7 +169,8 @@ TEST_CASE("representation_converter_registry has_converter", "[representation_co
     registry.register_converter<custom_test_representation, another_test_representation>(
       [](idata_representation& source,
          const memory::memory_space* target_space,
-         rmm::cuda_stream_view /*stream*/) -> std::unique_ptr<idata_representation> {
+         rmm::cuda_stream_view /*stream*/,
+         memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
         auto& src = source.cast<custom_test_representation>();
         return std::make_unique<another_test_representation>(
           static_cast<double>(src.get_value()), *const_cast<memory::memory_space*>(target_space));
@@ -186,7 +193,8 @@ TEST_CASE("representation_converter_registry has_converter_for runtime lookup",
   registry.register_converter<custom_test_representation, another_test_representation>(
     [](idata_representation& source,
        const memory::memory_space* target_space,
-       rmm::cuda_stream_view /*stream*/) -> std::unique_ptr<idata_representation> {
+       rmm::cuda_stream_view /*stream*/,
+       memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
       auto& src = source.cast<custom_test_representation>();
       return std::make_unique<another_test_representation>(
         static_cast<double>(src.get_value()), *const_cast<memory::memory_space*>(target_space));
@@ -221,7 +229,8 @@ TEST_CASE("representation_converter_registry unregister_converter", "[representa
     registry.register_converter<custom_test_representation, another_test_representation>(
       [](idata_representation& source,
          const memory::memory_space* target_space,
-         rmm::cuda_stream_view /*stream*/) -> std::unique_ptr<idata_representation> {
+         rmm::cuda_stream_view /*stream*/,
+         memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
         auto& src = source.cast<custom_test_representation>();
         return std::make_unique<another_test_representation>(
           static_cast<double>(src.get_value()), *const_cast<memory::memory_space*>(target_space));
@@ -239,7 +248,10 @@ TEST_CASE("representation_converter_registry unregister_converter", "[representa
     registry.register_converter<custom_test_representation, another_test_representation>(
       [](idata_representation&,
          const memory::memory_space*,
-         rmm::cuda_stream_view) -> std::unique_ptr<idata_representation> { return nullptr; });
+         rmm::cuda_stream_view,
+         memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
+        return nullptr;
+      });
 
     registry.unregister_converter<custom_test_representation, another_test_representation>();
 
@@ -248,7 +260,10 @@ TEST_CASE("representation_converter_registry unregister_converter", "[representa
       registry.register_converter<custom_test_representation, another_test_representation>(
         [](idata_representation&,
            const memory::memory_space*,
-           rmm::cuda_stream_view) -> std::unique_ptr<idata_representation> { return nullptr; }));
+           rmm::cuda_stream_view,
+           memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
+          return nullptr;
+        }));
   }
 }
 
@@ -272,7 +287,8 @@ TEST_CASE("representation_converter_registry convert with custom types",
   registry.register_converter<custom_test_representation, another_test_representation>(
     [](idata_representation& source,
        const memory::memory_space* target_space,
-       rmm::cuda_stream_view /*stream*/) -> std::unique_ptr<idata_representation> {
+       rmm::cuda_stream_view /*stream*/,
+       memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
       auto& src = source.cast<custom_test_representation>();
       return std::make_unique<another_test_representation>(
         static_cast<double>(src.get_value() * 2), *const_cast<memory::memory_space*>(target_space));
@@ -306,7 +322,8 @@ TEST_CASE("representation_converter_registry convert with type_index", "[represe
   registry.register_converter<custom_test_representation, another_test_representation>(
     [](idata_representation& source,
        const memory::memory_space* target_space,
-       rmm::cuda_stream_view /*stream*/) -> std::unique_ptr<idata_representation> {
+       rmm::cuda_stream_view /*stream*/,
+       memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
       auto& src = source.cast<custom_test_representation>();
       return std::make_unique<another_test_representation>(
         static_cast<double>(src.get_value()), *const_cast<memory::memory_space*>(target_space));
@@ -472,7 +489,8 @@ TEST_CASE("Converter preserves memory space properties", "[representation_conver
   registry.register_converter<custom_test_representation, another_test_representation>(
     [](idata_representation& source,
        const memory::memory_space* target_space,
-       rmm::cuda_stream_view /*stream*/) -> std::unique_ptr<idata_representation> {
+       rmm::cuda_stream_view /*stream*/,
+       memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
       auto& src = source.cast<custom_test_representation>();
       return std::make_unique<another_test_representation>(
         static_cast<double>(src.get_value()), *const_cast<memory::memory_space*>(target_space));
@@ -496,7 +514,8 @@ TEST_CASE("Multiple independent converters can coexist", "[representation_conver
   registry.register_converter<custom_test_representation, another_test_representation>(
     [](idata_representation& source,
        const memory::memory_space* target_space,
-       rmm::cuda_stream_view /*stream*/) -> std::unique_ptr<idata_representation> {
+       rmm::cuda_stream_view /*stream*/,
+       memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
       auto& src = source.cast<custom_test_representation>();
       return std::make_unique<another_test_representation>(
         static_cast<double>(src.get_value()), *const_cast<memory::memory_space*>(target_space));
@@ -506,7 +525,8 @@ TEST_CASE("Multiple independent converters can coexist", "[representation_conver
   registry.register_converter<another_test_representation, custom_test_representation>(
     [](idata_representation& source,
        const memory::memory_space* target_space,
-       rmm::cuda_stream_view /*stream*/) -> std::unique_ptr<idata_representation> {
+       rmm::cuda_stream_view /*stream*/,
+       memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
       auto& src = source.cast<another_test_representation>();
       return std::make_unique<custom_test_representation>(
         static_cast<int>(src.get_value()), *const_cast<memory::memory_space*>(target_space));
@@ -554,13 +574,19 @@ TEST_CASE("Duplicate registration error message includes type names", "[represen
   registry.register_converter<custom_test_representation, another_test_representation>(
     [](idata_representation&,
        const memory::memory_space*,
-       rmm::cuda_stream_view) -> std::unique_ptr<idata_representation> { return nullptr; });
+       rmm::cuda_stream_view,
+       memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
+      return nullptr;
+    });
 
   try {
     registry.register_converter<custom_test_representation, another_test_representation>(
       [](idata_representation&,
          const memory::memory_space*,
-         rmm::cuda_stream_view) -> std::unique_ptr<idata_representation> { return nullptr; });
+         rmm::cuda_stream_view,
+         memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
+        return nullptr;
+      });
     FAIL("Expected exception to be thrown");
   } catch (const std::runtime_error& e) {
     std::string msg = e.what();


### PR DESCRIPTION
# Summary
The converter API had no `memory::reservation`, so converters were double counting the capacity in the `__allocated_bytes`, causing artificial `rmm::out_of_memory` under tight capacity.

This PR threads an optional `memory::reservation*` from the conversion entry points down to the HOST allocator so the conversion draws down the existing reservation instead of committing fresh capacity.

# Root cause
The HOST converters called allocate_multiple_blocks(size) without a reservation. That path adds the full allocation size to the pool's `_allocated_bytes` counter — the same counter reserve() already charged. So reserve-then-convert charged N twice. The fix is to pass the reservation: `allocate_multiple_blocks(size, reservation*)` charges nothing extra when the allocation fits the reservation. The overload already existed; converters just never got a reservation to hand it.

# Changes

**Converter API** — added a memory::reservation* parameter to `representation_converter_fn`, `convert<T>()`, the runtime convert(...) overload, `convert_impl`, and data_batch's `convert_to` / `clone_to` methods. The parameter defaults to nullptr on every public entry point, so existing non-reserving callers are source-compatible and unchanged in behavior. (Because std::function types can't carry default arguments, every registered converter's signature gains the param.)

**HOST converters (behavior change)** — the 5 HOST-target converters (`convert_gpu_to_host, convert_host_to_host, convert_gpu_to_host_fast, convert_host_fast_to_host_fast, convert_disk_to_host_data`) now pass the reservation into `allocate_multiple_blocks(size, reservation)`.

**GPU/DISK converters (no behavior change)** — the 6 GPU/DISK-target converters take the param [[maybe_unused]]; they allocate via get_default_allocator(), not allocate_multiple_blocks.

**Tests** — added a regression test ("HOST converter draws from caller reservation (no double-count)") that reserves N, converts GPU→HOST with the reservation, and asserts the conversion adds ≤ one block and total committed stays well below 2N.

Addresses https://github.com/sirius-db/sirius/issues/566