### PR TITLE
Add `data_batch_probe`

### DIFF
--- a/include/cucascade/data/common.hpp
+++ b/include/cucascade/data/common.hpp
@@ -60,28 +60,28 @@ class idata_representation {
    *
    * @return Tier The memory tier
    */
-  memory::Tier get_current_tier() const { return _memory_space.get_tier(); }
+  memory::Tier get_current_tier() const noexcept { return _memory_space.get_tier(); }
 
   /**
    * @brief Get the device ID where the data resides
    *
    * @return device_id The device ID
    */
-  int get_device_id() const { return _memory_space.get_device_id(); }
+  int get_device_id() const noexcept { return _memory_space.get_device_id(); }
 
   /**
    * @brief Get the memory space where the data resides
    *
    * @return memory_space& Reference to the memory space
    */
-  cucascade::memory::memory_space& get_memory_space() { return _memory_space; }
+  cucascade::memory::memory_space& get_memory_space() noexcept { return _memory_space; }
 
   /**
    * @brief Get the memory space where the data resides (const version)
    *
    * @return const memory_space& Const reference to the memory space
    */
-  const cucascade::memory::memory_space& get_memory_space() const { return _memory_space; }
+  const cucascade::memory::memory_space& get_memory_space() const noexcept { return _memory_space; }
 
   /**
    * @brief Get the size of the data representation in bytes

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -52,6 +52,7 @@ enum class batch_state { idle, read_only, mutable_locked };
 // Forward declarations -- required before data_batch because it friends them.
 class read_only_data_batch;
 class mutable_data_batch;
+class idata_batch_probe;
 
 /**
  * @brief Core data batch type representing the "idle" (unlocked) state.
@@ -80,8 +81,10 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
    * @return A shared pointer owning the new batch.
    * @throws std::runtime_error if data is null.
    */
-  static std::shared_ptr<data_batch> make(uint64_t batch_id,
-                                          std::unique_ptr<idata_representation> data);
+  static std::shared_ptr<data_batch> make(
+    uint64_t batch_id,
+    std::unique_ptr<idata_representation> data,
+    std::unique_ptr<idata_batch_probe> probe = std::make_unique<idata_batch_probe>());
 
   ~data_batch() = default;
 
@@ -228,7 +231,9 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
   [[nodiscard]] static read_only_data_batch mutable_to_readonly(mutable_data_batch&& accessor);
 
  private:
-  data_batch(uint64_t batch_id, std::unique_ptr<idata_representation> data);
+  data_batch(uint64_t batch_id,
+             std::unique_ptr<idata_representation> data,
+             std::unique_ptr<idata_batch_probe> probe);
 
   /**
    * @brief Get the memory tier of the held data.
@@ -260,6 +265,7 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
   std::atomic<size_t> _subscriber_count{0};            ///< Atomic subscriber interest count
   std::atomic<batch_state> _state{batch_state::idle};  ///< Observable lock state
   std::atomic<size_t> _read_only_count{0};  ///< Count of active read_only_data_batch instances
+  std::unique_ptr<idata_batch_probe> _probe;
 };
 
 /**
@@ -321,8 +327,10 @@ class read_only_data_batch {
    * @return A new data_batch wrapped in shared_ptr.
    * @throws std::runtime_error if the data is null.
    */
-  [[nodiscard]] std::shared_ptr<data_batch> clone(uint64_t new_batch_id,
-                                                  rmm::cuda_stream_view stream) const;
+  [[nodiscard]] std::shared_ptr<data_batch> clone(
+    uint64_t new_batch_id,
+    rmm::cuda_stream_view stream,
+    std::unique_ptr<idata_batch_probe> probe = std::make_unique<idata_batch_probe>()) const;
 
   /**
    * @brief Create an independent deep copy with representation conversion.
@@ -342,7 +350,8 @@ class read_only_data_batch {
     representation_converter_registry& registry,
     uint64_t new_batch_id,
     const memory::memory_space* target_memory_space,
-    rmm::cuda_stream_view stream) const;
+    rmm::cuda_stream_view stream,
+    std::unique_ptr<idata_batch_probe> probe = std::make_unique<idata_batch_probe>()) const;
 
   // -- Move support --
   read_only_data_batch(read_only_data_batch&& other) noexcept;
@@ -453,8 +462,10 @@ class mutable_data_batch {
    * @return A new data_batch wrapped in shared_ptr.
    * @throws std::runtime_error if the data is null.
    */
-  [[nodiscard]] std::shared_ptr<data_batch> clone(uint64_t new_batch_id,
-                                                  rmm::cuda_stream_view stream) const;
+  [[nodiscard]] std::shared_ptr<data_batch> clone(
+    uint64_t new_batch_id,
+    rmm::cuda_stream_view stream,
+    std::unique_ptr<idata_batch_probe> probe = std::make_unique<idata_batch_probe>()) const;
 
   /**
    * @brief Create an independent deep copy with representation conversion.
@@ -474,7 +485,8 @@ class mutable_data_batch {
     representation_converter_registry& registry,
     uint64_t new_batch_id,
     const memory::memory_space* target_memory_space,
-    rmm::cuda_stream_view stream) const;
+    rmm::cuda_stream_view stream,
+    std::unique_ptr<idata_batch_probe> probe = std::make_unique<idata_batch_probe>()) const;
 
   // -- Move-only --
   mutable_data_batch(mutable_data_batch&& other) noexcept;
@@ -501,6 +513,41 @@ class mutable_data_batch {
   std::unique_lock<std::shared_mutex> _lock;  ///< Exclusive lock (destroyed first)
 };
 
+/**
+ * @brief Interface for probing the data_batch class.
+ *
+ * Applications may implement this interface to hold additional application specific
+ * data_batch metadata while probing the data_batch by overriding the provided methods
+ * that expose the data_batch state when certain events occur, like state transitions.
+ *
+ * @note It is the implementer's responsibility that the calls to this class' functions
+ * return quickly, as they are called in a thread-safe manner, and will block other
+ * mutating changes while they execute. This interface is primarily intended for
+ * bookkeeping purposes. Default impl is no-op
+ */
+class idata_batch_probe {
+ public:
+  idata_batch_probe()          = default;
+  virtual ~idata_batch_probe() = default;
+
+  virtual void created([[maybe_unused]] const uint64_t batch_id,
+                       [[maybe_unused]] const idata_representation& data)
+  {
+  }
+  virtual void conversion_started([[maybe_unused]] const idata_representation& current_data,
+                                  [[maybe_unused]] const memory::memory_space* target_memory_space)
+  {
+  }
+  virtual void conversion_completed([[maybe_unused]] const idata_representation& data,
+                                    [[maybe_unused]] const bool success)
+  {
+  }
+  virtual void data_replaced([[maybe_unused]] const idata_representation& new_data) {}
+  virtual void state_changed([[maybe_unused]] const batch_state new_state) {}
+  virtual void subscriber_count_changed([[maybe_unused]] const size_t& new_subscriber_count) {}
+  virtual void reader_count_changed([[maybe_unused]] const size_t& new_read_only_count) {}
+};
+
 // =============================================================================
 // Template implementations (TargetRepresentation-templated methods only)
 // =============================================================================
@@ -510,11 +557,12 @@ std::shared_ptr<data_batch> read_only_data_batch::clone_to(
   representation_converter_registry& registry,
   uint64_t new_batch_id,
   const memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view stream) const
+  rmm::cuda_stream_view stream,
+  std::unique_ptr<idata_batch_probe> probe) const
 {
   auto new_representation =
     registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
-  return data_batch::make(new_batch_id, std::move(new_representation));
+  return data_batch::make(new_batch_id, std::move(new_representation), std::move(probe));
 }
 
 // -- mutable_data_batch::convert_to (in-place conversion) --
