### PR TITLE
Make invocable and moodycamel backends swappable for host embedding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,13 +69,25 @@ set(CUCASCADE_ABSEIL_INVOCABLE_TARGET
       "abseil any_invocable CMake target to link (default: absl::any_invocable)"
 )
 
-# Existing moodycamel concurrentqueue target to link (e.g. sirius's
-# duckdb_moodycamel). If empty, cameron314/concurrentqueue is fetched.
+# How to obtain moodycamel's concurrentqueue headers. Resolution order: 1.
+# CUCASCADE_MOODYCAMEL_TARGET  - link an existing CMake target that carries the
+# include dirs (e.g. a host-provided interface target). 2.
+# CUCASCADE_MOODYCAMEL_INCLUDE_DIR - a directory already holding
+# blockingconcurrentqueue.h / concurrentqueue.h (e.g. sirius's
+# duckdb/third_party/concurrentqueue). Nothing is fetched. 3. neither set -
+# fetch cameron314/concurrentqueue.
 set(CUCASCADE_MOODYCAMEL_TARGET
     ""
     CACHE
       STRING
       "moodycamel concurrentqueue CMake target to link (default: fetch cameron314/concurrentqueue)"
+)
+
+set(CUCASCADE_MOODYCAMEL_INCLUDE_DIR
+    ""
+    CACHE
+      PATH
+      "Directory containing moodycamel concurrentqueue headers (skips fetching; ignored if CUCASCADE_MOODYCAMEL_TARGET is set)"
 )
 
 # C++ namespace of the moodycamel headers. duckdb's fork (used by sirius)
@@ -159,8 +171,8 @@ if(NOT CUCASCADE_TOPOLOGY_ONLY)
                 cucascade_io_thirdparty)
 
     # moodycamel::ConcurrentQueue — header-only lock-free MPMC queues used by
