### PR TITLE
Add candidate lookup + strategy-hash cache to topology_index

### DIFF
--- a/include/cucascade/memory/memory_reservation_manager.hpp
+++ b/include/cucascade/memory/memory_reservation_manager.hpp
@@ -24,6 +24,7 @@
 #include <rmm/cuda_device.hpp>
 #include <rmm/cuda_stream_view.hpp>
 
+#include <atomic>
 #include <condition_variable>
 #include <filesystem>
 #include <memory>
@@ -43,6 +44,7 @@ class memory_reservation_manager;
 class reservation_aware_resource_adaptor;
 class fixed_size_host_memory_resource;
 class reservation;
+class topology_index;
 
 //===----------------------------------------------------------------------===//
 // Reservation Request Strategies
@@ -52,6 +54,21 @@ struct reservation_request_strategy {
   explicit reservation_request_strategy(bool strong_ordering) : _strong_ordering(strong_ordering) {}
 
   virtual std::vector<memory_space*> get_candidates(memory_reservation_manager& manager) const = 0;
+
+  /**
+   * @brief Stable hash identifying this request's candidate selection.
+   *
+   * Used by @c topology_index to memoize candidate lists: two strategies that would
+   * produce the same candidate set must hash equal, and strategies producing different
+   * sets should hash differently (collisions only cost cache accuracy, not safety).
+   *
+   * The default mixes only the dynamic type, which is correct for strategies whose
+   * candidate set is fully determined by their type.
+   *
+   * @note Subclasses whose candidate set varies with instance fields MUST override this
+   *       and mix those fields in; otherwise distinct instances share a cache entry.
+   */
+  [[nodiscard]] virtual std::size_t hash() const noexcept;
 
   [[nodiscard]] bool has_strong_ordering() const noexcept { return _strong_ordering; }
 
@@ -85,6 +102,7 @@ struct any_memory_space_in_tier_with_preference : public reservation_request_str
   }
 
   std::vector<memory_space*> get_candidates(memory_reservation_manager& manager) const override;
+  [[nodiscard]] std::size_t hash() const noexcept override;
 };
 
 /**
@@ -95,6 +113,7 @@ struct any_memory_space_in_tier : public reservation_request_strategy {
   explicit any_memory_space_in_tier(Tier t) : reservation_request_strategy(false), tier(t) {}
 
   std::vector<memory_space*> get_candidates(memory_reservation_manager& manager) const override;
+  [[nodiscard]] std::size_t hash() const noexcept override;
 };
 
 /**
@@ -110,6 +129,7 @@ struct any_memory_space_in_tiers : public reservation_request_strategy {
   }
 
   std::vector<memory_space*> get_candidates(memory_reservation_manager& manager) const override;
+  [[nodiscard]] std::size_t hash() const noexcept override;
 };
 
 /**
@@ -125,6 +145,7 @@ struct specific_memory_space : public reservation_request_strategy {
   }
 
   std::vector<memory_space*> get_candidates(memory_reservation_manager& manager) const override;
+  [[nodiscard]] std::size_t hash() const noexcept override;
 };
 
 /**
@@ -145,6 +166,7 @@ struct any_memory_space_to_downgrade : public reservation_request_strategy {
   }
 
   std::vector<memory_space*> get_candidates(memory_reservation_manager& manager) const override;
+  [[nodiscard]] std::size_t hash() const noexcept override;
 };
 
 /**
@@ -160,6 +182,7 @@ struct any_memory_space_to_upgrade : public reservation_request_strategy {
   }
 
   std::vector<memory_space*> get_candidates(memory_reservation_manager& manager) const override;
+  [[nodiscard]] std::size_t hash() const noexcept override;
 };
 
 //===----------------------------------------------------------------------===//
@@ -234,6 +257,26 @@ class memory_reservation_manager {
   std::span<const memory_space*> get_all_memory_spaces() const noexcept;
 
   //===----------------------------------------------------------------------===//
+  // Topology Index
+  //===----------------------------------------------------------------------===//
+
+  /**
+   * Attach a topology_index that this manager uses to resolve (and memoize) candidate
+   * memory spaces for reservation requests. Typically built via
+   * cucascade::memory::build(topology, manager) after construction, then set here.
+   *
+   * @note The index holds a non-owning back-pointer to this manager, so it must not
+   *       outlive it. Passing nullptr detaches the index (candidate selection falls back
+   *       to computing directly from each request's strategy).
+   */
+  void set_topology_index(std::shared_ptr<const topology_index> index);
+
+  /**
+   * The currently attached topology_index, or nullptr if none is set.
+   */
+  [[nodiscard]] std::shared_ptr<const topology_index> get_topology_index() const noexcept;
+
+  //===----------------------------------------------------------------------===//
   // Aggregated Queries
   //===----------------------------------------------------------------------===//
 
