### PR TITLE
Stream-order slab reuse in small_pinned_host_memory_resource

### DIFF
--- a/include/cucascade/memory/small_pinned_host_memory_resource.hpp
+++ b/include/cucascade/memory/small_pinned_host_memory_resource.hpp
@@ -21,6 +21,7 @@
 
 #include <cuda/memory_resource>
 #include <cuda/stream_ref>
+#include <cuda_runtime_api.h>
 
 #include <array>
 #include <cstddef>
@@ -144,9 +145,27 @@ class small_pinned_host_memory_resource {
   /// Must be called with mutex_ held.
   void expand_pool_locked(std::size_t slab_idx);
 
+  /// A free slab plus, when it was just deallocated, a CUDA event recorded on
+  /// the freeing stream. Reusing the slab must wait on this event so an
+  /// in-flight async H2D copy that still reads the slab (e.g. cuDF's parquet
+  /// stats min/max buffers) completes before another stream overwrites it.
+  /// @c ready_event is null for freshly-carved slabs that were never used.
+  struct free_slab {
+    void* ptr;
+    cudaEvent_t ready_event;
+  };
+
+  /// Borrow a timing-disabled CUDA event (recycled from @c event_pool_ or newly
+  /// created). Returns null if event creation fails. Must hold @c mutex_.
+  cudaEvent_t acquire_event_locked();
+
+  /// Return an event to @c event_pool_ for reuse. Must hold @c mutex_.
+  void release_event_locked(cudaEvent_t event) noexcept;
+
   fixed_size_host_memory_resource& upstream_;
   mutable std::mutex mutex_;
-  std::array<std::vector<void*>, 5> free_lists_{};
+  std::array<std::vector<free_slab>, 5> free_lists_{};
+  std::vector<cudaEvent_t> event_pool_;
   std::vector<fixed_multiple_blocks_allocation> owned_allocations_;
 };
 