@@ -524,6 +572,23 @@ void mutable_data_batch::convert_to(representation_converter_registry& registry,
                                     const memory::memory_space* target_memory_space,
                                     rmm::cuda_stream_view stream)
 {
+  _batch->_probe->conversion_started(*(_batch->_data), target_memory_space);
+  bool conversion_succeeded = false;
+  // small helper that gets called when this scope is exited (including during exceptions)
+  struct OnScopeExit {
+    const std::unique_ptr<idata_batch_probe>& probe;
+    // a ref to the unique ptr so when data is updated,
+    // that new data is supplied with the notification.
+    const std::unique_ptr<idata_representation>& data;
+    const bool& success;
+
+    ~OnScopeExit() { probe->conversion_completed(*data, success); }
+  } on_scope_exit{
+    .probe   = _batch->_probe,
+    .data    = _batch->_data,
+    .success = conversion_succeeded,
+  };
+
   auto new_representation =
     registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
   auto old_representation = std::move(_batch->_data);
@@ -539,6 +604,8 @@ void mutable_data_batch::convert_to(representation_converter_registry& registry,
     // representation is destroyed to avoid use-after-free.
     stream.synchronize();
   }
+
+  conversion_succeeded = true;  // ref used by on_scope_exit helper.
 }
 
 template <typename TargetRepresentation>
@@ -546,11 +613,12 @@ std::shared_ptr<data_batch> mutable_data_batch::clone_to(
   representation_converter_registry& registry,
   uint64_t new_batch_id,
   const memory::memory_space* target_memory_space,
-  rmm::cuda_stream_view stream) const
+  rmm::cuda_stream_view stream,
+  std::unique_ptr<idata_batch_probe> probe) const
 {
   auto new_representation =
     registry.convert<TargetRepresentation>(*_batch->_data, target_memory_space, stream);
-  return data_batch::make(new_batch_id, std::move(new_representation));
+  return data_batch::make(new_batch_id, std::move(new_representation), std::move(probe));
 }
 
 }  // namespace cucascade

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -95,7 +95,7 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
   data_batch(const data_batch&)            = delete;
   data_batch& operator=(const data_batch&) = delete;
 
