### PR TITLE
Upgrade Catch2 from v2.13.10 to v3.8.1

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,7 +20,7 @@ include(FetchContent)
 FetchContent_Declare(
   Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG v2.13.10)
+  GIT_TAG v3.8.1)
 FetchContent_MakeAvailable(Catch2)
 
 if(NOT CUCASCADE_TOPOLOGY_ONLY)
@@ -45,8 +45,7 @@ if(NOT CUCASCADE_TOPOLOGY_ONLY)
   # Set include directories
   target_include_directories(
     cucascade_tests
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/utils
-            ${Catch2_SOURCE_DIR}/single_include)
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/utils)
 
   # Link dependencies
   target_link_libraries(cucascade_tests PRIVATE cucascade Catch2::Catch2
@@ -104,8 +103,7 @@ if(NOT CUCASCADE_TOPOLOGY_ONLY AND CUCASCADE_BUILD_CUDF)
   # Set include directories
   target_include_directories(
     cucascade_cudf_tests
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/utils
-            ${Catch2_SOURCE_DIR}/single_include)
+    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/utils)
 
   # Link dependencies
   target_link_libraries(
@@ -126,8 +124,7 @@ set_target_properties(cucascade_topology_discovery_tests
 # Set include directories
 target_include_directories(
   cucascade_topology_discovery_tests
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/utils
-          ${Catch2_SOURCE_DIR}/single_include)
+  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/utils)
 
 # Link dependencies
 target_link_libraries(cucascade_topology_discovery_tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,7 +20,8 @@ include(FetchContent)
 FetchContent_Declare(
   Catch2
   GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-  GIT_TAG v3.8.1)
+  GIT_TAG v3.8.1
+  GIT_SHALLOW TRUE)
 FetchContent_MakeAvailable(Catch2)
 
 if(NOT CUCASCADE_TOPOLOGY_ONLY)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,8 +44,8 @@ if(NOT CUCASCADE_TOPOLOGY_ONLY)
 
   # Set include directories
   target_include_directories(
-    cucascade_tests
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/utils)
+    cucascade_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+                            ${CMAKE_CURRENT_SOURCE_DIR}/utils)
 
   # Link dependencies
   target_link_libraries(cucascade_tests PRIVATE cucascade Catch2::Catch2
@@ -102,8 +102,8 @@ if(NOT CUCASCADE_TOPOLOGY_ONLY AND CUCASCADE_BUILD_CUDF)
 
   # Set include directories
   target_include_directories(
-    cucascade_cudf_tests
-    PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/utils)
+    cucascade_cudf_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+                                 ${CMAKE_CURRENT_SOURCE_DIR}/utils)
 
   # Link dependencies
   target_link_libraries(
@@ -123,8 +123,8 @@ set_target_properties(cucascade_topology_discovery_tests
 
 # Set include directories
 target_include_directories(
-  cucascade_topology_discovery_tests
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/utils)
+  cucascade_topology_discovery_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
+                                             ${CMAKE_CURRENT_SOURCE_DIR}/utils)
 
 # Link dependencies
 target_link_libraries(cucascade_topology_discovery_tests

--- a/test/data/test_bandwidth_profiler.cpp
+++ b/test/data/test_bandwidth_profiler.cpp
@@ -26,7 +26,7 @@
 
 #include <cuda_runtime_api.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <array>
 #include <cstddef>

--- a/test/data/test_data_batch.cpp
+++ b/test/data/test_data_batch.cpp
@@ -27,7 +27,7 @@
 
 #include <cuda_runtime_api.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <atomic>
 #include <chrono>

--- a/test/data/test_data_repository.cpp
+++ b/test/data/test_data_repository.cpp
@@ -20,7 +20,7 @@
 #include <cucascade/data/data_batch.hpp>
 #include <cucascade/data/data_repository.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <atomic>
 #include <memory>

--- a/test/data/test_data_repository_manager.cpp
+++ b/test/data/test_data_repository_manager.cpp
@@ -21,7 +21,7 @@
 #include <cucascade/data/data_repository.hpp>
 #include <cucascade/data/data_repository_manager.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <atomic>
 #include <map>

--- a/test/data/test_data_representation.cpp
+++ b/test/data/test_data_representation.cpp
@@ -44,7 +44,7 @@
 
 #include <cuda_runtime_api.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <array>
 #include <cstring>

--- a/test/data/test_disk_host_converters.cpp
+++ b/test/data/test_disk_host_converters.cpp
@@ -37,7 +37,7 @@
 
 #include <cuda_runtime_api.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/test/data/test_disk_io_backend.cpp
+++ b/test/data/test_disk_io_backend.cpp
@@ -22,7 +22,7 @@
 
 #include <rmm/aligned.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <cstdint>
 #include <filesystem>

--- a/test/data/test_gpu_disk_converters.cpp
+++ b/test/data/test_gpu_disk_converters.cpp
@@ -35,7 +35,7 @@
 
 #include <cuda_runtime_api.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/test/data/test_io_worker.cpp
+++ b/test/data/test_io_worker.cpp
@@ -25,7 +25,7 @@
 
 #include "../../src/data/io_worker.hpp"
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <atomic>
 #include <chrono>

--- a/test/data/test_representation_converter.cpp
+++ b/test/data/test_representation_converter.cpp
@@ -26,7 +26,7 @@
 #include <rmm/cuda_stream.hpp>
 #include <rmm/cuda_stream_view.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <memory>
 #include <vector>

--- a/test/io/cache/test_metadata_store.cpp
+++ b/test/io/cache/test_metadata_store.cpp
@@ -18,7 +18,7 @@
 
 #include <cucascade/io/cache/metadata_store.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <memory>
 #include <string>

--- a/test/io/kvikio/test_kvikio_config.cpp
+++ b/test/io/kvikio/test_kvikio_config.cpp
@@ -20,7 +20,7 @@
 
 #include <kvikio/defaults.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <stdexcept>
 

--- a/test/io/rest/s3/test_sigv4.cpp
+++ b/test/io/rest/s3/test_sigv4.cpp
@@ -16,7 +16,7 @@
 
 #include <cucascade/io/rest/s3/sigv4.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <algorithm>
 #include <cctype>

--- a/test/io/rest/s3/test_sigv4_authorizer.cpp
+++ b/test/io/rest/s3/test_sigv4_authorizer.cpp
@@ -21,7 +21,7 @@
 #include <cucascade/io/rest/s3/sigv4_authorizer.hpp>
 #include <cucascade/io/rest/s3/static_credentials.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <algorithm>
 #include <atomic>
@@ -227,7 +227,7 @@ TEST_CASE("ListObjectsV2 parser rejects Contents without a Key", "[s3][list_pars
   CHECK_THROWS_WITH(
     cucascade::io::rest::s3::parse_list_objects_v2(
       R"(<ListBucketResult><Contents><Size>5</Size></Contents><IsTruncated>false</IsTruncated></ListBucketResult>)"),
-    Catch::Contains("<Contents> without <Key>"));
+    Catch::Matchers::ContainsSubstring("<Contents> without <Key>"));
 }
 
 TEST_CASE("ListObjectsV2 parser rejects an unclosed Key", "[s3][list_parser]")
@@ -235,7 +235,7 @@ TEST_CASE("ListObjectsV2 parser rejects an unclosed Key", "[s3][list_parser]")
   CHECK_THROWS_WITH(
     cucascade::io::rest::s3::parse_list_objects_v2(
       R"(<ListBucketResult><Contents><Key>a<Size>5</Size></Contents><IsTruncated>false</IsTruncated></ListBucketResult>)"),
-    Catch::Contains("<Contents> without <Key>"));
+    Catch::Matchers::ContainsSubstring("<Contents> without <Key>"));
 }
 
 TEST_CASE("ListObjectsV2 parser rejects an empty Key", "[s3][list_parser]")