--- a/src/memory/small_pinned_host_memory_resource.cpp
+++ b/src/memory/small_pinned_host_memory_resource.cpp
@@ -35,6 +35,41 @@ small_pinned_host_memory_resource::~small_pinned_host_memory_resource()
 {
   // owned_allocations_ destructor returns upstream blocks to the free list.
   // free_lists_ entries are raw pointers into those blocks; no individual cleanup needed.
+  // Destroy every CUDA event we own — both idle (pooled) and still attached to a
+  // free slab that was never re-allocated.
+  for (auto& event : event_pool_) {
+    if (event != nullptr) { CUCASCADE_ASSERT_CUDA_SUCCESS(::cudaEventDestroy(event)); }
+  }
+  for (auto& list : free_lists_) {
+    for (auto& slab : list) {
+      if (slab.ready_event != nullptr) {
+        CUCASCADE_ASSERT_CUDA_SUCCESS(::cudaEventDestroy(slab.ready_event));
+      }
+    }
+  }
+}
+
+cudaEvent_t small_pinned_host_memory_resource::acquire_event_locked()
+{
+  if (!event_pool_.empty()) {
+    cudaEvent_t event = event_pool_.back();
+    event_pool_.pop_back();
+    return event;
+  }
+  cudaEvent_t event = nullptr;
+  // Timing is not needed; disabling it makes record/wait cheaper.
+  if (::cudaEventCreateWithFlags(&event, cudaEventDisableTiming) != cudaSuccess) {
+    // Best effort: without an event this deallocation loses stream ordering, but
+    // allocation must never throw here. Clear the sticky error and carry on.
+    (void)::cudaGetLastError();
+    return nullptr;
+  }
+  return event;
+}
+
+void small_pinned_host_memory_resource::release_event_locked(cudaEvent_t event) noexcept
+{
+  if (event != nullptr) { event_pool_.push_back(event); }
 }
 
 void* small_pinned_host_memory_resource::allocate([[maybe_unused]] cuda::stream_ref stream,
@@ -62,9 +97,18 @@ void* small_pinned_host_memory_resource::allocate([[maybe_unused]] cuda::stream_
   std::size_t idx = slab_index_for(bytes);
   std::lock_guard<std::mutex> lock(mutex_);
   if (free_lists_[idx].empty()) { expand_pool_locked(idx); }
-  void* ptr = free_lists_[idx].back();
+  free_slab slab = free_lists_[idx].back();
   free_lists_[idx].pop_back();
-  return ptr;
+  // If this slab was recently deallocated, its ready_event captures the freeing
+  // stream's last use (e.g. an in-flight async H2D copy still reading the slab).
+  // Make the reusing stream wait for it so we cannot overwrite the slab before
+  // that copy completes. Recording the event again (on a later deallocate) does
+  // not disturb this already-enqueued wait, so the event is safe to recycle.
+  if (slab.ready_event != nullptr) {
+    CUCASCADE_ASSERT_CUDA_SUCCESS(::cudaStreamWaitEvent(stream.get(), slab.ready_event, 0));
+    release_event_locked(slab.ready_event);
+  }
+  return slab.ptr;
 }
 
 void small_pinned_host_memory_resource::deallocate([[maybe_unused]] cuda::stream_ref stream,
@@ -80,7 +124,16 @@ void small_pinned_host_memory_resource::deallocate([[maybe_unused]] cuda::stream
 
   std::size_t idx = slab_index_for(bytes);
   std::lock_guard<std::mutex> lock(mutex_);
-  free_lists_[idx].push_back(ptr);
+  // Record an event on the freeing stream so a future reuse of this slab can wait
+  // for any still-pending work on it (the async H2D copy in cuDF's stats filter).
+  // Best effort: a null event just means this slab is recycled without ordering.
+  cudaEvent_t event = acquire_event_locked();
+  if (event != nullptr && ::cudaEventRecord(event, stream.get()) != cudaSuccess) {
+    (void)::cudaGetLastError();
+    release_event_locked(event);
+    event = nullptr;
+  }
+  free_lists_[idx].push_back(free_slab{ptr, event});
 }
 
 bool small_pinned_host_memory_resource::operator==(
@@ -107,7 +160,8 @@ void small_pinned_host_memory_resource::expand_pool_locked(std::size_t slab_idx)
   std::size_t num_slabs = upstream_block_size / slab_size;
   for (std::byte* block : allocation->get_blocks()) {
     for (std::size_t i = 0; i < num_slabs; ++i) {
-      free_lists_[slab_idx].push_back(block + i * slab_size);
+      // Freshly-carved slabs were never used, so they carry no pending-work event.
+      free_lists_[slab_idx].push_back(free_slab{block + i * slab_size, nullptr});
     }
   }
   owned_allocations_.push_back(std::move(allocation));


### PR DESCRIPTION
This PR is to fix the query validation error https://github.com/sirius-db/sirius/issues/1060
The root bug is in cudf https://github.com/rapidsai/cudf/issues/23178
This PR makes things work safely for now.

**Stream-order slab reuse in small_pinned_host_memory_resource**

The slab pool recycled freed pinned blocks immediately, ignoring the stream: deallocate pushed the slab straight onto the free list and allocate handed it back to the next caller with no ordering. When a consumer had an async H2D copy still reading a slab (e.g. cuDF's Parquet stats-filter min/max buffers, whose host_column::to_device copies async and doesn't synchronize before the source is freed), another task on a different stream could reuse that slab and overwrite it mid-copy â corrupting the data. In Sirius this surfaced as an intermittent (~1/800) filtered scan returning 0 rows (all row groups wrongly pruned) â wrong query results.

Change: make slab reuse stream-ordered via CUDA events.
- deallocate(stream, â¦) records a timing-disabled event on the freeing stream (capturing any in-flight use of the slab) and stores it alongside the slab on the free list.
- allocate(stream, â¦) issues cudaStreamWaitEvent before returning a recycled slab to a different stream, so the reusing stream can't touch the slab until the prior work completes; the event is then returned to a small internal pool for reuse.
- Freshly-carved slabs carry no event; events are best-effort (a creation/record failure just falls back to unordered reuse) and are destroyed in the destructor.

Buffers stay pinned (required â cuDF reads some of these directly from GPU kernels, so making them pageable would cause cudaErrorIllegalAddress); this only adds the missing cross-stream ordering.

Files: include/cucascade/memory/small_pinned_host_memory_resource.hpp, src/memory/small_pinned_host_memory_resource.cpp.