-    # the reactors and the prefetching cache. Reuse a host-provided target if
-    # given, otherwise fetch cameron314's upstream.
+    # the reactors and the prefetching cache. Reuse a host-provided target or
+    # include dir if given, otherwise fetch cameron314's upstream.
     if(CUCASCADE_MOODYCAMEL_TARGET)
       message(
         STATUS
@@ -169,6 +181,14 @@ if(NOT CUCASCADE_TOPOLOGY_ONLY)
       target_link_libraries(
         cucascade_io_thirdparty
         INTERFACE $<BUILD_INTERFACE:${CUCASCADE_MOODYCAMEL_TARGET}>)
+    elseif(CUCASCADE_MOODYCAMEL_INCLUDE_DIR)
+      message(
+        STATUS
+          "cucascade-io: using provided moodycamel include dir '${CUCASCADE_MOODYCAMEL_INCLUDE_DIR}' (namespace ${CUCASCADE_MOODYCAMEL_NAMESPACE})"
+      )
+      target_include_directories(
+        cucascade_io_thirdparty
+        INTERFACE $<BUILD_INTERFACE:${CUCASCADE_MOODYCAMEL_INCLUDE_DIR}>)
     else()
       include(FetchContent)
       FetchContent_Declare(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,44 @@ option(
   "Build the S3 parquet benchmark (requires aws-sdk-cpp; NOT a cuCascade dependency)"
   OFF)
 
+# Swappable third-party backends for the io layer. The io code was ported from a
+# codebase with its own vendored dependencies. These knobs let an embedding host
+# (e.g. sirius) reuse the copies it already links instead of the
+# standalone-build defaults.
+
+# cucascade::exec::invocable backing: OFF -> in-tree move-only callable; ON ->
+# absl::AnyInvocable (reuses a host project's abseil).
+option(
+  CUCASCADE_USE_ABSEIL_INVOCABLE
+  "Back cucascade::exec::invocable with absl::AnyInvocable instead of the built-in implementation"
+  OFF)
+
+# Existing abseil any_invocable target to link when
+# CUCASCADE_USE_ABSEIL_INVOCABLE is ON. If empty, an already-defined
+# absl::any_invocable target is used when present, otherwise find_package(absl)
+# is invoked.
+set(CUCASCADE_ABSEIL_INVOCABLE_TARGET
+    ""
+    CACHE
+      STRING
+      "abseil any_invocable CMake target to link (default: absl::any_invocable)"
+)
+
+# Existing moodycamel concurrentqueue target to link (e.g. sirius's
+# duckdb_moodycamel). If empty, cameron314/concurrentqueue is fetched.
+set(CUCASCADE_MOODYCAMEL_TARGET
+    ""
+    CACHE
+      STRING
+      "moodycamel concurrentqueue CMake target to link (default: fetch cameron314/concurrentqueue)"
+)
+
+# C++ namespace of the moodycamel headers. duckdb's fork (used by sirius)
+# renames it to duckdb_moodycamel; upstream cameron314 uses moodycamel.
+set(CUCASCADE_MOODYCAMEL_NAMESPACE
+    "moodycamel"
+    CACHE STRING "C++ namespace of the moodycamel concurrentqueue headers")
+
 # The io core is cudf-free (the cudf::io::datasource bridge lives in the
 # cucascade-cudf bundle); it only requires a full (non-topology-only) build.
 if(CUCASCADE_BUILD_IO AND CUCASCADE_TOPOLOGY_ONLY)
@@ -108,14 +146,68 @@ if(NOT CUCASCADE_TOPOLOGY_ONLY)
     pkg_check_modules(CURL REQUIRED IMPORTED_TARGET libcurl)
     find_package(OpenSSL REQUIRED)
 
+    # cucascade_io_thirdparty carries the swappable moodycamel + invocable
+    # (abseil) usage requirements from a single place; the io object library,
+    # its installable static/shared variants, and their in-tree consumers
+    # (cucascade-cudf, benchmarks) all inherit them by linking this target.
+    # External targets/include dirs are wrapped in $<BUILD_INTERFACE:...> so the
+    # exported package stays clean: an installed consumer supplies its own
+    # moodycamel/abseil (as before), while the propagated compile definitions
+    # keep the namespace/backend choice consistent across the boundary.
+    add_library(cucascade_io_thirdparty INTERFACE)
+    add_library(cuCascade::cucascade_io_thirdparty ALIAS
+                cucascade_io_thirdparty)
+
     # moodycamel::ConcurrentQueue — header-only lock-free MPMC queues used by
-    # the reactors and the prefetching cache.
-    include(FetchContent)
-    FetchContent_Declare(
-      concurrentqueue
-      GIT_REPOSITORY https://github.com/cameron314/concurrentqueue.git
-      GIT_TAG v1.0.4)
-    FetchContent_MakeAvailable(concurrentqueue)
+    # the reactors and the prefetching cache. Reuse a host-provided target if
+    # given, otherwise fetch cameron314's upstream.
+    if(CUCASCADE_MOODYCAMEL_TARGET)
+      message(
+        STATUS
+          "cucascade-io: using provided moodycamel target '${CUCASCADE_MOODYCAMEL_TARGET}' (namespace ${CUCASCADE_MOODYCAMEL_NAMESPACE})"
+      )
+      target_link_libraries(
+        cucascade_io_thirdparty
+        INTERFACE $<BUILD_INTERFACE:${CUCASCADE_MOODYCAMEL_TARGET}>)
+    else()
+      include(FetchContent)
+      FetchContent_Declare(
+        concurrentqueue
+        GIT_REPOSITORY https://github.com/cameron314/concurrentqueue.git
+        GIT_TAG v1.0.4)
+      FetchContent_MakeAvailable(concurrentqueue)
+      target_include_directories(
+        cucascade_io_thirdparty
+        INTERFACE $<BUILD_INTERFACE:${concurrentqueue_SOURCE_DIR}>)
+    endif()
+    target_compile_definitions(
+      cucascade_io_thirdparty
+      INTERFACE CUCASCADE_MOODYCAMEL_NAMESPACE=${CUCASCADE_MOODYCAMEL_NAMESPACE}
+    )
+
+    # cucascade::exec::invocable backend. When abseil is requested, reuse a
+    # provided target, else an already-defined absl::any_invocable, else
+    # find_package(absl). The compile definition is propagated to consumers so
+    # the header resolves to the same backend on both sides of the boundary.
+    if(CUCASCADE_USE_ABSEIL_INVOCABLE)
+      if(CUCASCADE_ABSEIL_INVOCABLE_TARGET)
+        set(_cucascade_absl_target ${CUCASCADE_ABSEIL_INVOCABLE_TARGET})
+      elseif(TARGET absl::any_invocable)
+        set(_cucascade_absl_target absl::any_invocable)
+      else()
+        find_package(absl CONFIG REQUIRED)
+        set(_cucascade_absl_target absl::any_invocable)
+      endif()
+      message(
+        STATUS
+          "cucascade::exec::invocable backed by absl::AnyInvocable (target '${_cucascade_absl_target}')"
+      )
+      target_link_libraries(
+        cucascade_io_thirdparty
+        INTERFACE $<BUILD_INTERFACE:${_cucascade_absl_target}>)
+      target_compile_definitions(cucascade_io_thirdparty
+                                 INTERFACE CUCASCADE_USE_ABSEIL_INVOCABLE)
+    endif()
   endif()
 
   # Find numa (provided by numactl-devel or libnuma-dev depending on the package
@@ -286,12 +378,11 @@ if(CUCASCADE_BUILD_IO)
   set(CUCASCADE_IO_LINK_LIBS PkgConfig::LIBURING PkgConfig::CURL
                              OpenSSL::Crypto)
 
-  target_link_libraries(cucascade_io_objects PUBLIC cucascade_objects
-                                                    ${CUCASCADE_IO_LINK_LIBS})
-  target_include_directories(
-    cucascade_io_objects
-    PUBLIC ${CUCASCADE_PUBLIC_INCLUDE_DIRS}
-           $<BUILD_INTERFACE:${concurrentqueue_SOURCE_DIR}>)
+  target_link_libraries(
+    cucascade_io_objects PUBLIC cucascade_objects ${CUCASCADE_IO_LINK_LIBS}
+                                cucascade_io_thirdparty)
+  target_include_directories(cucascade_io_objects
+                             PUBLIC ${CUCASCADE_PUBLIC_INCLUDE_DIRS})
   target_compile_features(cucascade_io_objects PUBLIC cxx_std_20)
   target_compile_features(cucascade_io_objects PRIVATE cuda_std_20)
 
@@ -375,12 +466,11 @@ if(CUCASCADE_BUILD_STATIC_LIBS)
                   $<TARGET_OBJECTS:cucascade_io_objects>)
       add_library(cuCascade::cucascade_io_static ALIAS cucascade_io_static)
 
-      target_include_directories(
-        cucascade_io_static
-        PUBLIC ${CUCASCADE_PUBLIC_INCLUDE_DIRS}
-               $<BUILD_INTERFACE:${concurrentqueue_SOURCE_DIR}>)
-      target_link_libraries(cucascade_io_static PUBLIC ${CUCASCADE_IO_LINK_LIBS}
-                                                       cucascade_static)
+      target_include_directories(cucascade_io_static
+                                 PUBLIC ${CUCASCADE_PUBLIC_INCLUDE_DIRS})
+      target_link_libraries(
+        cucascade_io_static PUBLIC ${CUCASCADE_IO_LINK_LIBS} cucascade_static
+                                   cucascade_io_thirdparty)
       target_compile_features(cucascade_io_static PUBLIC cxx_std_20)
 
       set_target_properties(
@@ -449,12 +539,11 @@ if(CUCASCADE_BUILD_SHARED_LIBS)
                   $<TARGET_OBJECTS:cucascade_io_objects>)
       add_library(cuCascade::cucascade_io_shared ALIAS cucascade_io_shared)
 
-      target_include_directories(
-        cucascade_io_shared
-        PUBLIC ${CUCASCADE_PUBLIC_INCLUDE_DIRS}
-               $<BUILD_INTERFACE:${concurrentqueue_SOURCE_DIR}>)
-      target_link_libraries(cucascade_io_shared PUBLIC ${CUCASCADE_IO_LINK_LIBS}
-                                                       cucascade_shared)
+      target_include_directories(cucascade_io_shared
+                                 PUBLIC ${CUCASCADE_PUBLIC_INCLUDE_DIRS})
+      target_link_libraries(
+        cucascade_io_shared PUBLIC ${CUCASCADE_IO_LINK_LIBS} cucascade_shared
+                                   cucascade_io_thirdparty)
       target_compile_features(cucascade_io_shared PUBLIC cxx_std_20)
 
       set_target_properties(cucascade_io_shared PROPERTIES OUTPUT_NAME
@@ -557,6 +646,14 @@ if(CUCASCADE_BUILD_SHARED_LIBS)
       list(APPEND CUCASCADE_INSTALL_TARGETS cucascade_io_shared)
     endif()
   endif()
+endif()
+
+# The io libraries link the cucascade_io_thirdparty INTERFACE target PUBLIC, so
+# it must join the export set. Its build-tree-only include dirs / link libs are
+# stripped on export (they are wrapped in $<BUILD_INTERFACE:...>); only the
+# moodycamel-namespace / invocable-backend compile definitions carry over.
+if(CUCASCADE_BUILD_IO AND NOT CUCASCADE_TOPOLOGY_ONLY)
+  list(APPEND CUCASCADE_INSTALL_TARGETS cucascade_io_thirdparty)
 endif()
 
 # Install library targets

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,12 @@ if(NOT CUCASCADE_TOPOLOGY_ONLY)
         cucascade_io_thirdparty
         INTERFACE $<BUILD_INTERFACE:${CUCASCADE_MOODYCAMEL_TARGET}>)
     elseif(CUCASCADE_MOODYCAMEL_INCLUDE_DIR)
+      if(NOT EXISTS "${CUCASCADE_MOODYCAMEL_INCLUDE_DIR}/concurrentqueue.h")
+        message(
+          FATAL_ERROR
+            "CUCASCADE_MOODYCAMEL_INCLUDE_DIR does not contain concurrentqueue.h: ${CUCASCADE_MOODYCAMEL_INCLUDE_DIR}"
+        )
+      endif()
       message(
         STATUS
           "cucascade-io: using provided moodycamel include dir '${CUCASCADE_MOODYCAMEL_INCLUDE_DIR}' (namespace ${CUCASCADE_MOODYCAMEL_NAMESPACE})"

--- a/cmake/cuCascadeConfig.cmake.in
+++ b/cmake/cuCascadeConfig.cmake.in
@@ -40,6 +40,22 @@ if(cuCascade_io_FOUND AND ("io" IN_LIST cuCascade_FIND_COMPONENTS
   find_dependency(OpenSSL REQUIRED)
 endif()
 
+# moodycamel (concurrentqueue) headers are not shipped with the install: the io
+# public headers include them via <cucascade/io/concurrent_queue.hpp>, so a
+# consumer must provide the same moodycamel this install was built against
+# (namespace @CUCASCADE_MOODYCAMEL_NAMESPACE@). Likewise, when the io library was
+# built with CUCASCADE_USE_ABSEIL_INVOCABLE, cucascade::exec::invocable resolves
+# to absl::AnyInvocable in the installed headers, so abseil must be available.
+# The exported targets do not force-link either (the build-tree links are
+# stripped); they only carry the matching compile definitions.
+set(cuCascade_USE_ABSEIL_INVOCABLE @CUCASCADE_USE_ABSEIL_INVOCABLE@)
+if(cuCascade_io_FOUND
+   AND cuCascade_USE_ABSEIL_INVOCABLE
+   AND ("io" IN_LIST cuCascade_FIND_COMPONENTS
+        OR "cudf" IN_LIST cuCascade_FIND_COMPONENTS))
+  find_dependency(absl CONFIG)
+endif()
+
 # Include the targets file
 include("${CMAKE_CURRENT_LIST_DIR}/cuCascadeTargets.cmake")
 

--- a/cmake/cuCascadeConfig.cmake.in
+++ b/cmake/cuCascadeConfig.cmake.in
@@ -38,6 +38,26 @@ if(cuCascade_io_FOUND AND ("io" IN_LIST cuCascade_FIND_COMPONENTS
   pkg_check_modules(LIBURING REQUIRED IMPORTED_TARGET liburing)
   pkg_check_modules(CURL REQUIRED IMPORTED_TARGET libcurl)
   find_dependency(OpenSSL REQUIRED)
+
+  # Best-effort check that the moodycamel headers the installed io headers
+  # include are reachable. They are not shipped (the consumer provides the same
+  # copy this install was built against, namespace @CUCASCADE_MOODYCAMEL_NAMESPACE@),
+  # so warn at configure time rather than letting it surface as an opaque
+  # "concurrentqueue.h: No such file" during compilation. This is a plain
+  # find_path over the default search paths, so a consumer supplying moodycamel
+  # only via a target's include dirs may still see this warning — hence a
+  # warning, not an error.
+  find_path(CUCASCADE_MOODYCAMEL_HEADER_DIR
+            NAMES concurrentqueue.h blockingconcurrentqueue.h)
+  if(NOT CUCASCADE_MOODYCAMEL_HEADER_DIR)
+    message(
+      WARNING
+        "cuCascade[io]: moodycamel concurrentqueue headers (concurrentqueue.h / "
+        "blockingconcurrentqueue.h, namespace @CUCASCADE_MOODYCAMEL_NAMESPACE@) were "
+        "not found on the default include search paths. The installed io headers "
+        "include them; add the directory containing them to the consuming target's "
+        "include path (they are not shipped with cuCascade).")
+  endif()
 endif()
 
 # moodycamel (concurrentqueue) headers are not shipped with the install: the io
@@ -53,7 +73,7 @@ if(cuCascade_io_FOUND
    AND cuCascade_USE_ABSEIL_INVOCABLE
    AND ("io" IN_LIST cuCascade_FIND_COMPONENTS
         OR "cudf" IN_LIST cuCascade_FIND_COMPONENTS))
-  find_dependency(absl CONFIG)
+  find_dependency(absl REQUIRED CONFIG)
 endif()
 
 # Include the targets file

--- a/include/cucascade/exec/invocable.hpp
+++ b/include/cucascade/exec/invocable.hpp
@@ -18,6 +18,42 @@
 
 #pragma once
 
+/**
+ * @file invocable.hpp
+ * @brief Move-only type-erased callable used across the exec layer.
+ *
+ * `cucascade::exec::invocable<Signature>` is the single spelling used by the
+ * thread pool, dispatcher, and future/promise continuations. Two backing
+ * implementations are selected at configure time:
+ *
+ *   - Default (standard-library only): a minimal in-tree implementation, a
+ *     stand-in for C++23 `std::move_only_function` on the C++20 toolchain.
+ *   - `CUCASCADE_USE_ABSEIL_INVOCABLE` defined: an alias for
+ *     `absl::AnyInvocable`. Enable via the `CUCASCADE_USE_ABSEIL_INVOCABLE`
+ *     CMake option so the library reuses a host project's abseil (e.g. when
+ *     embedded in a codebase that already depends on it).
+ *
+ * The macro must be defined consistently for the library build and every
+ * consumer that includes this header; the CMake option propagates it as a
+ * public compile definition to guarantee that.
+ */
+
+#ifdef CUCASCADE_USE_ABSEIL_INVOCABLE
+
+#include <absl/functional/any_invocable.h>
+
+namespace cucascade::exec {
+
+/**
+ * @brief Move-only type-erased callable, backed by `absl::AnyInvocable`.
+ */
+template <typename Signature>
+using invocable = absl::AnyInvocable<Signature>;
+
+}  // namespace cucascade::exec
+
+#else  // CUCASCADE_USE_ABSEIL_INVOCABLE
+
 #include <concepts>
 #include <cstddef>
 #include <functional>
@@ -35,29 +71,29 @@ namespace cucascade::exec {
  * std::function (copyable target required) cannot hold.
  */
 template <typename Signature>
-class unique_function;
+class invocable;
 
 template <typename R, typename... Args>
-class unique_function<R(Args...)> {
+class invocable<R(Args...)> {
  public:
-  unique_function() noexcept = default;
-  unique_function(std::nullptr_t) noexcept {}  // NOLINT(google-explicit-constructor)
+  invocable() noexcept = default;
+  invocable(std::nullptr_t) noexcept {}  // NOLINT(google-explicit-constructor)
 
   template <typename F>
-    requires(!std::same_as<std::remove_cvref_t<F>, unique_function> &&
+    requires(!std::same_as<std::remove_cvref_t<F>, invocable> &&
              std::invocable<std::decay_t<F>&, Args...>)
-  unique_function(F&& f)  // NOLINT(google-explicit-constructor)
+  invocable(F&& f)  // NOLINT(google-explicit-constructor)
     : _impl(std::make_unique<model<std::decay_t<F>>>(std::forward<F>(f)))
   {
   }
 
-  unique_function(unique_function&&) noexcept            = default;
-  unique_function& operator=(unique_function&&) noexcept = default;
-  unique_function(const unique_function&)                = delete;
-  unique_function& operator=(const unique_function&)     = delete;
-  ~unique_function()                                     = default;
+  invocable(invocable&&) noexcept            = default;
+  invocable& operator=(invocable&&) noexcept = default;
+  invocable(const invocable&)                = delete;
+  invocable& operator=(const invocable&)     = delete;
+  ~invocable()                               = default;
 
-  unique_function& operator=(std::nullptr_t) noexcept
+  invocable& operator=(std::nullptr_t) noexcept
   {
     _impl.reset();
     return *this;
@@ -65,7 +101,7 @@ class unique_function<R(Args...)> {
 
   [[nodiscard]] explicit operator bool() const noexcept { return _impl != nullptr; }
 
-  friend bool operator==(const unique_function& f, std::nullptr_t) noexcept { return !f; }
+  friend bool operator==(const invocable& f, std::nullptr_t) noexcept { return !f; }
 
   R operator()(Args... args) { return _impl->invoke(std::forward<Args>(args)...); }
 
@@ -86,3 +122,5 @@ class unique_function<R(Args...)> {
 };
 
 }  // namespace cucascade::exec
+
+#endif  // CUCASCADE_USE_ABSEIL_INVOCABLE

--- a/include/cucascade/exec/scoped_dispatcher.hpp
+++ b/include/cucascade/exec/scoped_dispatcher.hpp
@@ -18,8 +18,8 @@
 
 #pragma once
 
+#include <cucascade/exec/invocable.hpp>
 #include <cucascade/exec/thread_pool.hpp>
-#include <cucascade/exec/unique_function.hpp>
 
 #include <cassert>
 #include <concepts>
@@ -111,7 +111,7 @@ class scoped_dispatcher {
   }
 
  private:
-  using task_t = unique_function<void()>;
+  using task_t = invocable<void()>;
 
   template <typename F>
   task_t wrap(F&& f)

--- a/include/cucascade/exec/semi_future.hpp
+++ b/include/cucascade/exec/semi_future.hpp
@@ -20,7 +20,7 @@
 
 #pragma once
 
-#include <cucascade/exec/unique_function.hpp>
+#include <cucascade/exec/invocable.hpp>
 
 #include <atomic>
 #include <cassert>
@@ -45,7 +45,7 @@
 namespace cucascade::exec {
 
 // Task type submitted to an executor.
-using executor_func = unique_function<void()>;
+using executor_func = invocable<void()>;
 
 // Concept: any type with a void enqueue(executor_func) member.
 template <class exec_t>
@@ -271,7 +271,7 @@ inline void futex_wake_all(std::atomic<std::uint32_t>& atom)
 template <class value_t>
 class core {
  public:
-  using callback = unique_function<void(try_t<value_t>&&)>;
+  using callback = invocable<void(try_t<value_t>&&)>;
 
   core()                       = default;
   core(core const&)            = delete;
@@ -389,7 +389,7 @@ class core {
 
 template <class value_t>
 struct state {
-  using callback = unique_function<void(try_t<value_t>&&)>;
+  using callback = invocable<void(try_t<value_t>&&)>;
 
   virtual ~state()                                                         = default;
   virtual void await()                                                     = 0;

--- a/include/cucascade/exec/thread_pool.hpp
+++ b/include/cucascade/exec/thread_pool.hpp
@@ -18,7 +18,7 @@
 
 #pragma once
 
-#include <cucascade/exec/unique_function.hpp>
+#include <cucascade/exec/invocable.hpp>
 #include <cucascade/log/logging.hpp>
 
 #include <algorithm>
@@ -120,7 +120,7 @@ class static_thread_pool {
   void work_loop()
   {
     while (!stop_requested_) {
-      unique_function<void()> func;
+      invocable<void()> func;
       {
         std::unique_lock<std::mutex> l(mu_);
         cv_.wait(l, [this] { return has_work_or_stopped(); });
@@ -135,7 +135,7 @@ class static_thread_pool {
 
   std::mutex mu_;
   std::condition_variable cv_;
-  std::queue<unique_function<void()>> queue_;
+  std::queue<invocable<void()>> queue_;
   std::atomic<bool> stop_requested_{false};
   std::vector<std::thread> threads_;
 };

--- a/include/cucascade/io/cache/prefetching_cache.hpp
+++ b/include/cucascade/io/cache/prefetching_cache.hpp
@@ -24,9 +24,7 @@
 #include <cucascade/exec/thread_pool.hpp>
 #include <cucascade/io/cache/config.hpp>
 #include <cucascade/io/cache/types.hpp>
-
-#include <blockingconcurrentqueue.h>
-#include <concurrentqueue.h>
+#include <cucascade/io/concurrent_queue.hpp>
 
 #include <atomic>
 #include <cstddef>
@@ -138,7 +136,7 @@ class prefetching_cache {
  public:
   using byte_range         = cucascade::io::byte_range;
   using prefetch_request   = std::shared_ptr<prefetch_request_context>;
-  using request_queue_type = moodycamel::BlockingConcurrentQueue<prefetch_request>;
+  using request_queue_type = blocking_concurrent_queue<prefetch_request>;
 
   prefetching_cache(cucascade::memory::memory_reservation_manager& reservation_manager,
                     ioctx* io_ctx,

--- a/include/cucascade/io/concurrent_queue.hpp
+++ b/include/cucascade/io/concurrent_queue.hpp
@@ -1,0 +1,60 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+/**
+ * @file concurrent_queue.hpp
+ * @brief Single include point for moodycamel's lock-free MPMC queues.
+ *
+ * The io reactors and prefetching cache use moodycamel's `ConcurrentQueue` /
+ * `BlockingConcurrentQueue`. This header decouples that code from *which*
+ * moodycamel it links against: standalone builds fetch cameron314's upstream
+ * (namespace `moodycamel`), while an embedding host may provide its own vendored
+ * copy under a different namespace (e.g. duckdb's fork is `duckdb_moodycamel`,
+ * used by sirius).
+ *
+ * `CUCASCADE_MOODYCAMEL_NAMESPACE` selects the namespace and defaults to
+ * `moodycamel`; the CMake build propagates it as a public compile definition so
+ * the library and every consumer of these headers agree on the same value. Use
+ * the `cucascade::io::concurrent_queue` / `cucascade::io::blocking_concurrent_queue`
+ * aliases below rather than naming the moodycamel namespace directly.
+ */
+
+#ifndef CUCASCADE_MOODYCAMEL_NAMESPACE
+#define CUCASCADE_MOODYCAMEL_NAMESPACE moodycamel
+#endif
+
+#include <blockingconcurrentqueue.h>
+#include <concurrentqueue.h>
+
+namespace cucascade::io {
+
+namespace detail {
+namespace moodycamel_ns = ::CUCASCADE_MOODYCAMEL_NAMESPACE;
+}  // namespace detail
+
+/// Lock-free MPMC queue (alias for moodycamel::ConcurrentQueue).
+template <typename T, typename Traits = detail::moodycamel_ns::ConcurrentQueueDefaultTraits>
+using concurrent_queue = detail::moodycamel_ns::ConcurrentQueue<T, Traits>;
+
+/// Blocking lock-free MPMC queue (alias for moodycamel::BlockingConcurrentQueue).
+template <typename T, typename Traits = detail::moodycamel_ns::ConcurrentQueueDefaultTraits>
+using blocking_concurrent_queue = detail::moodycamel_ns::BlockingConcurrentQueue<T, Traits>;
+
+}  // namespace cucascade::io

--- a/include/cucascade/io/rest/rest_reactor.hpp
+++ b/include/cucascade/io/rest/rest_reactor.hpp
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <cucascade/io/cache/types.hpp>
+#include <cucascade/io/concurrent_queue.hpp>
 #include <cucascade/io/rest/authorizer.hpp>
 #include <cucascade/io/rest/config.hpp>
 #include <cucascade/io/rest/types.hpp>
@@ -26,8 +27,6 @@
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 
 #include <rmm/cuda_stream_view.hpp>
-
-#include <blockingconcurrentqueue.h>
 
 #include <chrono>
 #include <cstddef>
@@ -237,7 +236,7 @@ class rest_reactor {
   file_descriptor _wakeup_fd;
 
   std::stop_source _stop_source;
-  moodycamel::BlockingConcurrentQueue<std::unique_ptr<rest_chunked_rx_request>> _requests;
+  blocking_concurrent_queue<std::unique_ptr<rest_chunked_rx_request>> _requests;
   std::jthread _worker;
 };
 

--- a/include/cucascade/io/uring/uring_reactor.hpp
+++ b/include/cucascade/io/uring/uring_reactor.hpp
@@ -20,6 +20,7 @@
 
 #include <cucascade/exec/semi_future.hpp>
 #include <cucascade/io/cache/types.hpp>
+#include <cucascade/io/concurrent_queue.hpp>
 #include <cucascade/io/details/slot_pool.hpp>
 #include <cucascade/io/types.hpp>
 #include <cucascade/io/uring/config.hpp>
@@ -28,8 +29,6 @@
 
 #include <cuda_runtime.h>
 
-#include <blockingconcurrentqueue.h>
-#include <concurrentqueue.h>
 #include <liburing.h>
 
 #include <array>
@@ -309,7 +308,7 @@ class uring_reactor {
   std::size_t _bounce_slot_size;
   std::stop_source _stop_source;
   std::jthread _worker;
-  moodycamel::BlockingConcurrentQueue<chunk_io_request_type_ptr> _requests;
+  blocking_concurrent_queue<chunk_io_request_type_ptr> _requests;
 };
 
 }  // namespace cucascade::io::uring


### PR DESCRIPTION
## What

The io layer was ported from a codebase (sirius) that had its own vendored
dependencies. It currently ships two in-tree stand-ins — a hand-rolled
`unique_function` and a fetched `cameron314/concurrentqueue`. This makes those
two dependencies **swappable at configure time** so an embedding host can reuse
the copies it already links, instead of duplicating them.

### 1. `unique_function` → `cucascade::exec::invocable`
- New header `include/cucascade/exec/invocable.hpp`; the old
  `unique_function.hpp` is removed and its three consumers (`thread_pool`,
  `semi_future`, `scoped_dispatcher`) updated.
- Default backend is the same in-tree move-only callable. With
  `CUCASCADE_USE_ABSEIL_INVOCABLE=ON`, `invocable` aliases `absl::AnyInvocable`.

### 2. moodycamel indirection
- New wrapper `include/cucascade/io/concurrent_queue.hpp` exposing
  `cucascade::io::{concurrent_queue,blocking_concurrent_queue}`, aliased to the
  `CUCASCADE_MOODYCAMEL_NAMESPACE` namespace (default `moodycamel`, e.g.
  `duckdb_moodycamel` for duckdb's fork). The reactors/cache use these aliases.

### 3. CMake wiring
A single `cucascade_io_thirdparty` INTERFACE target carries the swappable usage
requirements. Resolution prefers a host-provided target/include-dir, else fetches:
- `CUCASCADE_USE_ABSEIL_INVOCABLE` / `CUCASCADE_ABSEIL_INVOCABLE_TARGET`
- `CUCASCADE_MOODYCAMEL_TARGET` / `CUCASCADE_MOODYCAMEL_INCLUDE_DIR` / `CUCASCADE_MOODYCAMEL_NAMESPACE`

External deps are `$<BUILD_INTERFACE:...>`-scoped so the exported package stays
clean; only the namespace/backend compile definitions cross the install boundary.
`cuCascadeConfig.cmake` gains a gated `find_dependency(absl)`.

**Defaults are unchanged** — a standalone build still uses the in-tree callable
and fetches concurrentqueue.

## Verification
- Default configure + build of `cucascade_io_objects` and `cucascade_cudf_objects`: clean.
- Abseil branch of `invocable.hpp` compiled + ran against a faithful `absl::AnyInvocable` stub.
- Built inside sirius's environment with `CUCASCADE_USE_ABSEIL_INVOCABLE=ON` +
  duckdb's concurrentqueue: object symbols confirm `invocable` resolved to
  `absl::…AnyInvocable` and the queues to
  `duckdb_moodycamel::ConcurrentQueue<…>`, with no fetch.
- clang-format / cmake-format / cmake-lint / codespell pass.