@@ -243,7 +243,7 @@ TEST_CASE("ListObjectsV2 parser rejects an empty Key", "[s3][list_parser]")
   CHECK_THROWS_WITH(
     cucascade::io::rest::s3::parse_list_objects_v2(
       R"(<ListBucketResult><Contents><Key></Key><Size>5</Size></Contents><IsTruncated>false</IsTruncated></ListBucketResult>)"),
-    Catch::Contains("empty <Key>"));
+    Catch::Matchers::ContainsSubstring("empty <Key>"));
 }
 
 TEST_CASE("ListObjectsV2 parser requires IsTruncated", "[s3][list_parser]")
@@ -251,7 +251,7 @@ TEST_CASE("ListObjectsV2 parser requires IsTruncated", "[s3][list_parser]")
   CHECK_THROWS_WITH(
     cucascade::io::rest::s3::parse_list_objects_v2(
       R"(<ListBucketResult><Contents><Key>a</Key><Size>5</Size></Contents></ListBucketResult>)"),
-    Catch::Contains("missing <IsTruncated>"));
+    Catch::Matchers::ContainsSubstring("missing <IsTruncated>"));
 }
 
 TEST_CASE("ListObjectsV2 parser rejects invalid IsTruncated values", "[s3][list_parser]")
@@ -265,7 +265,7 @@ TEST_CASE("ListObjectsV2 parser rejects invalid IsTruncated values", "[s3][list_
           "</Contents><IsTruncated>"} +
         value + "</IsTruncated></ListBucketResult>";
       CHECK_THROWS_WITH(cucascade::io::rest::s3::parse_list_objects_v2(xml),
-                        Catch::Contains("invalid <IsTruncated>"));
+                        Catch::Matchers::ContainsSubstring("invalid <IsTruncated>"));
     }
   }
 
