### PR TITLE
perf(cudf): skip uploading all-valid null masks in host->GPU reconstruction

### DIFF
--- a/src/cudf/representation_converter_builtins.cpp
+++ b/src/cudf/representation_converter_builtins.cpp
@@ -971,9 +971,11 @@ static rmm::device_buffer alloc_and_schedule_h2d(
   rmm::device_async_resource_ref mr,
   BatchCopyAccumulator& batch)
 {
-  nvtxRangePushA("hg:dev_alloc");
-  rmm::device_buffer buf(size, stream, mr);
-  nvtxRangePop();
+  rmm::device_buffer buf;
+  {
+    nvtx_scope alloc_range{"hg:dev_alloc"};
+    buf = rmm::device_buffer(size, stream, mr);
+  }
   if (size == 0) { return buf; }
   if (alloc.size() == 0) {
     throw std::invalid_argument(
@@ -1017,9 +1019,11 @@ static rmm::device_buffer alloc_and_copy_h2d_sync(
   rmm::device_async_resource_ref mr)
 {
   nvtx_scope range{"hg:nullmask_sync"};
-  nvtxRangePushA("hg:dev_alloc");
-  rmm::device_buffer buf(size, stream, mr);
-  nvtxRangePop();
+  rmm::device_buffer buf;
+  {
+    nvtx_scope alloc_range{"hg:dev_alloc"};
+    buf = rmm::device_buffer(size, stream, mr);
+  }
   if (size == 0) { return buf; }
 
   const std::size_t block_size = alloc.block_size();
@@ -1197,9 +1201,10 @@ std::unique_ptr<idata_representation> convert_host_fast_to_gpu(
   // host_data_representation is flushed before we read the pinned host blocks.
   // The caller's stream may be bound to a non-target device under multi-GPU;
   // synchronize is safe across devices.
-  nvtxRangePushA("hg:presync");
-  stream.synchronize();
-  nvtxRangePop();
+  {
+    nvtx_scope presync_range{"hg:presync"};
+    stream.synchronize();
+  }
 
   rmm::cuda_set_device_raii device_guard{rmm::cuda_device_id{target_memory_space->get_device_id()}};
 
@@ -1207,30 +1212,34 @@ std::unique_ptr<idata_representation> convert_host_fast_to_gpu(
   // Using the caller's stream for the H2D batch under a target-device RAII
   // guard raises cudaErrorInvalidValue when stream and current device belong
   // to different CUDA contexts (multi-GPU case).
-  nvtxRangePushA("hg:acquire_stream");
-  auto target_stream = target_memory_space->acquire_stream();
-  auto mr            = target_memory_space->get_default_allocator();
-  nvtxRangePop();
+  auto target_stream = [&] {
+    nvtx_scope acquire_range{"hg:acquire_stream"};
+    return target_memory_space->acquire_stream();
+  }();
+  auto mr = target_memory_space->get_default_allocator();
 
   // Collect all H→D copy ops across all columns, then fire one batched call.
   BatchCopyAccumulator batch;
   std::vector<std::unique_ptr<cudf::column>> gpu_columns;
   gpu_columns.reserve(fast_table->columns.size());
-  nvtxRangePushA("hg:reconstruct");
-  for (const auto& col_meta : fast_table->columns) {
-    gpu_columns.push_back(
-      reconstruct_column(col_meta, *fast_table->allocation, target_stream, mr, batch));
+  {
+    nvtx_scope reconstruct_range{"hg:reconstruct"};
+    for (const auto& col_meta : fast_table->columns) {
+      gpu_columns.push_back(
+        reconstruct_column(col_meta, *fast_table->allocation, target_stream, mr, batch));
+    }
   }
-  nvtxRangePop();
   // Source is CPU-written pinned host memory: fully prepared before this call.
-  nvtxRangePushA("hg:flush_submit");
-  batch.flush(target_stream, cudaMemcpySrcAccessOrderDuringApiCall);
-  nvtxRangePop();
+  {
+    nvtx_scope flush_range{"hg:flush_submit"};
+    batch.flush(target_stream, cudaMemcpySrcAccessOrderDuringApiCall);
+  }
 
   auto new_table = std::make_unique<cudf::table>(std::move(gpu_columns));
-  nvtxRangePushA("hg:final_sync");
-  target_stream.synchronize();
-  nvtxRangePop();
+  {
+    nvtx_scope final_sync_range{"hg:final_sync"};
+    target_stream.synchronize();
+  }
 
   // STREAM-LINEAGE: writes happened on target_stream; record event so
   // cross-stream readers observe ordering.

--- a/src/cudf/representation_converter_builtins.cpp
+++ b/src/cudf/representation_converter_builtins.cpp
@@ -50,6 +50,7 @@
 #include <rmm/resource_ref.hpp>
 
 #include <cuda_runtime.h>
+#include <nvtx3/nvToolsExt.h>
 
 #include <algorithm>
 #include <cassert>
@@ -73,6 +74,14 @@ namespace cucascade {
 // =============================================================================
 
 namespace {
+
+// RAII NVTX range for profiling converter phases (thread-local push/pop stack).
+struct nvtx_scope {
+  explicit nvtx_scope(const char* name) { nvtxRangePushA(name); }
+  ~nvtx_scope() { nvtxRangePop(); }
+  nvtx_scope(const nvtx_scope&)            = delete;
+  nvtx_scope& operator=(const nvtx_scope&) = delete;
+};
 
 // memory::column_metadata::type_id is a generic int32_t type tag; the cudf layer interprets it
 // as the numeric value of a cudf::type_id. These helpers convert across that boundary.
@@ -962,7 +971,9 @@ static rmm::device_buffer alloc_and_schedule_h2d(
   rmm::device_async_resource_ref mr,
   BatchCopyAccumulator& batch)
 {
+  nvtxRangePushA("hg:dev_alloc");
   rmm::device_buffer buf(size, stream, mr);
+  nvtxRangePop();
   if (size == 0) { return buf; }
   if (alloc.size() == 0) {
     throw std::invalid_argument(
@@ -1005,7 +1016,10 @@ static rmm::device_buffer alloc_and_copy_h2d_sync(
   rmm::cuda_stream_view stream,
   rmm::device_async_resource_ref mr)
 {
+  nvtx_scope range{"hg:nullmask_sync"};
+  nvtxRangePushA("hg:dev_alloc");
   rmm::device_buffer buf(size, stream, mr);
+  nvtxRangePop();
   if (size == 0) { return buf; }
 
   const std::size_t block_size = alloc.block_size();
@@ -1075,6 +1089,7 @@ static std::unique_ptr<cudf::column> reconstruct_column(
       // Flush pending H2D copies so the INT32 offsets buffer has valid data on device
       // before the cast reads from it. The cast replaces offsets_col, freeing the old
       // INT32 buffer, so batch must not hold dangling pointers to it.
+      nvtx_scope cast_range{"hg:offsets_cast"};
       batch.flush(stream, cudaMemcpySrcAccessOrderDuringApiCall);
       offsets_col =
         cudf::cast(offsets_col->view(), cudf::data_type{cudf::type_id::INT64}, stream, mr);
@@ -1167,6 +1182,7 @@ std::unique_ptr<idata_representation> convert_host_fast_to_gpu(
   rmm::cuda_stream_view stream,
   [[maybe_unused]] memory::reservation* reservation)
 {
+  nvtx_scope convert_range{"hg:convert"};
   auto& fast_source      = source.cast<host_data_representation>();
   const auto& fast_table = fast_source.get_host_table();
   if (!fast_table) { throw std::runtime_error("convert_host_fast_to_gpu: host table is null"); }
@@ -1178,7 +1194,9 @@ std::unique_ptr<idata_representation> convert_host_fast_to_gpu(
   // host_data_representation is flushed before we read the pinned host blocks.
   // The caller's stream may be bound to a non-target device under multi-GPU;
   // synchronize is safe across devices.
+  nvtxRangePushA("hg:presync");
   stream.synchronize();
+  nvtxRangePop();
 
   rmm::cuda_set_device_raii device_guard{rmm::cuda_device_id{target_memory_space->get_device_id()}};
 
@@ -1186,22 +1204,30 @@ std::unique_ptr<idata_representation> convert_host_fast_to_gpu(
   // Using the caller's stream for the H2D batch under a target-device RAII
   // guard raises cudaErrorInvalidValue when stream and current device belong
   // to different CUDA contexts (multi-GPU case).
+  nvtxRangePushA("hg:acquire_stream");
   auto target_stream = target_memory_space->acquire_stream();
   auto mr            = target_memory_space->get_default_allocator();
+  nvtxRangePop();
 
   // Collect all H→D copy ops across all columns, then fire one batched call.
   BatchCopyAccumulator batch;
   std::vector<std::unique_ptr<cudf::column>> gpu_columns;
   gpu_columns.reserve(fast_table->columns.size());
+  nvtxRangePushA("hg:reconstruct");
   for (const auto& col_meta : fast_table->columns) {
     gpu_columns.push_back(
       reconstruct_column(col_meta, *fast_table->allocation, target_stream, mr, batch));
   }
+  nvtxRangePop();
   // Source is CPU-written pinned host memory: fully prepared before this call.
+  nvtxRangePushA("hg:flush_submit");
   batch.flush(target_stream, cudaMemcpySrcAccessOrderDuringApiCall);
+  nvtxRangePop();
 
   auto new_table = std::make_unique<cudf::table>(std::move(gpu_columns));
+  nvtxRangePushA("hg:final_sync");
   target_stream.synchronize();
+  nvtxRangePop();
 
   // STREAM-LINEAGE: writes happened on target_stream; record event so
   // cross-stream readers observe ordering.

--- a/src/cudf/representation_converter_builtins.cpp
+++ b/src/cudf/representation_converter_builtins.cpp
@@ -1065,9 +1065,12 @@ static std::unique_ptr<cudf::column> reconstruct_column(
   rmm::device_async_resource_ref mr,
   BatchCopyAccumulator& batch)
 {
-  // Null mask — copied synchronously because cudf factories access it on construction
+  // Null mask — copied synchronously because cudf factories access it on construction.
+  // An all-valid mask (null_count == 0) is semantically identical to no mask: skip its
+  // upload entirely and construct the column non-nullable, avoiding a per-column
+  // blocking memcpy + stream sync.
   rmm::device_buffer null_mask{};
-  if (meta.has_null_mask) {
+  if (meta.has_null_mask && meta.null_count > 0) {
     null_mask =
       alloc_and_copy_h2d_sync(alloc, meta.null_mask_offset, meta.null_mask_size, stream, mr);
   }

--- a/test/data/test_data_representation.cpp
+++ b/test/data/test_data_representation.cpp
@@ -2000,7 +2000,7 @@ TEST_CASE("Round-trip fast: INT32 column data preserved", "[fast][roundtrip]")
   REQUIRE(bytes[N * sizeof(int32_t) - 1] == 0xAB);
 }
 
-TEST_CASE("Round-trip fast: nullable INT64 null mask preserved", "[fast][roundtrip]")
+TEST_CASE("Round-trip fast: all-valid null mask is elided on reconstruction", "[fast][roundtrip]")
 {
   memory::memory_reservation_manager mgr(create_conversion_test_configs());
   representation_converter_registry registry;
@@ -2030,11 +2030,64 @@ TEST_CASE("Round-trip fast: nullable INT64 null mask preserved", "[fast][roundtr
 
   REQUIRE(back->get_table_view().num_columns() == 1);
   cudf::table_view back_tv = back->get_table_view();
-  REQUIRE(back_tv.column(0).nullable());
+  // An all-valid mask (null_count == 0) is semantically identical to no mask:
+  // reconstruction deliberately skips its upload and builds the column
+  // non-nullable, saving a per-column blocking memcpy + stream sync.
+  REQUIRE_FALSE(back_tv.column(0).nullable());
   REQUIRE(back_tv.column(0).null_count() == 0);
 
   auto data_bytes = gpu_bytes(back_tv.column(0).data<uint8_t>(), N * sizeof(int64_t));
   REQUIRE(data_bytes[0] == 0x77);
+}
+
+TEST_CASE("Round-trip fast: null mask with real nulls is uploaded and preserved",
+          "[fast][roundtrip]")
+{
+  memory::memory_reservation_manager mgr(create_conversion_test_configs());
+  representation_converter_registry registry;
+  register_builtin_converters(registry);
+
+  const auto* gpu_space  = mgr.get_memory_space(memory::Tier::GPU, 0);
+  const auto* host_space = mgr.get_memory_space(memory::Tier::HOST, 0);
+  rmm::cuda_stream stream;
+
+  constexpr int N = 32;
+  auto col        = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT64},
+                                       N,
+                                       cudf::mask_state::ALL_VALID,
+                                       stream.view(),
+                                       gpu_space->get_default_allocator());
+  CUCASCADE_CUDA_TRY(
+    cudaMemsetAsync(col->mutable_view().head(), 0x55, N * sizeof(int64_t), stream.view()));
+  // Null out rows [3, 7) — 4 nulls.
+  cudf::set_null_mask(col->mutable_view().null_mask(), 3, 7, false, stream.view());
+  stream.synchronize();
+  col->set_null_count(4);
+
+  auto orig_repr = wrap_column(
+    std::move(col), *const_cast<memory::memory_space*>(gpu_space), rmm::cuda_stream_view{});
+  auto host = fast_convert(orig_repr, host_space, registry, stream.view());
+  stream.synchronize();
+
+  auto back = fast_back_convert(*host, gpu_space, registry, stream.view());
+  stream.synchronize();
+
+  REQUIRE(back->get_table_view().num_columns() == 1);
+  cudf::table_view back_tv = back->get_table_view();
+  REQUIRE(back_tv.column(0).nullable());
+  REQUIRE(back_tv.column(0).null_count() == 4);
+
+  // Mask bits round-trip exactly: rows [3, 7) invalid, everything else valid.
+  auto mask_bytes = gpu_bytes(reinterpret_cast<const uint8_t*>(back_tv.column(0).null_mask()),
+                              sizeof(cudf::bitmask_type));
+  const uint32_t mask_word =
+    static_cast<uint32_t>(mask_bytes[0]) | (static_cast<uint32_t>(mask_bytes[1]) << 8) |
+    (static_cast<uint32_t>(mask_bytes[2]) << 16) | (static_cast<uint32_t>(mask_bytes[3]) << 24);
+  REQUIRE(mask_word == ~(uint32_t{0b1111} << 3));
+
+  auto data_bytes = gpu_bytes(back_tv.column(0).data<uint8_t>(), N * sizeof(int64_t));
+  REQUIRE(data_bytes[0] == 0x55);
+  REQUIRE(data_bytes[N * sizeof(int64_t) - 1] == 0x55);
 }
 
 TEST_CASE("Round-trip fast: FLOAT64 byte integrity", "[fast][roundtrip]")


### PR DESCRIPTION
## What

Two commits:

1. **NVTX phase instrumentation** for `convert_host_fast_to_gpu` — named ranges around each conversion phase (presync, stream acquisition, column reconstruction, device alloc, null-mask sync, offsets cast, batch flush, final sync). Zero-cost without a profiler; with nsys it yields a per-phase wall-time breakdown of every host→GPU conversion.
2. **Skip all-valid null masks** during column reconstruction. Masks upload via a synchronous per-column memcpy + stream sync (cudf factories read them at construction, so they cannot join the async copy batch). When `null_count == 0` the mask is semantically a no-op — skip the upload and construct the column non-nullable.

## Why / measurements

Profiling TPC-H SF1000 host-pinned scans on GB300 (all columns all-valid): the mask syncs accounted for ~10.4 ms of every 39 ms five-GB conversion (~975 blocking round-trips and 5.2 GB of mask bytes per q9 iteration), amplified by pooled-stream aliasing across converting threads. With the fix, per-conversion wall time drops ~2.5x in combination with larger host block sizes, q9 hot improves 3.5%, and copy-engine duty within conversion windows reaches ~89% (link-bound). Query results are byte-identical.

## Semantics caveat for review

Reconstructed all-valid columns become **non-nullable** instead of nullable-with-all-valid-mask. cudf treats these as equivalent for computation, but strict column-equality checks that compare nullability flags could notice. If that is a concern, the alternative is batching mask uploads into the existing `cudaMemcpyBatchAsync` flush for the column constructors that don't read mask contents (fixed-width/LIST/STRUCT) — happy to rework in that direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)