### PR TITLE
fix(test): migrate the last Catch2 v2 include to v3

### DIFF
--- a/test/memory/test_reservation_manager_configurator.cpp
+++ b/test/memory/test_reservation_manager_configurator.cpp
@@ -26,7 +26,7 @@
 #include <cucascade/memory/reservation_manager_configurator.hpp>
 #include <cucascade/memory/topology_discovery.hpp>
 
-#include <catch2/catch.hpp>
+#include <catch2/catch_all.hpp>
 
 #include <cstddef>
 #include <stdexcept>


### PR DESCRIPTION
test_reservation_manager_configurator.cpp still included <catch2/catch.hpp>, which no longer exists after the v3.8.1 upgrade (#170), so building the cucascade_tests target fails on main. 

Every sibling test file already uses <catch2/catch_all.hpp>; align the one missed file. No test-content changes.