@@ -274,7 +274,7 @@ TEST_CASE("ListObjectsV2 parser rejects invalid IsTruncated values", "[s3][list_
     CHECK_THROWS_WITH(
       cucascade::io::rest::s3::parse_list_objects_v2(
         R"(<ListBucketResult><Contents><Key>a</Key><Size>5</Size></Contents><IsTruncated>true</ListBucketResult>)"),
-      Catch::Contains("missing <IsTruncated>"));
+      Catch::Matchers::ContainsSubstring("missing <IsTruncated>"));
   }
 }
 
@@ -283,7 +283,7 @@ TEST_CASE("ListObjectsV2 parser requires a token for a truncated page", "[s3][li
   CHECK_THROWS_WITH(
     cucascade::io::rest::s3::parse_list_objects_v2(
       R"(<ListBucketResult><Contents><Key>a</Key><Size>5</Size></Contents><IsTruncated>true</IsTruncated></ListBucketResult>)"),
-    Catch::Contains("without") && Catch::Contains("ContinuationToken"));
+    Catch::Matchers::ContainsSubstring("without") && Catch::Matchers::ContainsSubstring("ContinuationToken"));
 }
 
 TEST_CASE("ListObjectsV2 parser trims a valid IsTruncated value", "[s3][list_parser]")
@@ -300,14 +300,14 @@ TEST_CASE("ListObjectsV2 parser rejects object entries after the root element", 
   CHECK_THROWS_WITH(
     cucascade::io::rest::s3::parse_list_objects_v2(
       R"(<ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult><Contents><Key>outside</Key><Size>1</Size></Contents>)"),
-    Catch::Contains("after </ListBucketResult>"));
+    Catch::Matchers::ContainsSubstring("after </ListBucketResult>"));
 }
 
 TEST_CASE("ListObjectsV2 parser does not read IsTruncated outside the root", "[s3][list_parser]")
 {
   CHECK_THROWS_WITH(cucascade::io::rest::s3::parse_list_objects_v2(
                       R"(<ListBucketResult></ListBucketResult><IsTruncated>false</IsTruncated>)"),
-                    Catch::Contains("missing <IsTruncated>"));
+                    Catch::Matchers::ContainsSubstring("missing <IsTruncated>"));
 }
 
 TEST_CASE("ListObjectsV2 parser does not read a continuation token outside the root",
@@ -316,7 +316,7 @@ TEST_CASE("ListObjectsV2 parser does not read a continuation token outside the r
   CHECK_THROWS_WITH(
     cucascade::io::rest::s3::parse_list_objects_v2(
       R"(<ListBucketResult><Contents><Key>a</Key><Size>1</Size></Contents><IsTruncated>true</IsTruncated></ListBucketResult><NextContinuationToken>outside</NextContinuationToken>)"),
-    Catch::Contains("without") && Catch::Contains("ContinuationToken"));
+    Catch::Matchers::ContainsSubstring("without") && Catch::Matchers::ContainsSubstring("ContinuationToken"));
 }
 
 TEST_CASE("ListObjectsV2 parser rejects a root close before the root open", "[s3][list_parser]")