-  // -- Public API usable without holding an accessor --
+  // -- Lock-free public API --
 
   /**
    * @brief Get the unique batch identifier.
@@ -108,11 +108,15 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
 
   /**
    * @brief Increment the subscriber interest count.
+   *
+   * Atomic, lock-free.
    */
   void subscribe();
 
   /**
    * @brief Decrement the subscriber interest count.
+   *
+   * Atomic, lock-free.
    *
    * @throws std::runtime_error if subscriber count is already zero.
    */
@@ -266,9 +270,6 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
   std::atomic<size_t> _read_only_count{0};  ///< Count of active read_only_data_batch instances
 
   std::unique_ptr<idata_batch_probe> _probe;
-  /// Serializes counter/state updates with their probe callbacks so notifications
-  /// are delivered in the order the changes occurred.
-  mutable std::mutex _probe_mutex;
 };
 
 /**
@@ -523,10 +524,11 @@ class mutable_data_batch {
  * data_batch metadata while probing the data_batch by overriding the provided methods
  * that expose the data_batch state when certain events occur, like state transitions.
  *
- * @note It is the implementer's responsibility that the calls to this class' functions
- * return quickly, as they are called in a thread-safe manner, and will block other
- * mutating changes while they execute. This interface is primarily intended for
- * bookkeeping purposes. Default impl is no-op
+ * @note All callbacks are invoked either during batch construction (created) or while
+ * the batch's exclusive lock is held via mutable_data_batch, so per batch they are
+ * totally ordered and never run concurrently. It is the implementer's responsibility
+ * that they return quickly, as they block other mutating changes while they execute.
+ * This interface is primarily intended for bookkeeping purposes. Default impl is no-op
  */
 class idata_batch_probe {
  public:
@@ -547,12 +549,6 @@ class idata_batch_probe {
   {
   }
   virtual void data_replaced([[maybe_unused]] const idata_representation& new_data) noexcept {}
-  virtual void state_changed([[maybe_unused]] const batch_state new_state) noexcept {}
-  virtual void subscriber_count_changed(
-    [[maybe_unused]] const size_t& new_subscriber_count) noexcept
-  {
-  }
-  virtual void reader_count_changed([[maybe_unused]] const size_t& new_read_only_count) noexcept {}
 };
 
 // =============================================================================

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -27,6 +27,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <shared_mutex>
 #include <stdexcept>
@@ -94,7 +95,7 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
   data_batch(const data_batch&)            = delete;
   data_batch& operator=(const data_batch&) = delete;
 
-  // -- Lock-free public API --
+  // -- Public API usable without holding an accessor --
 
   /**
    * @brief Get the unique batch identifier.
@@ -112,8 +113,6 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
 
   /**
    * @brief Decrement the subscriber interest count.
-   *
-   * Atomic, lock-free.
    *
    * @throws std::runtime_error if subscriber count is already zero.
    */
@@ -265,7 +264,11 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
   std::atomic<size_t> _subscriber_count{0};            ///< Atomic subscriber interest count
   std::atomic<batch_state> _state{batch_state::idle};  ///< Observable lock state
   std::atomic<size_t> _read_only_count{0};  ///< Count of active read_only_data_batch instances
+
   std::unique_ptr<idata_batch_probe> _probe;
+  /// Serializes counter/state updates with their probe callbacks so notifications
+  /// are delivered in the order the changes occurred.
+  mutable std::mutex _probe_mutex;
 };
 
 /**
@@ -531,21 +534,25 @@ class idata_batch_probe {
   virtual ~idata_batch_probe() = default;
 
   virtual void created([[maybe_unused]] const uint64_t batch_id,
-                       [[maybe_unused]] const idata_representation& data)
+                       [[maybe_unused]] const idata_representation& data) noexcept
   {
   }
-  virtual void conversion_started([[maybe_unused]] const idata_representation& current_data,
-                                  [[maybe_unused]] const memory::memory_space* target_memory_space)
+  virtual void conversion_started(
+    [[maybe_unused]] const idata_representation& current_data,
+    [[maybe_unused]] const memory::memory_space* target_memory_space) noexcept
   {
   }
   virtual void conversion_completed([[maybe_unused]] const idata_representation& data,
-                                    [[maybe_unused]] const bool success)
+                                    [[maybe_unused]] const bool success) noexcept
   {
   }
-  virtual void data_replaced([[maybe_unused]] const idata_representation& new_data) {}
-  virtual void state_changed([[maybe_unused]] const batch_state new_state) {}
-  virtual void subscriber_count_changed([[maybe_unused]] const size_t& new_subscriber_count) {}
-  virtual void reader_count_changed([[maybe_unused]] const size_t& new_read_only_count) {}
+  virtual void data_replaced([[maybe_unused]] const idata_representation& new_data) noexcept {}
+  virtual void state_changed([[maybe_unused]] const batch_state new_state) noexcept {}
+  virtual void subscriber_count_changed(
+    [[maybe_unused]] const size_t& new_subscriber_count) noexcept
+  {
+  }
+  virtual void reader_count_changed([[maybe_unused]] const size_t& new_read_only_count) noexcept {}
 };
 
 // =============================================================================

--- a/src/data/data_batch.cpp
+++ b/src/data/data_batch.cpp
@@ -18,6 +18,7 @@
 #include <cucascade/data/data_batch.hpp>
 
 #include <memory>
+#include <mutex>
 #include <stdexcept>
 
 namespace cucascade {
@@ -45,23 +46,19 @@ uint64_t data_batch::get_batch_id() const { return _batch_id; }
 
 void data_batch::subscribe()
 {
-  const size_t prev = _subscriber_count.fetch_add(1, std::memory_order_relaxed);
-  _probe->subscriber_count_changed(prev + 1);
+  std::lock_guard<std::mutex> guard(_probe_mutex);
+  const size_t count = _subscriber_count.fetch_add(1, std::memory_order_relaxed) + 1;
+  _probe->subscriber_count_changed(count);
 }
 
 void data_batch::unsubscribe()
 {
-  size_t current = _subscriber_count.load(std::memory_order_relaxed);
-  while (true) {
-    if (current == 0) {
-      throw std::runtime_error("Cannot unsubscribe: subscriber count is already zero");
-    }
-    if (_subscriber_count.compare_exchange_weak(
-          current, current - 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
-      _probe->subscriber_count_changed(current - 1);
-      return;
-    }
+  std::lock_guard<std::mutex> guard(_probe_mutex);
+  if (_subscriber_count.load(std::memory_order_relaxed) == 0) {
+    throw std::runtime_error("Cannot unsubscribe: subscriber count is already zero");
   }
+  const size_t count = _subscriber_count.fetch_sub(1, std::memory_order_relaxed) - 1;
+  _probe->subscriber_count_changed(count);
 }
 
 size_t data_batch::get_subscriber_count() const
@@ -83,7 +80,7 @@ memory::memory_space* data_batch::get_memory_space() const
 
 void data_batch::set_data(std::unique_ptr<idata_representation> data)
 {
-  if (_data == nullptr) { throw std::runtime_error("data is null in data_batch::set_data"); }
+  if (data == nullptr) { throw std::runtime_error("data is null in data_batch::set_data"); }
   _data = std::move(data);
   _probe->data_replaced(*_data);
 }
@@ -170,6 +167,7 @@ read_only_data_batch::read_only_data_batch(std::shared_ptr<data_batch> parent,
                                            std::shared_lock<std::shared_mutex> lock)
   : _batch(std::move(parent)), _lock(std::move(lock))
 {
+  std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
   const size_t prev = _batch->_read_only_count.fetch_add(1);
   if (prev == 0) {
     _batch->_state.store(batch_state::read_only);
@@ -191,6 +189,7 @@ read_only_data_batch::read_only_data_batch(const read_only_data_batch& other)
                        : std::shared_lock<std::shared_mutex>())
 {
   if (_batch) {
+    std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
     const size_t prev = _batch->_read_only_count.fetch_add(1);
     assert(_batch->_state == batch_state::read_only);
     _batch->_probe->reader_count_changed(prev + 1);
@@ -202,12 +201,15 @@ read_only_data_batch& read_only_data_batch::operator=(read_only_data_batch&& oth
   if (this != &other) {
     // Release the current state (same logic as destructor)
     if (_batch) {
-      const size_t prev = _batch->_read_only_count.fetch_sub(1);
-      if (prev == 1) {
-        _batch->_state.store(batch_state::idle);
-        _batch->_probe->state_changed(batch_state::idle);
+      {
+        std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
+        const size_t prev = _batch->_read_only_count.fetch_sub(1);
+        if (prev == 1) {
+          _batch->_state.store(batch_state::idle);
+          _batch->_probe->state_changed(batch_state::idle);
+        }
+        _batch->_probe->reader_count_changed(prev - 1);
       }
-      _batch->_probe->reader_count_changed(prev - 1);
 
       // _lock will be replaced below; its destructor fires when the old _lock is overwritten,
       // releasing the shared lock. We release _lock explicitly here so the sequence is:
@@ -224,12 +226,15 @@ read_only_data_batch& read_only_data_batch::operator=(const read_only_data_batch
 {
   if (this != &other) {
     if (_batch) {
-      const size_t prev = _batch->_read_only_count.fetch_sub(1);
-      if (prev == 1) {
-        _batch->_state.store(batch_state::idle);
-        _batch->_probe->state_changed(batch_state::idle);
+      {
+        std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
+        const size_t prev = _batch->_read_only_count.fetch_sub(1);
+        if (prev == 1) {
+          _batch->_state.store(batch_state::idle);
+          _batch->_probe->state_changed(batch_state::idle);
+        }
+        _batch->_probe->reader_count_changed(prev - 1);
       }
-      _batch->_probe->reader_count_changed(prev - 1);
 
       _lock.unlock();
     }
@@ -237,6 +242,7 @@ read_only_data_batch& read_only_data_batch::operator=(const read_only_data_batch
     if (_batch) {
       _lock = std::shared_lock<std::shared_mutex>(_batch->_rw_mutex);
 
+      std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
       const size_t prev = _batch->_read_only_count.fetch_add(1);
       if (prev == 0) {
         _batch->_state.store(batch_state::read_only);
@@ -258,6 +264,7 @@ read_only_data_batch::~read_only_data_batch()
     // The destructor body runs before member destructors, so _batch is still valid here.
     // After this function returns, _lock destructor fires first (declared after _batch,
     // destroyed in reverse order), releasing the shared lock. Then _batch destructor fires.
+    std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
     const size_t prev = _batch->_read_only_count.fetch_sub(1);
     if (prev == 1) {
       _batch->_state.store(batch_state::idle);
@@ -283,6 +290,7 @@ mutable_data_batch::mutable_data_batch(std::shared_ptr<data_batch> parent,
                                        std::unique_lock<std::shared_mutex> lock)
   : _batch(std::move(parent)), _lock(std::move(lock))
 {
+  std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
   _batch->_state.store(batch_state::mutable_locked);
   _batch->_probe->state_changed(batch_state::mutable_locked);
 }
@@ -298,8 +306,11 @@ mutable_data_batch& mutable_data_batch::operator=(mutable_data_batch&& other) no
   if (this != &other) {
     // Release the current state (same logic as destructor)
     if (_batch) {
-      _batch->_state.store(batch_state::idle);
-      _batch->_probe->state_changed(batch_state::idle);
+      {
+        std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
+        _batch->_state.store(batch_state::idle);
+        _batch->_probe->state_changed(batch_state::idle);
+      }
       // Release the exclusive lock explicitly before taking ownership of the new one.
       _lock.unlock();
     }
@@ -313,6 +324,7 @@ mutable_data_batch::~mutable_data_batch()
 {
   if (_batch) {
     // Transition state to idle. The _lock member destructor handles releasing the exclusive lock.
+    std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
     _batch->_state.store(batch_state::idle);
     _batch->_probe->state_changed(batch_state::idle);
   }

--- a/src/data/data_batch.cpp
+++ b/src/data/data_batch.cpp
@@ -17,25 +17,37 @@
 
 #include <cucascade/data/data_batch.hpp>
 
+#include <memory>
+#include <stdexcept>
+
 namespace cucascade {
 
 // ========== data_batch implementation ==========
 
 std::shared_ptr<data_batch> data_batch::make(uint64_t batch_id,
-                                             std::unique_ptr<idata_representation> data)
+                                             std::unique_ptr<idata_representation> data,
+                                             std::unique_ptr<idata_batch_probe> probe)
 {
   if (data == nullptr) { throw std::runtime_error("data is null in data_batch factory"); }
-  return std::shared_ptr<data_batch>(new data_batch(batch_id, std::move(data)));
+  if (probe == nullptr) { throw std::runtime_error("probe is null in data_batch factory"); }
+  return std::shared_ptr<data_batch>(new data_batch(batch_id, std::move(data), std::move(probe)));
 }
 
-data_batch::data_batch(uint64_t batch_id, std::unique_ptr<idata_representation> data)
-  : _batch_id(batch_id), _data(std::move(data))
+data_batch::data_batch(uint64_t batch_id,
+                       std::unique_ptr<idata_representation> data,
+                       std::unique_ptr<idata_batch_probe> probe)
+  : _batch_id(batch_id), _data(std::move(data)), _probe(std::move(probe))
 {
+  _probe->created(get_batch_id(), *get_data());
 }
 
 uint64_t data_batch::get_batch_id() const { return _batch_id; }
 
-void data_batch::subscribe() { _subscriber_count.fetch_add(1, std::memory_order_relaxed); }
+void data_batch::subscribe()
+{
+  const size_t prev = _subscriber_count.fetch_add(1, std::memory_order_relaxed);
+  _probe->subscriber_count_changed(prev + 1);
+}
 
 void data_batch::unsubscribe()
 {
@@ -46,6 +58,7 @@ void data_batch::unsubscribe()
     }
     if (_subscriber_count.compare_exchange_weak(
           current, current - 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
+      _probe->subscriber_count_changed(current - 1);
       return;
     }
   }
@@ -68,7 +81,12 @@ memory::memory_space* data_batch::get_memory_space() const
   return &_data->get_memory_space();
 }
 
-void data_batch::set_data(std::unique_ptr<idata_representation> data) { _data = std::move(data); }
+void data_batch::set_data(std::unique_ptr<idata_representation> data)
+{
+  if (_data == nullptr) { throw std::runtime_error("data is null in data_batch::set_data"); }
+  _data = std::move(data);
+  _probe->data_replaced(*_data);
+}
 
 // ========== Static transition methods ==========
 
@@ -152,8 +170,12 @@ read_only_data_batch::read_only_data_batch(std::shared_ptr<data_batch> parent,
                                            std::shared_lock<std::shared_mutex> lock)
   : _batch(std::move(parent)), _lock(std::move(lock))
 {
-  _batch->_read_only_count.fetch_add(1);
-  _batch->_state.store(batch_state::read_only);
+  const size_t prev = _batch->_read_only_count.fetch_add(1);
+  if (prev == 0) {
+    _batch->_state.store(batch_state::read_only);
+    _batch->_probe->state_changed(batch_state::read_only);
+  }
+  _batch->_probe->reader_count_changed(prev + 1);
 }
 
 read_only_data_batch::read_only_data_batch(read_only_data_batch&& other) noexcept
@@ -168,7 +190,11 @@ read_only_data_batch::read_only_data_batch(const read_only_data_batch& other)
     _lock(other._batch ? std::shared_lock<std::shared_mutex>(other._batch->_rw_mutex)
                        : std::shared_lock<std::shared_mutex>())
 {
-  if (_batch) { _batch->_read_only_count.fetch_add(1); }
+  if (_batch) {
+    const size_t prev = _batch->_read_only_count.fetch_add(1);
+    assert(_batch->_state == batch_state::read_only);
+    _batch->_probe->reader_count_changed(prev + 1);
+  }
 }
 
 read_only_data_batch& read_only_data_batch::operator=(read_only_data_batch&& other) noexcept
@@ -176,8 +202,13 @@ read_only_data_batch& read_only_data_batch::operator=(read_only_data_batch&& oth
   if (this != &other) {
     // Release the current state (same logic as destructor)
     if (_batch) {
-      auto prev = _batch->_read_only_count.fetch_sub(1);
-      if (prev == 1) { _batch->_state.store(batch_state::idle); }
+      const size_t prev = _batch->_read_only_count.fetch_sub(1);
+      if (prev == 1) {
+        _batch->_state.store(batch_state::idle);
+        _batch->_probe->state_changed(batch_state::idle);
+      }
+      _batch->_probe->reader_count_changed(prev - 1);
+
       // _lock will be replaced below; its destructor fires when the old _lock is overwritten,
       // releasing the shared lock. We release _lock explicitly here so the sequence is:
       // decrement count -> set state (if last) -> release lock.
@@ -193,15 +224,25 @@ read_only_data_batch& read_only_data_batch::operator=(const read_only_data_batch
 {
   if (this != &other) {
     if (_batch) {
-      auto prev = _batch->_read_only_count.fetch_sub(1);
-      if (prev == 1) { _batch->_state.store(batch_state::idle); }
+      const size_t prev = _batch->_read_only_count.fetch_sub(1);
+      if (prev == 1) {
+        _batch->_state.store(batch_state::idle);
+        _batch->_probe->state_changed(batch_state::idle);
+      }
+      _batch->_probe->reader_count_changed(prev - 1);
+
       _lock.unlock();
     }
     _batch = other._batch;
     if (_batch) {
       _lock = std::shared_lock<std::shared_mutex>(_batch->_rw_mutex);
-      _batch->_read_only_count.fetch_add(1);
-      _batch->_state.store(batch_state::read_only);
+
+      const size_t prev = _batch->_read_only_count.fetch_add(1);
+      if (prev == 0) {
+        _batch->_state.store(batch_state::read_only);
+        _batch->_probe->state_changed(batch_state::read_only);
+      }
+      _batch->_probe->reader_count_changed(prev + 1);
     } else {
       _lock = std::shared_lock<std::shared_mutex>();
     }
@@ -217,17 +258,23 @@ read_only_data_batch::~read_only_data_batch()
     // The destructor body runs before member destructors, so _batch is still valid here.
     // After this function returns, _lock destructor fires first (declared after _batch,
     // destroyed in reverse order), releasing the shared lock. Then _batch destructor fires.
-    auto prev = _batch->_read_only_count.fetch_sub(1);
-    if (prev == 1) { _batch->_state.store(batch_state::idle); }
+    const size_t prev = _batch->_read_only_count.fetch_sub(1);
+    if (prev == 1) {
+      _batch->_state.store(batch_state::idle);
+      _batch->_probe->state_changed(batch_state::idle);
+    }
+    _batch->_probe->reader_count_changed(prev - 1);
   }
 }
 
-std::shared_ptr<data_batch> read_only_data_batch::clone(uint64_t new_batch_id,
-                                                        rmm::cuda_stream_view stream) const
+std::shared_ptr<data_batch> read_only_data_batch::clone(
+  uint64_t new_batch_id,
+  rmm::cuda_stream_view stream,
+  std::unique_ptr<idata_batch_probe> probe) const
 {
   if (_batch->_data == nullptr) { throw std::runtime_error("Cannot clone: data is null"); }
   auto cloned_data = _batch->_data->clone(stream);
-  return data_batch::make(new_batch_id, std::move(cloned_data));
+  return data_batch::make(new_batch_id, std::move(cloned_data), std::move(probe));
 }
 
 // ========== mutable_data_batch ==========
@@ -237,6 +284,7 @@ mutable_data_batch::mutable_data_batch(std::shared_ptr<data_batch> parent,
   : _batch(std::move(parent)), _lock(std::move(lock))
 {
   _batch->_state.store(batch_state::mutable_locked);
+  _batch->_probe->state_changed(batch_state::mutable_locked);
 }
 
 mutable_data_batch::mutable_data_batch(mutable_data_batch&& other) noexcept
@@ -251,6 +299,7 @@ mutable_data_batch& mutable_data_batch::operator=(mutable_data_batch&& other) no
     // Release the current state (same logic as destructor)
     if (_batch) {
       _batch->_state.store(batch_state::idle);
+      _batch->_probe->state_changed(batch_state::idle);
       // Release the exclusive lock explicitly before taking ownership of the new one.
       _lock.unlock();
     }
@@ -265,6 +314,7 @@ mutable_data_batch::~mutable_data_batch()
   if (_batch) {
     // Transition state to idle. The _lock member destructor handles releasing the exclusive lock.
     _batch->_state.store(batch_state::idle);
+    _batch->_probe->state_changed(batch_state::idle);
   }
 }
 
@@ -273,12 +323,14 @@ void mutable_data_batch::rebind_stream(rmm::cuda_stream_view stream)
   if (auto* repr = _batch->get_data()) { repr->rebind_stream(stream); }
 }
 
-std::shared_ptr<data_batch> mutable_data_batch::clone(uint64_t new_batch_id,
-                                                      rmm::cuda_stream_view stream) const
+std::shared_ptr<data_batch> mutable_data_batch::clone(
+  uint64_t new_batch_id,
+  rmm::cuda_stream_view stream,
+  std::unique_ptr<idata_batch_probe> probe) const
 {
   if (_batch->_data == nullptr) { throw std::runtime_error("Cannot clone: data is null"); }
   auto cloned_data = _batch->_data->clone(stream);
-  return data_batch::make(new_batch_id, std::move(cloned_data));
+  return data_batch::make(new_batch_id, std::move(cloned_data), std::move(probe));
 }
 
 }  // namespace cucascade

--- a/src/data/data_batch.cpp
+++ b/src/data/data_batch.cpp
@@ -44,21 +44,20 @@ data_batch::data_batch(uint64_t batch_id,
 
 uint64_t data_batch::get_batch_id() const { return _batch_id; }
 
-void data_batch::subscribe()
-{
-  std::lock_guard<std::mutex> guard(_probe_mutex);
-  const size_t count = _subscriber_count.fetch_add(1, std::memory_order_relaxed) + 1;
-  _probe->subscriber_count_changed(count);
-}
+void data_batch::subscribe() { _subscriber_count.fetch_add(1, std::memory_order_relaxed); }
 
 void data_batch::unsubscribe()
 {
-  std::lock_guard<std::mutex> guard(_probe_mutex);
-  if (_subscriber_count.load(std::memory_order_relaxed) == 0) {
-    throw std::runtime_error("Cannot unsubscribe: subscriber count is already zero");
+  size_t current = _subscriber_count.load(std::memory_order_relaxed);
+  while (true) {
+    if (current == 0) {
+      throw std::runtime_error("Cannot unsubscribe: subscriber count is already zero");
+    }
+    if (_subscriber_count.compare_exchange_weak(
+          current, current - 1, std::memory_order_relaxed, std::memory_order_relaxed)) {
+      return;
+    }
   }
-  const size_t count = _subscriber_count.fetch_sub(1, std::memory_order_relaxed) - 1;
-  _probe->subscriber_count_changed(count);
 }
 
 size_t data_batch::get_subscriber_count() const
@@ -167,13 +166,8 @@ read_only_data_batch::read_only_data_batch(std::shared_ptr<data_batch> parent,
                                            std::shared_lock<std::shared_mutex> lock)
   : _batch(std::move(parent)), _lock(std::move(lock))
 {
-  std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
-  const size_t prev = _batch->_read_only_count.fetch_add(1);
-  if (prev == 0) {
-    _batch->_state.store(batch_state::read_only);
-    _batch->_probe->state_changed(batch_state::read_only);
-  }
-  _batch->_probe->reader_count_changed(prev + 1);
+  _batch->_read_only_count.fetch_add(1);
+  _batch->_state.store(batch_state::read_only);
 }
 
 read_only_data_batch::read_only_data_batch(read_only_data_batch&& other) noexcept
@@ -188,12 +182,7 @@ read_only_data_batch::read_only_data_batch(const read_only_data_batch& other)
     _lock(other._batch ? std::shared_lock<std::shared_mutex>(other._batch->_rw_mutex)
                        : std::shared_lock<std::shared_mutex>())
 {
-  if (_batch) {
-    std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
-    const size_t prev = _batch->_read_only_count.fetch_add(1);
-    assert(_batch->_state == batch_state::read_only);
-    _batch->_probe->reader_count_changed(prev + 1);
-  }
+  if (_batch) { _batch->_read_only_count.fetch_add(1); }
 }
 
 read_only_data_batch& read_only_data_batch::operator=(read_only_data_batch&& other) noexcept
@@ -201,16 +190,8 @@ read_only_data_batch& read_only_data_batch::operator=(read_only_data_batch&& oth
   if (this != &other) {
     // Release the current state (same logic as destructor)
     if (_batch) {
-      {
-        std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
-        const size_t prev = _batch->_read_only_count.fetch_sub(1);
-        if (prev == 1) {
-          _batch->_state.store(batch_state::idle);
-          _batch->_probe->state_changed(batch_state::idle);
-        }
-        _batch->_probe->reader_count_changed(prev - 1);
-      }
-
+      size_t prev = _batch->_read_only_count.fetch_sub(1);
+      if (prev == 1) { _batch->_state.store(batch_state::idle); }
       // _lock will be replaced below; its destructor fires when the old _lock is overwritten,
       // releasing the shared lock. We release _lock explicitly here so the sequence is:
       // decrement count -> set state (if last) -> release lock.
@@ -226,29 +207,15 @@ read_only_data_batch& read_only_data_batch::operator=(const read_only_data_batch
 {
   if (this != &other) {
     if (_batch) {
-      {
-        std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
-        const size_t prev = _batch->_read_only_count.fetch_sub(1);
-        if (prev == 1) {
-          _batch->_state.store(batch_state::idle);
-          _batch->_probe->state_changed(batch_state::idle);
-        }
-        _batch->_probe->reader_count_changed(prev - 1);
-      }
-
+      size_t prev = _batch->_read_only_count.fetch_sub(1);
+      if (prev == 1) { _batch->_state.store(batch_state::idle); }
       _lock.unlock();
     }
     _batch = other._batch;
     if (_batch) {
       _lock = std::shared_lock<std::shared_mutex>(_batch->_rw_mutex);
-
-      std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
-      const size_t prev = _batch->_read_only_count.fetch_add(1);
-      if (prev == 0) {
-        _batch->_state.store(batch_state::read_only);
-        _batch->_probe->state_changed(batch_state::read_only);
-      }
-      _batch->_probe->reader_count_changed(prev + 1);
+      _batch->_read_only_count.fetch_add(1);
+      _batch->_state.store(batch_state::read_only);
     } else {
       _lock = std::shared_lock<std::shared_mutex>();
     }
@@ -264,13 +231,8 @@ read_only_data_batch::~read_only_data_batch()
     // The destructor body runs before member destructors, so _batch is still valid here.
     // After this function returns, _lock destructor fires first (declared after _batch,
     // destroyed in reverse order), releasing the shared lock. Then _batch destructor fires.
-    std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
-    const size_t prev = _batch->_read_only_count.fetch_sub(1);
-    if (prev == 1) {
-      _batch->_state.store(batch_state::idle);
-      _batch->_probe->state_changed(batch_state::idle);
-    }
-    _batch->_probe->reader_count_changed(prev - 1);
+    size_t prev = _batch->_read_only_count.fetch_sub(1);
+    if (prev == 1) { _batch->_state.store(batch_state::idle); }
   }
 }
 
@@ -290,9 +252,7 @@ mutable_data_batch::mutable_data_batch(std::shared_ptr<data_batch> parent,
                                        std::unique_lock<std::shared_mutex> lock)
   : _batch(std::move(parent)), _lock(std::move(lock))
 {
-  std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
   _batch->_state.store(batch_state::mutable_locked);
-  _batch->_probe->state_changed(batch_state::mutable_locked);
 }
 
 mutable_data_batch::mutable_data_batch(mutable_data_batch&& other) noexcept
@@ -306,11 +266,7 @@ mutable_data_batch& mutable_data_batch::operator=(mutable_data_batch&& other) no
   if (this != &other) {
     // Release the current state (same logic as destructor)
     if (_batch) {
-      {
-        std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
-        _batch->_state.store(batch_state::idle);
-        _batch->_probe->state_changed(batch_state::idle);
-      }
+      _batch->_state.store(batch_state::idle);
       // Release the exclusive lock explicitly before taking ownership of the new one.
       _lock.unlock();
     }
@@ -324,9 +280,7 @@ mutable_data_batch::~mutable_data_batch()
 {
   if (_batch) {
     // Transition state to idle. The _lock member destructor handles releasing the exclusive lock.
-    std::lock_guard<std::mutex> guard(_batch->_probe_mutex);
     _batch->_state.store(batch_state::idle);
-    _batch->_probe->state_changed(batch_state::idle);
   }
 }
 


### PR DESCRIPTION
Add a virtual `idata_batch_probe` that consumers can override to inspect or probe `data_batch` behavior.
