### PR TITLE
fix(memory): propagate GPU pool handle to the reservation adaptor

### DIFF
--- a/src/memory/common.cpp
+++ b/src/memory/common.cpp
@@ -252,7 +252,13 @@ cuda::mr::any_resource<cuda::mr::device_accessible> make_default_gpu_memory_reso
   int device_id, size_t capacity)
 {
   rmm::cuda_set_device_raii set_device(rmm::cuda_device_id{device_id});
-  return {rmm::mr::cuda_async_memory_resource(capacity)};
+  rmm::mr::cuda_async_memory_resource mr(capacity);
+  // Expose the pool as the device's current mem pool so the handle survives the
+  // type-erasure below; RMM still allocates from its own explicit pool regardless.
+  if (cudaDeviceSetMemPool(device_id, mr.pool_handle()) != cudaSuccess) {
+    (void)cudaGetLastError();  // best effort
+  }
+  return {std::move(mr)};
 }
 
 cuda::mr::any_resource<cuda::mr::device_accessible, cuda::mr::host_accessible>

--- a/src/memory/memory_space.cpp
+++ b/src/memory/memory_space.cpp
@@ -115,6 +115,13 @@ memory_space::memory_space(const gpu_memory_space_config& config)
 
   if (config.mr_factory_fn) {
     _allocator = config.mr_factory_fn(config.device_id, config.memory_capacity);
+    // The factory type-erases its resource, losing the pool handle; recover it from
+    // the device's current mem pool so pool-aware OOM policies can inspect/trim it.
+    rmm::cuda_set_device_raii set_device(rmm::cuda_device_id{config.device_id});
+    if (cudaDeviceGetMemPool(&pool_handle, config.device_id) != cudaSuccess) {
+      pool_handle = nullptr;
+      (void)cudaGetLastError();
+    }
   } else {
     rmm::cuda_set_device_raii set_device(rmm::cuda_device_id{config.device_id});
     rmm::mr::cuda_async_memory_resource concrete_mr(config.memory_capacity);


### PR DESCRIPTION
This fix was created after noticing that the OOM resolving code in Sirius (trim the pool and device sync) never actually fires because the pool is null in the OOM handler.

The GPU memory_space builds its allocator through config.mr_factory_fn (the default path when using the reservation_manager_configurator), which returns a type-erased any_resource. The concrete cuda_async_memory_resource's cudaMallocAsync pool handle was therefore never captured, and the reservation_aware_resource_adaptor was constructed with a null pool_handle.

With a null handle, cucascade_out_of_memory carries no pool, so any OOM-handling policy that inspects or trims the pool bails immediately and never runs.

Publish the default resource's pool as the device's current mem pool (cudaDeviceSetMemPool) and recover it in memory_space (cudaDeviceGetMemPool) on the factory path. RMM allocates via cudaMallocFromPoolAsync with its own explicit pool, so making it the device's current pool does not change how RMM allocates. A custom factory that does not publish leaves the handle at the device default pool.