@@ -347,7 +347,7 @@ TEST_CASE("ListObjectsV2 parser rejects a root-name prefix collision", "[s3][lis
   CHECK_THROWS_WITH(
     cucascade::io::rest::s3::parse_list_objects_v2(
       R"(<ListBucketResultBogus><IsTruncated>false</IsTruncated></ListBucketResult>)"),
-    Catch::Contains("not a ListObjectsV2 response"));
+    Catch::Matchers::ContainsSubstring("not a ListObjectsV2 response"));
 }
 
 TEST_CASE("ListObjectsV2 parser rejects content before the root element", "[s3][list_parser]")
@@ -355,7 +355,7 @@ TEST_CASE("ListObjectsV2 parser rejects content before the root element", "[s3][
   CHECK_THROWS_WITH(
     cucascade::io::rest::s3::parse_list_objects_v2(
       R"(<Foo/><ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>)"),
-    Catch::Contains("before <ListBucketResult>"));
+    Catch::Matchers::ContainsSubstring("before <ListBucketResult>"));
 }
 
 TEST_CASE("ListObjectsV2 parser accepts a prologue and newline before the root",

--- a/test/io/rest/s3/test_sigv4_authorizer.cpp
+++ b/test/io/rest/s3/test_sigv4_authorizer.cpp
@@ -283,7 +283,8 @@ TEST_CASE("ListObjectsV2 parser requires a token for a truncated page", "[s3][li
   CHECK_THROWS_WITH(
     cucascade::io::rest::s3::parse_list_objects_v2(
       R"(<ListBucketResult><Contents><Key>a</Key><Size>5</Size></Contents><IsTruncated>true</IsTruncated></ListBucketResult>)"),
-    Catch::Matchers::ContainsSubstring("without") && Catch::Matchers::ContainsSubstring("ContinuationToken"));
+    Catch::Matchers::ContainsSubstring("without") &&
+      Catch::Matchers::ContainsSubstring("ContinuationToken"));
 }
 
 TEST_CASE("ListObjectsV2 parser trims a valid IsTruncated value", "[s3][list_parser]")
@@ -316,7 +317,8 @@ TEST_CASE("ListObjectsV2 parser does not read a continuation token outside the r
   CHECK_THROWS_WITH(
     cucascade::io::rest::s3::parse_list_objects_v2(
       R"(<ListBucketResult><Contents><Key>a</Key><Size>1</Size></Contents><IsTruncated>true</IsTruncated></ListBucketResult><NextContinuationToken>outside</NextContinuationToken>)"),
-    Catch::Matchers::ContainsSubstring("without") && Catch::Matchers::ContainsSubstring("ContinuationToken"));
+    Catch::Matchers::ContainsSubstring("without") &&
+      Catch::Matchers::ContainsSubstring("ContinuationToken"));
 }
 
 TEST_CASE("ListObjectsV2 parser rejects a root close before the root open", "[s3][list_parser]")

--- a/test/io/rest/s3/test_static_credentials.cpp
+++ b/test/io/rest/s3/test_static_credentials.cpp
@@ -16,7 +16,7 @@
 
 #include <cucascade/io/rest/s3/static_credentials.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <chrono>
 

--- a/test/io/rest/test_shared_byte_span.cpp
+++ b/test/io/rest/test_shared_byte_span.cpp
@@ -18,7 +18,7 @@
 
 #include <cucascade/io/rest/rest_reactor.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <cstdint>
 #include <numeric>