@@ -264,6 +307,12 @@ class memory_reservation_manager {
   std::unordered_map<memory_space_id, memory_space*> _memory_space_lookup;
   std::unordered_map<Tier, std::vector<memory_space*>> _tier_to_memory_spaces;
   std::unordered_map<Tier, std::vector<const memory_space*>> _const_tier_to_memory_spaces;
+
+  // Optional topology index used to resolve/memoize reservation candidates (non-owning
+  // back-pointer to this manager lives inside the index; see set_topology_index).
+  // Atomic so the reservation hot path can load-and-pin it without tearing against a
+  // concurrent set_topology_index().
+  std::atomic<std::shared_ptr<const topology_index>> _topology_index;
 
   // Helper method: attempts to select a space and immediately make a reservation
   // Returns a reservation when successful, or std::nullopt if none can satisfy the request

--- a/include/cucascade/memory/topology_index.hpp
+++ b/include/cucascade/memory/topology_index.hpp
@@ -18,9 +18,15 @@
 
 #pragma once
 
+#include <cucascade/error.hpp>
 #include <cucascade/memory/memory_reservation_manager.hpp>
 #include <cucascade/memory/topology_discovery.hpp>
 
+#include <algorithm>
+#include <cstddef>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
 #include <span>
 #include <unordered_map>
 #include <utility>
@@ -77,9 +83,14 @@ class topology_index {
   ///
   /// @param topology  the system topology to resolve NUMA nodes from.
   /// @param manager   reservation manager whose GPU/HOST spaces define the scope.
+  ///
+  /// @note The index keeps a non-owning back-pointer to @p manager so it can resolve
+  ///       memory spaces and candidates on demand.  The manager MUST outlive this index
+  ///       (the manager-dependent accessors @c get_spaces_of and @c get_candidates are
+  ///       undefined otherwise); the NUMA accessors do not touch the manager.
   topology_index(cucascade::memory::system_topology_info topology,
-                 const cucascade::memory::memory_reservation_manager& manager)
-    : _topology(std::move(topology))
+                 cucascade::memory::memory_reservation_manager& manager)
+    : _topology(std::move(topology)), _manager(&manager)
   {
     auto extract_ids = [](cucascade::memory::Tier tier) {
       return [tier](const cucascade::memory::memory_reservation_manager& manager) {
@@ -113,6 +124,17 @@ class topology_index {
       _gpu_to_numa[gpu_id] = numa_node;
       _numa_to_gpus[numa_node].push_back(gpu_id);
     }
+
+    // Snapshot the manager's memory spaces per tier so get_spaces_of() can hand out both
+    // mutable and const views without re-querying the manager on every call.  Mutable
+    // pointers are recovered via the manager's non-const lookup to avoid const_cast.
+    for (const auto* space : manager.get_all_memory_spaces()) {
+      cucascade::memory::Tier const tier = space->get_tier();
+      cucascade::memory::memory_space* mutable_space =
+        manager.get_memory_space(tier, space->get_device_id());
+      _tier_spaces[tier].push_back(mutable_space);
+      _const_tier_spaces[tier].push_back(mutable_space);
+    }
   }
 
   /// @brief The topology this index was built from.
@@ -145,11 +167,103 @@ class topology_index {
 
   [[nodiscard]] std::span<const int> gpu_ids() const noexcept { return _gpu_ids; }
 
+  /// @brief Mutable memory spaces in @p tier (snapshot taken at build time).
+  /// @return a view of the manager's spaces for that tier, or an empty span if none.
+  ///         The span is valid for the lifetime of this index.
+  [[nodiscard]] std::span<cucascade::memory::memory_space*> get_spaces_of(
+    cucascade::memory::Tier tier)
+  {
+    auto it = _tier_spaces.find(tier);
+    if (it == _tier_spaces.end()) { return {}; }
+    return it->second;
+  }
+
+  /// @brief Const memory spaces in @p tier (snapshot taken at build time).
+  /// @return a read-only view of the manager's spaces for that tier, or an empty span.
+  [[nodiscard]] std::span<const cucascade::memory::memory_space*> get_spaces_of(
+    cucascade::memory::Tier tier) const
+  {
+    auto it = _const_tier_spaces.find(tier);
+    if (it == _const_tier_spaces.end()) { return {}; }
+    // span<const memory_space*> binds to a non-const vector of const pointers; the
+    // const_cast drops only the container's constness, not the pointees' (same pattern as
+    // memory_reservation_manager::get_memory_spaces_for_tier).
+    return const_cast<std::vector<const cucascade::memory::memory_space*>&>(it->second);
+  }
+
+  /// @brief Candidate memory spaces for a reservation @p strategy, memoized by its hash.
+  ///
+  /// The first call for a given @c strategy.hash() computes the candidate list via the
+  /// strategy and caches it; later calls with an equal hash return the cached span
+  /// directly.  Candidate *sets* depend only on the topology (live free-memory is checked
+  /// later, when a reservation is actually made), so caching by strategy identity is
+  /// sound.
+  ///
+  /// @return a view of the candidate spaces, valid for the lifetime of this index.
+  /// @throws cucascade::logic_error if this index was not built from a reservation
+  ///         manager (the device-ids constructor cannot resolve candidates).
+  [[nodiscard]] std::span<cucascade::memory::memory_space*> get_candidates(
+    const cucascade::memory::reservation_request_strategy& strategy) const
+  {
+    if (_manager == nullptr) {
+      CUCASCADE_FAIL("topology_index::get_candidates requires an index built from a manager");
+    }
+    std::size_t const key = strategy.hash();
+
+    // Fast path: concurrent readers share the lock on a cache hit.
+    {
+      std::shared_lock<std::shared_mutex> read_lock(_candidate_mutex);
+      auto it = _candidate_cache.find(key);
+      if (it != _candidate_cache.end()) { return it->second; }
+    }
+
+    // Cache miss: compute outside the lock (the manager's space set is immutable), then
+    // insert under an exclusive lock.  A concurrent miss on the same key is harmless:
+    // emplace keeps the first inserted value and both callers return the same node.
+    std::vector<cucascade::memory::memory_space*> computed = strategy.get_candidates(*_manager);
+    std::unique_lock<std::shared_mutex> write_lock(_candidate_mutex);
+    // References into an unordered_map node stay valid across later inserts, and cached
+    // entries are never mutated after insertion, so the returned span outlives the lock.
+    return _candidate_cache.emplace(key, std::move(computed)).first->second;
+  }
+
  private:
   cucascade::memory::system_topology_info _topology;
   std::unordered_map<int, int> _gpu_to_numa;                ///< GPU device id -> NUMA node.
   std::unordered_map<int, std::vector<int>> _numa_to_gpus;  ///< NUMA node -> GPU device ids.
   std::vector<int> _gpu_ids;  ///< Scoped GPU device ids, in caller order (for span stability).
+
+  /// Non-owning back-pointer to the manager the index was built from (nullptr when built
+  /// from explicit device ids).  The manager must outlive this index.
+  cucascade::memory::memory_reservation_manager* _manager{nullptr};
+
+  /// Per-tier memory-space snapshots (mutable + const views over the same pointers).
+  std::unordered_map<cucascade::memory::Tier, std::vector<cucascade::memory::memory_space*>>
+    _tier_spaces;
+  std::unordered_map<cucascade::memory::Tier, std::vector<const cucascade::memory::memory_space*>>
+    _const_tier_spaces;
+
+  /// Candidate lists memoized by reservation-strategy hash.  Mutable so get_candidates can
+  /// populate the cache while remaining a const query.  A shared_mutex lets concurrent
+  /// cache hits proceed in parallel; only the (rare) insert takes the lock exclusively.
+  mutable std::shared_mutex _candidate_mutex;
+  mutable std::unordered_map<std::size_t, std::vector<cucascade::memory::memory_space*>>
+    _candidate_cache;
 };
+
+/// @brief Build a topology index scoped to a reservation manager's memory spaces.
+///
+/// Convenience factory returning a shared, immutable index.  The index keeps a non-owning
+/// back-pointer to @p manager, so @p manager must outlive the returned index.
+///
+/// @param topology  the system topology to resolve NUMA nodes from.
+/// @param manager   reservation manager whose GPU/HOST spaces define the scope.
+/// @return a shared const topology index.
+[[nodiscard]] inline std::shared_ptr<const topology_index> build(
+  cucascade::memory::system_topology_info topology,
+  cucascade::memory::memory_reservation_manager& manager)
+{
+  return std::make_shared<const topology_index>(std::move(topology), manager);
+}
 
 }  // namespace cucascade::memory

--- a/src/memory/memory_reservation_manager.cpp
+++ b/src/memory/memory_reservation_manager.cpp
@@ -20,6 +20,7 @@
 #include <cucascade/memory/memory_reservation_manager.hpp>
 #include <cucascade/memory/memory_space.hpp>
 #include <cucascade/memory/numa_region_pinned_host_allocator.hpp>
+#include <cucascade/memory/topology_index.hpp>
 #include <cucascade/utils/overloaded.hpp>
 
 #include <rmm/cuda_device.hpp>
@@ -29,14 +30,76 @@
 #include <cstdint>
 #include <mutex>
 #include <stdexcept>
+#include <typeinfo>
 #include <variant>
 
 namespace cucascade {
 namespace memory {
 
+namespace {
+
+// Fold an additional value into a running hash seed (boost::hash_combine formula, 64-bit).
+std::size_t hash_combine(std::size_t seed, std::size_t value) noexcept
+{
+  return seed ^ (value + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2));
+}
+
+}  // namespace
+
 //===----------------------------------------------------------------------===//
 // Reservation Strategy Implementations
 //===----------------------------------------------------------------------===//
+
+std::size_t reservation_request_strategy::hash() const noexcept
+{
+  return typeid(*this).hash_code();
+}
+
+std::size_t any_memory_space_in_tier_with_preference::hash() const noexcept
+{
+  std::size_t seed = typeid(*this).hash_code();
+  seed             = hash_combine(seed, static_cast<std::size_t>(tier));
+  seed             = hash_combine(seed, preferred_device_id.has_value() ? *preferred_device_id : 0);
+  seed             = hash_combine(seed, preferred_device_id.has_value() ? 1u : 0u);
+  return seed;
+}
+
+std::size_t any_memory_space_in_tier::hash() const noexcept
+{
+  return hash_combine(typeid(*this).hash_code(), static_cast<std::size_t>(tier));
+}
+
+std::size_t any_memory_space_in_tiers::hash() const noexcept
+{
+  std::size_t seed = typeid(*this).hash_code();
+  for (Tier t : tiers) {
+    seed = hash_combine(seed, static_cast<std::size_t>(t));
+  }
+  return seed;
+}
+
+std::size_t specific_memory_space::hash() const noexcept
+{
+  return hash_combine(typeid(*this).hash_code(), target_id.uuid());
+}
+
+std::size_t any_memory_space_to_downgrade::hash() const noexcept
+{
+  std::size_t seed = typeid(*this).hash_code();
+  seed             = hash_combine(seed, src_id.uuid());
+  for (Tier t : target_tiers) {
+    seed = hash_combine(seed, static_cast<std::size_t>(t));
+  }
+  return seed;
+}
+
+std::size_t any_memory_space_to_upgrade::hash() const noexcept
+{
+  std::size_t seed = typeid(*this).hash_code();
+  seed             = hash_combine(seed, src_id.uuid());
+  seed             = hash_combine(seed, static_cast<std::size_t>(target_tier));
+  return seed;
+}
 
 std::span<memory_space*> reservation_request_strategy::get_all_memory_resource(
   memory_reservation_manager& manager)
@@ -191,6 +254,17 @@ std::span<const memory_space*> memory_reservation_manager::get_all_memory_spaces
   return const_cast<std::vector<const memory_space*>&>(_const_memory_space_views);
 }
 
+void memory_reservation_manager::set_topology_index(std::shared_ptr<const topology_index> index)
+{
+  _topology_index.store(std::move(index));
+}
+
+std::shared_ptr<const topology_index> memory_reservation_manager::get_topology_index()
+  const noexcept
+{
+  return _topology_index.load();
+}
+
 memory_space* memory_reservation_manager::get_mutable_memory_space(Tier tier, int32_t device_id)
 {
   memory_space_id id(tier, device_id);
@@ -302,7 +376,21 @@ memory_reservation_manager::select_memory_space_and_make_reservation(
   };
 
   bool has_strong_ordering = request.has_strong_ordering();
-  auto candidates          = request.get_candidates(*this);
+
+  // Resolve candidates through the topology index (memoized by strategy hash) when one is
+  // attached; otherwise compute them directly from the request.  Pin the index in a local
+  // shared_ptr so a concurrent set_topology_index() cannot free the cache backing the
+  // returned span while it is still in use below.
+  std::shared_ptr<const topology_index> index = _topology_index.load();
+  std::vector<memory_space*> fallback;
+  std::span<memory_space*> candidates;
+  if (index) {
+    candidates = index->get_candidates(request);
+  } else {
+    fallback   = request.get_candidates(*this);
+    candidates = fallback;
+  }
+
   if (has_strong_ordering) {
     return try_candidates(candidates, &memory_space::make_reservation, size);
   } else {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,7 @@ if(NOT CUCASCADE_TOPOLOGY_ONLY)
     # Memory tests
     memory/test_memory_reservation_manager.cpp
     memory/test_small_pinned_host_memory_resource.cpp
+    memory/test_topology_index.cpp
     memory/test_gpu_kernels.cu
     # Data tests
     data/test_data_repository.cpp

--- a/test/memory/test_topology_index.cpp
+++ b/test/memory/test_topology_index.cpp
@@ -1,0 +1,178 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Test Tags:
+ * [topology_index] - topology_index space/candidate lookup + strategy-hash cache
+ * [gpu] - requires CUDA (memory spaces are backed by real device/host resources)
+ */
+
+#include "utils/test_memory_resources.hpp"
+
+#include <cucascade/error.hpp>
+#include <cucascade/memory/common.hpp>
+#include <cucascade/memory/memory_reservation.hpp>
+#include <cucascade/memory/memory_reservation_manager.hpp>
+#include <cucascade/memory/memory_space.hpp>
+#include <cucascade/memory/reservation_manager_configurator.hpp>
+#include <cucascade/memory/topology_discovery.hpp>
+#include <cucascade/memory/topology_index.hpp>
+
+#include <catch2/catch.hpp>
+
+#include <memory>
+#include <vector>
+
+using namespace cucascade::memory;
+
+namespace {
+
+constexpr size_t gpu_capacity  = 2ull << 30;  // 2 GB
+constexpr size_t host_capacity = 4ull << 30;  // 4 GB
+constexpr double limit_ratio   = 0.75;
+
+std::unique_ptr<memory_reservation_manager> make_single_device_manager()
+{
+  reservation_manager_configurator builder;
+  builder.set_gpu_usage_limit(gpu_capacity);
+  builder.set_gpu_memory_resource_factory(cucascade::test::make_shared_current_device_resource);
+  builder.set_reservation_fraction_per_gpu(limit_ratio);
+  builder.set_per_host_capacity(host_capacity);
+  builder.use_host_per_gpu();
+  builder.set_reservation_fraction_per_host(limit_ratio);
+  return std::make_unique<memory_reservation_manager>(builder.build());
+}
+
+// Minimal topology describing a single GPU on NUMA node 0.
+system_topology_info single_gpu_topology()
+{
+  system_topology_info topology{};
+  topology.hostname            = "test-host";
+  topology.num_gpus            = 1;
+  topology.num_numa_nodes      = 1;
+  topology.num_network_devices = 0;
+  gpu_topology_info gpu{};
+  gpu.id        = 0;
+  gpu.numa_node = 0;
+  topology.gpus.push_back(gpu);
+  return topology;
+}
+
+}  // namespace
+
+TEST_CASE("topology_index::build exposes per-tier spaces", "[topology_index][gpu]")
+{
+  auto manager = make_single_device_manager();
+  auto index   = build(single_gpu_topology(), *manager);
+  REQUIRE(index != nullptr);
+
+  // NUMA mapping still works (GPU 0 -> NUMA 0, cross-checked against the HOST space).
+  REQUIRE(index->numa_node_of(0) == 0);
+
+  // Const overload of get_spaces_of.
+  auto gpu_spaces = index->get_spaces_of(Tier::GPU);
+  REQUIRE(gpu_spaces.size() == 1);
+  REQUIRE(gpu_spaces[0]->get_tier() == Tier::GPU);
+  REQUIRE(gpu_spaces[0]->get_device_id() == 0);
+
+  auto host_spaces = index->get_spaces_of(Tier::HOST);
+  REQUIRE(host_spaces.size() == 1);
+  REQUIRE(host_spaces[0]->get_tier() == Tier::HOST);
+
+  // A tier with no configured spaces yields an empty span.
+  REQUIRE(index->get_spaces_of(Tier::DISK).empty());
+}
+
+TEST_CASE("topology_index mutable and const get_spaces_of agree", "[topology_index][gpu]")
+{
+  auto manager = make_single_device_manager();
+  // Non-const index to reach the mutable overload.
+  topology_index index(single_gpu_topology(), *manager);
+
+  std::span<memory_space*> mutable_spaces     = index.get_spaces_of(Tier::GPU);
+  std::span<const memory_space*> const_spaces = std::as_const(index).get_spaces_of(Tier::GPU);
+
+  REQUIRE(mutable_spaces.size() == const_spaces.size());
+  REQUIRE(mutable_spaces.size() == 1);
+  REQUIRE(mutable_spaces[0] == const_spaces[0]);  // same underlying space
+}
+
+TEST_CASE("reservation_request_strategy::hash distinguishes strategies", "[topology_index]")
+{
+  // Type + field sensitivity.
+  REQUIRE(any_memory_space_in_tier(Tier::GPU).hash() == any_memory_space_in_tier(Tier::GPU).hash());
+  REQUIRE(any_memory_space_in_tier(Tier::GPU).hash() !=
+          any_memory_space_in_tier(Tier::HOST).hash());
+
+  // Different concrete types hash differently even for the same tier.
+  REQUIRE(any_memory_space_in_tier(Tier::GPU).hash() !=
+          any_memory_space_in_tier_with_preference(Tier::GPU).hash());
+
+  // Field sensitivity on specific_memory_space.
+  REQUIRE(specific_memory_space(Tier::GPU, 0).hash() == specific_memory_space(Tier::GPU, 0).hash());
+  REQUIRE(specific_memory_space(Tier::GPU, 0).hash() != specific_memory_space(Tier::GPU, 1).hash());
+
+  // Preference presence changes the hash.
+  REQUIRE(any_memory_space_in_tier_with_preference(Tier::GPU).hash() !=
+          any_memory_space_in_tier_with_preference(Tier::GPU, 0).hash());
+
+  // Ordered tier list is order-sensitive.
+  REQUIRE(any_memory_space_in_tiers({Tier::GPU, Tier::HOST}).hash() !=
+          any_memory_space_in_tiers({Tier::HOST, Tier::GPU}).hash());
+}
+
+TEST_CASE("topology_index::get_candidates memoizes and matches the strategy",
+          "[topology_index][gpu]")
+{
+  auto manager = make_single_device_manager();
+  auto index   = build(single_gpu_topology(), *manager);
+
+  any_memory_space_in_tier strategy(Tier::GPU);
+
+  auto expected  = strategy.get_candidates(*manager);
+  auto candidate = index->get_candidates(strategy);
+  REQUIRE(candidate.size() == expected.size());
+  REQUIRE(candidate.size() == 1);
+  REQUIRE(candidate[0] == expected[0]);
+
+  // Second call with an equal-hash strategy is a cache hit: identical backing storage.
+  any_memory_space_in_tier same_strategy(Tier::GPU);
+  auto candidate2 = index->get_candidates(same_strategy);
+  REQUIRE(candidate2.data() == candidate.data());
+  REQUIRE(candidate2.size() == candidate.size());
+}
+
+TEST_CASE("topology_index::get_candidates without a manager throws", "[topology_index]")
+{
+  // The device-ids constructor leaves the index without a manager back-pointer.
+  topology_index index(single_gpu_topology(), std::vector<int>{0});
+  any_memory_space_in_tier strategy(Tier::GPU);
+  REQUIRE_THROWS_AS(index.get_candidates(strategy), cucascade::logic_error);
+}
+
+TEST_CASE("reservation manager routes candidate selection through the index",
+          "[topology_index][gpu]")
+{
+  auto manager = make_single_device_manager();
+  manager->set_topology_index(build(single_gpu_topology(), *manager));
+  REQUIRE(manager->get_topology_index() != nullptr);
+
+  // A reservation still succeeds through the memoized candidate path.
+  any_memory_space_in_tier strategy(Tier::GPU);
+  auto res = manager->request_reservation(strategy, 1ull << 20);  // 1 MB
+  REQUIRE(res != nullptr);
+}


### PR DESCRIPTION
## Summary

Grows `topology_index` into the place that resolves and memoizes reservation candidates, and wires it into `memory_reservation_manager`.

- **`reservation_request_strategy::hash()`** — new virtual method (typeid-based default, kept **non-pure** so downstream custom strategies still compile) overridden by all six strategies to mix their fields; backed by a file-local `hash_combine` helper.
- **`topology_index`** — new `get_spaces_of(tier)` (mutable + const overloads), `get_candidates(strategy)` memoized by strategy hash under a `std::shared_mutex` (concurrent cache hits, exclusive lock only on insert), and a `build(topology, manager)` factory. The index keeps a non-owning back-pointer to the manager (documented: the manager must outlive the index). Existing `numa_node_of`/`gpus_of`/`gpu_ids` and both constructors are unchanged, so `io_context`/`prefetching_cache` keep compiling.
- **`memory_reservation_manager`** — holds an `std::atomic<std::shared_ptr<const topology_index>>` with `set_/get_topology_index`, and routes `select_memory_space_and_make_reservation` through the memoized candidate path. The index is loaded into a local `shared_ptr` and pinned for the lifetime of the returned candidate span, so a concurrent `set_topology_index()` can't free the cache mid-use.

## Design notes

- Candidate **sets** depend only on the topology (live free-memory is still checked at reservation time), and the manager's memory-space set is immutable after construction — so memoizing candidates by strategy identity is sound.
- Cache key is the 64-bit `strategy.hash()`; collisions only cost cache accuracy, not safety.

## Testing

New `test/memory/test_topology_index.cpp` (6 cases, 26 assertions) covering `build()`, both `get_spaces_of` overloads, `hash()` distinctions, candidate memoization (cache-hit returns identical backing storage), the no-manager throw, and end-to-end reservation routing.

- `pixi run build` links cleanly.
- `[topology_index]` (26 assertions) and `[memory_space]` (173 assertions) suites pass on an RTX 6000 Ada.
- clang-format pre-commit hook passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)