### PR TITLE
adds ability to set_num_partitions in a data_repository

### DIFF
--- a/include/cucascade/data/data_repository.hpp
+++ b/include/cucascade/data/data_repository.hpp
@@ -23,6 +23,8 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <stdexcept>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -275,6 +277,37 @@ class data_repository {
   {
     std::lock_guard<std::mutex> lock(_mutex);
     return _data_batches.size();
+  }
+
+  /**
+   * @brief Grow the number of partitions in the repository.
+   *
+   * Growing only: the new count must be strictly greater than the current count.
+   * Shrinking is not supported because it could discard batches that are already in
+   * flight.
+   *
+   * @param new_num_partitions The desired number of partitions. Must be strictly
+   *        greater than 0 and strictly greater than the current number of partitions.
+   *
+   * @note Thread-safe operation protected by internal mutex
+   * @throws std::invalid_argument if @p new_num_partitions is 0
+   * @throws std::invalid_argument if @p new_num_partitions is not strictly greater
+   *         than the current number of partitions
+   */
+  void set_num_partitions(std::size_t new_num_partitions)
+  {
+    std::lock_guard<std::mutex> lock(_mutex);
+    if (new_num_partitions == 0) {
+      throw std::invalid_argument(
+        "data_repository::set_num_partitions: new number of partitions must be greater than 0");
+    }
+    if (new_num_partitions <= _data_batches.size()) {
+      throw std::invalid_argument(
+        "data_repository::set_num_partitions: new number of partitions (" +
+        std::to_string(new_num_partitions) + ") must be greater than the current number (" +
+        std::to_string(_data_batches.size()) + ")");
+    }
+    _data_batches.resize(new_num_partitions);
   }
 
  protected:

--- a/test/data/test_data_repository.cpp
+++ b/test/data/test_data_repository.cpp
@@ -25,6 +25,7 @@
 #include <atomic>
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <thread>
 #include <type_traits>
 #include <vector>
@@ -475,6 +476,47 @@ TEST_CASE("data_repository pop Multiple Partitions", "[data_repository]")
   REQUIRE(retrieved_batch_ids1.empty());
   retrieved_batch_ids2 = repository.get_batch_ids(2);
   REQUIRE(retrieved_batch_ids2.empty());
+}
+
+TEST_CASE("data_repository set_num_partitions grows and validates size(p)", "[data_repository]")
+{
+  data_repository repository;
+
+  // A fresh repository starts with a single partition; size(p>0) is out of range.
+  REQUIRE(repository.num_partitions() == 1);
+  REQUIRE_THROWS_AS(repository.size(1), std::out_of_range);
+
+  // Growing to 4 partitions makes every index in [0, 4) queryable and empty.
+  repository.set_num_partitions(4);
+  REQUIRE(repository.num_partitions() == 4);
+  for (std::size_t p = 0; p < 4; ++p) {
+    REQUIRE(repository.size(p) == 0);
+  }
+
+  // Existing data in partition 0 is preserved across the grow.
+  auto data  = std::make_unique<mock_data_representation>(memory::Tier::GPU, 1024);
+  auto batch = data_batch::make(7, std::move(data));
+  repository.add_data_batch(batch, 3);
+  repository.set_num_partitions(8);
+  REQUIRE(repository.num_partitions() == 8);
+  REQUIRE(repository.size(3) == 1);
+  REQUIRE(repository.size(7) == 0);
+}
+
+TEST_CASE("data_repository set_num_partitions rejects non-growing counts", "[data_repository]")
+{
+  data_repository repository;
+  repository.set_num_partitions(3);
+
+  // Zero is never valid.
+  REQUIRE_THROWS_AS(repository.set_num_partitions(0), std::invalid_argument);
+
+  // Equal to or smaller than the current count is rejected (grow-only).
+  REQUIRE_THROWS_AS(repository.set_num_partitions(3), std::invalid_argument);
+  REQUIRE_THROWS_AS(repository.set_num_partitions(2), std::invalid_argument);
+
+  // The failed calls leave the partition count untouched.
+  REQUIRE(repository.num_partitions() == 3);
 }
 
 TEST_CASE("data_repository pop by id", "[data_repository]")


### PR DESCRIPTION
This PR is a companion to https://github.com/sirius-db/sirius/pull/1194

All it does is add a new API which allows for setting the number of partitions on a data_repository.
Before we were implicitly doing that by adding data_batches into a partition index, so it would resize automatically. That functionality is still there, but this allows you to explicitly set that and it will resize its internal containers