--- a/test/io/test_uri_parser.cpp
+++ b/test/io/test_uri_parser.cpp
@@ -18,7 +18,7 @@
 
 #include <cucascade/io/uri_parser.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <stdexcept>
 #include <string>

--- a/test/memory/test_memory_reservation_manager.cpp
+++ b/test/memory/test_memory_reservation_manager.cpp
@@ -42,7 +42,7 @@
 #include <rmm/device_buffer.hpp>
 #include <rmm/mr/cuda_memory_resource.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <cstdlib>
 #include <memory>

--- a/test/memory/test_reservation_aware_resource_adaptor.cpp
+++ b/test/memory/test_reservation_aware_resource_adaptor.cpp
@@ -42,7 +42,7 @@
 #include <cuda/stream_ref>
 #include <cuda_runtime_api.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <cstddef>
 

--- a/test/memory/test_small_pinned_host_memory_resource.cpp
+++ b/test/memory/test_small_pinned_host_memory_resource.cpp
@@ -20,7 +20,7 @@
 #include <rmm/cuda_stream_view.hpp>
 #include <rmm/mr/pinned_host_memory_resource.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/test/memory/test_topology_discovery.cpp
+++ b/test/memory/test_topology_discovery.cpp
@@ -31,7 +31,7 @@
 
 #include <cucascade/memory/topology_discovery.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <algorithm>
 #include <cstdlib>

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -26,7 +26,7 @@
 #include <cuda/memory_resource>
 #include <cuda_runtime_api.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <algorithm>
 #include <cstdlib>
@@ -98,8 +98,8 @@ test_gpu_pool global_pool;
 }  // namespace
 
 namespace {
-struct device_sync_listener : Catch::TestEventListenerBase {
-  using Catch::TestEventListenerBase::TestEventListenerBase;
+struct device_sync_listener : Catch::EventListenerBase {
+  using Catch::EventListenerBase::EventListenerBase;
 
   void testCaseEnded(Catch::TestCaseStats const&) override { cudaDeviceSynchronize(); }
 };

--- a/test/unittest.cpp
+++ b/test/unittest.cpp
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-#define CATCH_CONFIG_RUNNER
-
 #include <rmm/cuda_device.hpp>
 #include <rmm/mr/cuda_async_memory_resource.hpp>
 #include <rmm/mr/per_device_resource.hpp>

--- a/test/unittest_topology_discovery.cpp
+++ b/test/unittest_topology_discovery.cpp
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-#define CATCH_CONFIG_RUNNER
 
 #include <catch2/catch_all.hpp>
 

--- a/test/unittest_topology_discovery.cpp
+++ b/test/unittest_topology_discovery.cpp
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-
 #include <catch2/catch_all.hpp>
 
 int main(int argc, char* argv[])

--- a/test/unittest_topology_discovery.cpp
+++ b/test/unittest_topology_discovery.cpp
@@ -17,7 +17,7 @@
 
 #define CATCH_CONFIG_RUNNER
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 int main(int argc, char* argv[])
 {

--- a/test/utils/cudf_test_utils.cpp
+++ b/test/utils/cudf_test_utils.cpp
@@ -35,7 +35,7 @@
 #include <cuda/memory_resource>
 #include <cuda_runtime_api.h>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <cstdint>
 #include <cstring>


### PR DESCRIPTION
## Summary

- Bumps Catch2 from v2.13.10 to v3.8.1, eliminating the CMake deprecation warning emitted by v2's `cmake_minimum_required(VERSION 2.8.8)` under CMake 3.27+
- Removes manual `single_include/` include paths from all three test targets (v3 exposes headers via its CMake target)
- Replaces `<catch2/catch.hpp>` with `<catch2/catch_all.hpp>` across all 17 test files
- Renames `Catch::TestEventListenerBase` → `Catch::EventListenerBase` in `unittest.cpp` (class was renamed in v3)

## Test plan

- [x] `pixi run build` — clean build, no deprecation warnings
- [x] `pixi run test` — all 3 test suites pass (100%, 13.34s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)