### PR TITLE
Migrate pixi to rich-platform CUDA requirements (pixi 0.71)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
 
     env:
       SCCACHE_GHA_ENABLED: true
+      CONDA_OVERRIDE_CUDA: ${{ matrix.cuda == 12 && '12.9' || '13' }}
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,8 +1,13 @@
 [workspace]
 channels = ["conda-forge"]
 name = "cuCascade"
-platforms = ["linux-64", "linux-aarch64"]
-requires-pixi = ">=0.59"
+platforms = [
+    { platform = "linux-64", cuda = "12.9" },
+    { platform = "linux-aarch64", cuda = "12.9" },
+    { platform = "linux-64", cuda = "13" },
+    { platform = "linux-aarch64", cuda = "13" },
+]
+requires-pixi = ">=0.71"
 
 [dependencies]
 cmake = "4.*"
@@ -23,13 +28,13 @@ unzip = "*"
 
 # CUDA 13
 [feature.cuda-13]
-system-requirements = { cuda = "13" }
+platforms = ["linux-64-cuda-13", "linux-aarch64-cuda-13"]
 dependencies = { "cuda-version" = "13.2.*" }
 activation = { env = { CUDAARCHS = "75-real;80-real;86-real;90a-real;100f-real;120a-real;120" } }
 
 # CUDA 12
 [feature.cuda-12]
-system-requirements = { cuda = "12.9" }
+platforms = ["linux-64-cuda-12-9", "linux-aarch64-cuda-12-9"]
 dependencies = { "cuda-version" = "12.9.*" }
 activation = { env = { CUDAARCHS = "75-real;80-real;86-real;90a-real;100f-real" } }
 


### PR DESCRIPTION
pixi 0.71 deprecated the `[system-requirements]` table and turned the per-feature CUDA requirement into a platform-match gate, so a CUDA environment no longer matches a driverless host. This broke `pixi list` / install on the CPU-only build runner with "no platform supported by environment ... matches the current system".

- Move the CUDA requirement into the new `[workspace].platforms` inline tables and reference the synthesized platform names from the cuda-12 / cuda-13 features. Removes the deprecation warnings.
- Bump `requires-pixi` to >=0.71 (rich-platform syntax + lock format v7).
- Set `CONDA_OVERRIDE_CUDA` on the CPU build job so the CUDA environment resolves without a driver. The real `__cuda` is still detected and the requirement enforced at runtime on the GPU test/benchmark runners.