### PR TITLE
feat(io): capture object ETags and expose a validation tag on io_object 

### DIFF
--- a/include/cucascade/io/rest/rest_reactor.hpp
+++ b/include/cucascade/io/rest/rest_reactor.hpp
@@ -122,9 +122,8 @@ struct head_object_result {
 /**
  * @brief Concrete @c io_object backed by a RESTful object-store key.
  *
- * Passive bag of identity: the original URL/path (also the cache id), the
- * bucket + key the reactor authorizes against, and the object size discovered
- * by a one-time HEAD at construction.  Does no I/O of its own.
+ * Stores the object identity and metadata captured when it was opened.
+ * Does no I/O of its own.
  */
 class rest_io_object : public io_object {
  public:

--- a/include/cucascade/io/rest/rest_reactor.hpp
+++ b/include/cucascade/io/rest/rest_reactor.hpp
@@ -104,6 +104,15 @@ struct footer_probe {
   std::size_t object_size{0};
   std::size_t window_lo{0};
   shared_byte_span bytes;
+  /// ETag from the verified 206, quotes preserved; empty otherwise.
+  std::string etag;
+};
+
+/// Result of a blocking HEAD: the object's size plus its ETag when the server
+/// sent one (quotes preserved, empty otherwise).
+struct head_object_result {
+  std::size_t object_size{0};
+  std::string etag;
 };
 
 // ---------------------------------------------------------------------------
@@ -119,8 +128,13 @@ struct footer_probe {
  */
 class rest_io_object : public io_object {
  public:
-  rest_io_object(std::string path, std::string bucket, std::string key, size_t size)
-    : _path(std::move(path)), _bucket(std::move(bucket)), _key(std::move(key)), _file_size(size)
+  rest_io_object(
+    std::string path, std::string bucket, std::string key, size_t size, std::string etag = {})
+    : _path(std::move(path)),
+      _bucket(std::move(bucket)),
+      _key(std::move(key)),
+      _file_size(size),
+      _etag(std::move(etag))
   {
   }
 
@@ -132,19 +146,22 @@ class rest_io_object : public io_object {
                  std::string key,
                  size_t object_size,
                  size_t window_lo,
-                 shared_byte_span stash)
+                 shared_byte_span stash,
+                 std::string etag = {})
     : _path(std::move(path)),
       _bucket(std::move(bucket)),
       _key(std::move(key)),
       _file_size(object_size),
       _window_lo(window_lo),
-      _stash(std::move(stash))
+      _stash(std::move(stash)),
+      _etag(std::move(etag))
   {
   }
 
   [[nodiscard]] const std::string& raw_file_cache_id() const noexcept override { return _path; }
   [[nodiscard]] const std::string& object_path() const noexcept override { return _path; }
   [[nodiscard]] size_t size() const noexcept override { return _file_size; }
+  [[nodiscard]] std::string_view validation_tag() const noexcept override { return _etag; }
 
   [[nodiscard]] const std::string& bucket() const noexcept { return _bucket; }
   [[nodiscard]] const std::string& key() const noexcept { return _key; }
@@ -163,6 +180,7 @@ class rest_io_object : public io_object {
   size_t _file_size{0};
   size_t _window_lo{0};
   shared_byte_span _stash;
+  std::string _etag;
 };
 
 // ---------------------------------------------------------------------------
@@ -324,16 +342,19 @@ class rest_reactor {
   /// Synchronous buffered host read (blocking ranged GET).  Blocks the caller.
   size_t host_read(const io_object_type& file, size_t offset, size_t size, uint8_t* dst);
 
-  /// Blocking HEAD to discover an object's size.  Used by the ioctx to build
-  /// an @c rest_io_object.  @p bucket / @p key identify the object.
+  /// Blocking HEAD to discover an object's size and ETag.  Used by the ioctx to
+  /// build an @c rest_io_object.  @p bucket / @p key identify the object.
+  head_object_result head_object(std::string_view bucket, std::string_view key);
+
+  /// Size-only convenience wrapper around @c head_object.
   size_t head_object_size(std::string_view bucket, std::string_view key);
 
   /// Blocking suffix-range GET of the last @p n bytes of an object, resolving
   /// the size and stashing the parquet footer in a single round-trip.  On a
   /// well-formed 206 the returned @c footer_probe carries the object size, the
-  /// window origin, and the trailing bytes; on any unusable response (200 full
-  /// body, missing / unsatisfied Content-Range) @c bytes is null so the caller
-  /// falls back to a HEAD.  @p bucket / @p key identify the object.
+  /// window origin, the trailing bytes, and the ETag; on any unusable response
+  /// (200 full body, missing / unsatisfied Content-Range) @c bytes is null so
+  /// the caller falls back to a HEAD.  @p bucket / @p key identify the object.
   footer_probe fetch_footer_suffix(std::string_view bucket, std::string_view key, std::size_t n);
 
   /// Blocking bucket-level ListObjectsV2 GET for one page: returns the raw XML

--- a/include/cucascade/io/types.hpp
+++ b/include/cucascade/io/types.hpp
@@ -29,6 +29,7 @@
 #include <cstdint>
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace cucascade::io {
@@ -93,6 +94,16 @@ class io_object : public std::enable_shared_from_this<io_object> {
   /// Total size of the underlying object, populated by the reactor at
   /// construction time and stored on the io_object thereafter.
   [[nodiscard]] virtual size_t size() const noexcept = 0;
+
+  /// Opaque validation tag for the underlying object as observed at open (the
+  /// HTTP ETag for object-store backends, quotes and any weak `W/` prefix
+  /// preserved); empty when unavailable.  Consumers compare it only for
+  /// equality against a tag they captured earlier — it is a cache validator,
+  /// NOT a precondition token (weak ETags are invalid for If-Match / If-Range
+  /// strong comparison).  The view is valid only while this io_object is
+  /// alive; copy it to outlive the handle.  An empty tag disables
+  /// validation-based caching above — degraded performance, never wrong bytes.
+  [[nodiscard]] virtual std::string_view validation_tag() const noexcept { return {}; }
 };
 
 class io_object_metadata {

--- a/include/cucascade/io/types.hpp
+++ b/include/cucascade/io/types.hpp
@@ -95,14 +95,10 @@ class io_object : public std::enable_shared_from_this<io_object> {
   /// construction time and stored on the io_object thereafter.
   [[nodiscard]] virtual size_t size() const noexcept = 0;
 
-  /// Opaque validation tag for the underlying object as observed at open (the
-  /// HTTP ETag for object-store backends, quotes and any weak `W/` prefix
-  /// preserved); empty when unavailable.  Consumers compare it only for
-  /// equality against a tag they captured earlier — it is a cache validator,
-  /// NOT a precondition token (weak ETags are invalid for If-Match / If-Range
-  /// strong comparison).  The view is valid only while this io_object is
-  /// alive; copy it to outlive the handle.  An empty tag disables
-  /// validation-based caching above — degraded performance, never wrong bytes.
+  /// Opaque cache validator observed when the object was opened; empty when
+  /// unavailable.  HTTP backends preserve quotes and a weak W/ prefix.  This
+  /// is not an If-Match or If-Range token.  The view is valid for this
+  /// object's lifetime.
   [[nodiscard]] virtual std::string_view validation_tag() const noexcept { return {}; }
 };
 

--- a/src/io/rest/rest_ioctx.cpp
+++ b/src/io/rest/rest_ioctx.cpp
@@ -163,11 +163,14 @@ std::shared_ptr<io_object> rest_ioctx::create_io_object(std::string path)
   if (_reactors.empty()) { throw std::runtime_error("rest_ioctx::create_io_object: no reactors"); }
 
   // A blocking HEAD on the caller thread (a one-time metadata round-trip) via
-  // any reactor's authorizer — head_object_size uses a local easy handle and
-  // does not touch worker state, so any reactor is equivalent.
-  size_t const size = _reactors.front()->head_object_size(parsed.host, parsed.path);
-  return std::make_shared<rest_io_object>(
-    std::move(path), std::move(parsed.host), std::move(parsed.path), size);
+  // any reactor's authorizer — head_object uses a local easy handle and does
+  // not touch worker state, so any reactor is equivalent.
+  auto head = _reactors.front()->head_object(parsed.host, parsed.path);
+  return std::make_shared<rest_io_object>(std::move(path),
+                                          std::move(parsed.host),
+                                          std::move(parsed.path),
+                                          head.object_size,
+                                          std::move(head.etag));
 }
 
 std::shared_ptr<io_object> rest_ioctx::create_io_object(std::string path, open_hint hint)
@@ -209,16 +212,20 @@ std::shared_ptr<io_object> rest_ioctx::create_footer_probe_object(std::string pa
   if (!probe.bytes) {
     // Unusable suffix response (200 full body, 416, missing / "*" Content-Range):
     // fall back to a plain HEAD for the size, with no stash.
-    size_t const size = _reactors.front()->head_object_size(parsed.host, parsed.path);
-    return std::make_shared<rest_io_object>(
-      std::move(path), std::move(parsed.host), std::move(parsed.path), size);
+    auto head = _reactors.front()->head_object(parsed.host, parsed.path);
+    return std::make_shared<rest_io_object>(std::move(path),
+                                            std::move(parsed.host),
+                                            std::move(parsed.path),
+                                            head.object_size,
+                                            std::move(head.etag));
   }
   return std::make_shared<rest_io_object>(std::move(path),
                                           std::move(parsed.host),
                                           std::move(parsed.path),
                                           probe.object_size,
                                           probe.window_lo,
-                                          probe.bytes);
+                                          probe.bytes,
+                                          std::move(probe.etag));
 }
 
 }  // namespace cucascade::io::rest

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -144,18 +144,16 @@ size_t capture_header(char* buffer, size_t size, size_t nitems, void* userdata)
   return bytes;
 }
 
-/// True iff @p line is an HTTP status line ("HTTP/..."), i.e. the start of a
-/// (possibly interim) response's header block within one transfer.
+/// Returns true for an HTTP status line.
 bool is_http_status_line(std::string_view line) noexcept
 {
   return line.size() >= 5 && ascii_lower(line[0]) == 'h' && ascii_lower(line[1]) == 't' &&
          ascii_lower(line[2]) == 't' && ascii_lower(line[3]) == 'p' && line[4] == '/';
 }
 
-/// Per-attempt capture for the blocking HEAD: Retry-After for backoff plus the
-/// object's ETag.  Separate from @c header_capture so the async data-GET path
-/// parses nothing it does not consume.  The ETag resets on every status line,
-/// so interim responses (proxy CONNECT) within one transfer leave no residue.
+/// Headers captured for one HEAD attempt.  Separate from @c header_capture so
+/// the async data-GET path parses nothing it does not consume.  A status line
+/// starts a new response block within the transfer, so all fields reset there.
 struct head_capture {
   std::string retry_after;
   std::string etag;
@@ -166,7 +164,10 @@ size_t head_header_cb(char* buffer, size_t size, size_t nitems, void* userdata)
   auto* hc           = static_cast<head_capture*>(userdata);
   size_t const bytes = size * nitems;
   std::string_view const line(buffer, bytes);
-  if (is_http_status_line(line)) { hc->etag.clear(); }
+  if (is_http_status_line(line)) {
+    hc->etag.clear();
+    hc->retry_after.clear();
+  }
   if (auto v = match_header(line, "etag"); !v.empty()) { hc->etag = std::move(v); }
   if (auto v = match_header(line, "retry-after"); !v.empty()) { hc->retry_after = std::move(v); }
   return bytes;
@@ -187,10 +188,9 @@ struct suffix_sink {
   std::string etag;
 };
 
-/// Header callback for a suffix probe: parse the status code out of the status
-/// line so the body callback can abort a non-206 early, and capture the headers
-/// the caller needs (Content-Range to verify the 206, Retry-After for backoff,
-/// ETag for the probe result).
+/// Capture the status and headers used to validate or retry a suffix probe.
+/// A status line starts a new response block within the transfer, so the
+/// header fields reset there — only the final block's values survive.
 size_t suffix_header_cb(char* buffer, size_t size, size_t nitems, void* userdata)
 {
   auto* s            = static_cast<suffix_sink*>(userdata);
@@ -198,6 +198,8 @@ size_t suffix_header_cb(char* buffer, size_t size, size_t nitems, void* userdata
   std::string_view const line(buffer, bytes);
   if (is_http_status_line(line)) {
     s->etag.clear();
+    s->content_range.clear();
+    s->retry_after.clear();
     if (auto const sp = line.find(' '); sp != std::string_view::npos) {
       long code = 0;
       for (size_t i = sp + 1; i < line.size() && line[i] >= '0' && line[i] <= '9'; ++i) {

--- a/src/io/rest/rest_reactor.cpp
+++ b/src/io/rest/rest_reactor.cpp
@@ -144,10 +144,39 @@ size_t capture_header(char* buffer, size_t size, size_t nitems, void* userdata)
   return bytes;
 }
 
+/// True iff @p line is an HTTP status line ("HTTP/..."), i.e. the start of a
+/// (possibly interim) response's header block within one transfer.
+bool is_http_status_line(std::string_view line) noexcept
+{
+  return line.size() >= 5 && ascii_lower(line[0]) == 'h' && ascii_lower(line[1]) == 't' &&
+         ascii_lower(line[2]) == 't' && ascii_lower(line[3]) == 'p' && line[4] == '/';
+}
+
+/// Per-attempt capture for the blocking HEAD: Retry-After for backoff plus the
+/// object's ETag.  Separate from @c header_capture so the async data-GET path
+/// parses nothing it does not consume.  The ETag resets on every status line,
+/// so interim responses (proxy CONNECT) within one transfer leave no residue.
+struct head_capture {
+  std::string retry_after;
+  std::string etag;
+};
+
+size_t head_header_cb(char* buffer, size_t size, size_t nitems, void* userdata)
+{
+  auto* hc           = static_cast<head_capture*>(userdata);
+  size_t const bytes = size * nitems;
+  std::string_view const line(buffer, bytes);
+  if (is_http_status_line(line)) { hc->etag.clear(); }
+  if (auto v = match_header(line, "etag"); !v.empty()) { hc->etag = std::move(v); }
+  if (auto v = match_header(line, "retry-after"); !v.empty()) { hc->retry_after = std::move(v); }
+  return bytes;
+}
+
 /// Shared sink for a suffix-range footer probe: the header callback records the
-/// HTTP status (from the status line) plus Content-Range / Retry-After; the body
-/// callback consults @c status to abort a non-206 response before it streams a
-/// whole object into us.  @c HEADERDATA and @c WRITEDATA point at the same one.
+/// HTTP status (from the status line) plus Content-Range / Retry-After / ETag;
+/// the body callback consults @c status to abort a non-206 response before it
+/// streams a whole object into us.  @c HEADERDATA and @c WRITEDATA point at the
+/// same one.
 struct suffix_sink {
   std::vector<std::uint8_t> data;
   std::size_t cap{0};
@@ -155,18 +184,20 @@ struct suffix_sink {
   long status{0};
   std::string content_range;
   std::string retry_after;
+  std::string etag;
 };
 
 /// Header callback for a suffix probe: parse the status code out of the status
 /// line so the body callback can abort a non-206 early, and capture the headers
-/// the caller needs (Content-Range to verify the 206, Retry-After for backoff).
+/// the caller needs (Content-Range to verify the 206, Retry-After for backoff,
+/// ETag for the probe result).
 size_t suffix_header_cb(char* buffer, size_t size, size_t nitems, void* userdata)
 {
   auto* s            = static_cast<suffix_sink*>(userdata);
   size_t const bytes = size * nitems;
   std::string_view const line(buffer, bytes);
-  if (line.size() >= 5 && ascii_lower(line[0]) == 'h' && ascii_lower(line[1]) == 't' &&
-      ascii_lower(line[2]) == 't' && ascii_lower(line[3]) == 'p' && line[4] == '/') {
+  if (is_http_status_line(line)) {
+    s->etag.clear();
     if (auto const sp = line.find(' '); sp != std::string_view::npos) {
       long code = 0;
       for (size_t i = sp + 1; i < line.size() && line[i] >= '0' && line[i] <= '9'; ++i) {
@@ -177,6 +208,7 @@ size_t suffix_header_cb(char* buffer, size_t size, size_t nitems, void* userdata
   }
   if (auto v = match_header(line, "content-range"); !v.empty()) { s->content_range = std::move(v); }
   if (auto v = match_header(line, "retry-after"); !v.empty()) { s->retry_after = std::move(v); }
+  if (auto v = match_header(line, "etag"); !v.empty()) { s->etag = std::move(v); }
   return bytes;
 }
 
@@ -846,17 +878,17 @@ rest_perf_snapshot rest_reactor::perf_snapshot() const noexcept
   return s;
 }
 
-size_t rest_reactor::head_object_size(std::string_view bucket, std::string_view key)
+head_object_result rest_reactor::head_object(std::string_view bucket, std::string_view key)
 {
   object_ref const obj{std::string(bucket), std::string(key)};
   std::string last_error;
   for (std::size_t attempt = 0; attempt < _config.max_retry_attempts; ++attempt) {
-    header_capture hc;
+    head_capture hc;
     auto const authd =
       _ctx->authorizer()->authorize(obj, request_method::HEAD, presign_ttl(_config));
 
     curl_easy_ptr h{curl_easy_init()};
-    if (!h) { throw std::runtime_error("rest_reactor::head_object_size: curl_easy_init failed"); }
+    if (!h) { throw std::runtime_error("rest_reactor::head_object: curl_easy_init failed"); }
     configure_easy_handle(h.get(), global_curl_context::instance().share_handle());
     apply_request_opts(h.get(), _config);
 
@@ -865,7 +897,7 @@ size_t rest_reactor::head_object_size(std::string_view bucket, std::string_view 
     CUCASCADE_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_NOBODY, 1L));
     CUCASCADE_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_HTTPHEADER, hdrs.get()));
     CUCASCADE_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_WRITEFUNCTION, &write_discard));
-    CUCASCADE_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_HEADERFUNCTION, &capture_header));
+    CUCASCADE_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_HEADERFUNCTION, &head_header_cb));
     CUCASCADE_CURL_CHECK(curl_easy_setopt(h.get(), CURLOPT_HEADERDATA, &hc));
 
     CURLcode const rc = curl_easy_perform(h.get());
@@ -877,10 +909,10 @@ size_t rest_reactor::head_object_size(std::string_view bucket, std::string_view 
       curl_easy_getinfo(h.get(), CURLINFO_CONTENT_LENGTH_DOWNLOAD_T, &cl);
       if (cl < 0) {
         _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
-        throw std::runtime_error("rest_reactor::head_object_size: missing Content-Length for " +
+        throw std::runtime_error("rest_reactor::head_object: missing Content-Length for " +
                                  obj.bucket + "/" + obj.key);
       }
-      return static_cast<size_t>(cl);
+      return head_object_result{static_cast<size_t>(cl), std::move(hc.etag)};
     }
 
     last_error =
@@ -889,12 +921,12 @@ size_t rest_reactor::head_object_size(std::string_view bucket, std::string_view 
       (rc != CURLE_OK && is_retriable_curl(rc)) || (rc == CURLE_OK && is_retriable_status(status));
     if (!retriable) {
       _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
-      throw std::runtime_error("rest_reactor::head_object_size: " + last_error + " for " +
-                               obj.bucket + "/" + obj.key);
+      throw std::runtime_error("rest_reactor::head_object: " + last_error + " for " + obj.bucket +
+                               "/" + obj.key);
     }
     if (attempt + 1 < _config.max_retry_attempts) {
       _perf.retries_total.fetch_add(1, std::memory_order_relaxed);
-      CUCASCADE_LOG_WARN("rest_reactor::head_object_size: retrying {}/{} after {} (attempt {}/{})",
+      CUCASCADE_LOG_WARN("rest_reactor::head_object: retrying {}/{} after {} (attempt {}/{})",
                          obj.bucket,
                          obj.key,
                          last_error,
@@ -904,8 +936,13 @@ size_t rest_reactor::head_object_size(std::string_view bucket, std::string_view 
     }
   }
   _perf.terminal_failures_total.fetch_add(1, std::memory_order_relaxed);
-  throw std::runtime_error("rest_reactor::head_object_size: exhausted retries (" + last_error +
+  throw std::runtime_error("rest_reactor::head_object: exhausted retries (" + last_error +
                            ") for " + obj.bucket + "/" + obj.key);
+}
+
+size_t rest_reactor::head_object_size(std::string_view bucket, std::string_view key)
+{
+  return head_object(bucket, key).object_size;
 }
 
 std::string rest_reactor::list_page(std::string_view bucket,
@@ -1044,6 +1081,7 @@ footer_probe rest_reactor::fetch_footer_suffix(std::string_view bucket,
         probe.object_size = *total;
         probe.window_lo   = *start;
         probe.bytes       = make_shared_byte_span(std::move(sink.data));
+        probe.etag        = std::move(sink.etag);
       }
       return probe;
     } else if (status == 200 || status == 416) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -65,6 +65,7 @@ if(NOT CUCASCADE_TOPOLOGY_ONLY AND CUCASCADE_BUILD_IO)
     io/cache/test_metadata_store.cpp
     io/kvikio/test_kvikio_config.cpp
     io/rest/test_rest_perf_snapshot.cpp
+    io/rest/test_rest_validation_tag.cpp
     io/rest/test_shared_byte_span.cpp
     io/rest/s3/test_sigv4.cpp
     io/rest/s3/test_sigv4_authorizer.cpp

--- a/test/io/rest/loopback_range_server.hpp
+++ b/test/io/rest/loopback_range_server.hpp
@@ -54,6 +54,15 @@ struct range_fault_policy {
   bool fail_all_heads{false};
   int head_fail_status{503};
   std::chrono::milliseconds response_delay{0};
+  bool ignore_range_with_200{false};
+  bool fail_range_with_416{false};
+  bool malformed_content_range{false};
+  std::string failed_get_etag;
+  std::string failed_head_etag;
+  std::string successful_get_etag;
+  std::string successful_head_etag;
+  std::string interim_get_etag;
+  std::string interim_head_etag;
 };
 
 struct listed_object {
@@ -124,6 +133,20 @@ class loopback_range_server {
  private:
   static std::string errno_message() { return std::strerror(errno); }
 
+  static void append_etag_header(std::string& response, std::string const& etag)
+  {
+    if (!etag.empty()) { response += "\r\nETag: " + etag; }
+  }
+
+  static void send_interim_headers(int fd, std::string const& etag)
+  {
+    if (etag.empty()) { return; }
+    std::string response{"HTTP/1.1 100 Continue"};
+    append_etag_header(response, etag);
+    response += "\r\n\r\n";
+    send_all(fd, response);
+  }
+
   void accept_loop()
   {
     while (!_stop.load(std::memory_order_relaxed)) {
@@ -161,15 +184,19 @@ class loopback_range_server {
 
     if (is_head) {
       auto const head_idx = _head_count.fetch_add(1, std::memory_order_relaxed);
+      send_interim_headers(fd, _fault.interim_head_etag);
       if (_fault.fail_all_heads || head_idx < _fault.fail_first_heads) {
-        send_all(fd,
-                 "HTTP/1.1 " + std::to_string(_fault.head_fail_status) +
-                   " Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+        std::string response =
+          "HTTP/1.1 " + std::to_string(_fault.head_fail_status) + " Error\r\nContent-Length: 0";
+        append_etag_header(response, _fault.failed_head_etag);
+        response += "\r\nConnection: close\r\n\r\n";
+        send_all(fd, response);
         return;
       }
-      send_all(fd,
-               "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(_object.size()) +
-                 "\r\nConnection: close\r\n\r\n");
+      std::string response = "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(_object.size());
+      append_etag_header(response, _fault.successful_head_etag);
+      response += "\r\nConnection: close\r\n\r\n";
+      send_all(fd, response);
       return;
     }
 
@@ -189,27 +216,55 @@ class loopback_range_server {
     }
 
     auto const get_idx = _get_count.fetch_add(1, std::memory_order_relaxed);
+    send_interim_headers(fd, _fault.interim_get_etag);
     if (_fault.fail_all_gets || get_idx < _fault.fail_first_gets) {
-      send_all(fd,
-               "HTTP/1.1 " + std::to_string(_fault.fail_status) +
-                 " Error\r\nContent-Length: 0\r\nConnection: close\r\n\r\n");
+      std::string response =
+        "HTTP/1.1 " + std::to_string(_fault.fail_status) + " Error\r\nContent-Length: 0";
+      append_etag_header(response, _fault.failed_get_etag);
+      response += "\r\nConnection: close\r\n\r\n";
+      send_all(fd, response);
       return;
     }
 
     if (auto range = parse_range(request)) {
+      if (_fault.fail_range_with_416) {
+        std::string response{"HTTP/1.1 416 Range Not Satisfiable\r\nContent-Length: 0"};
+        append_etag_header(response, _fault.failed_get_etag);
+        response += "\r\nConnection: close\r\n\r\n";
+        send_all(fd, response);
+        return;
+      }
+      if (_fault.ignore_range_with_200) {
+        std::string response =
+          "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(_object.size());
+        append_etag_header(response, _fault.failed_get_etag);
+        response += "\r\nConnection: close\r\n\r\n";
+        send_all(fd, response);
+        send_all(fd, _object.data(), _object.size());
+        return;
+      }
       auto const [start, end] = *range;
       auto const size         = end - start + 1;
-      send_all(fd,
-               "HTTP/1.1 206 Partial Content\r\nContent-Length: " + std::to_string(size) +
-                 "\r\nContent-Range: bytes " + std::to_string(start) + "-" + std::to_string(end) +
-                 "/" + std::to_string(_object.size()) + "\r\nConnection: close\r\n\r\n");
+      std::string response =
+        "HTTP/1.1 206 Partial Content\r\nContent-Length: " + std::to_string(size);
+      if (_fault.malformed_content_range) {
+        response += "\r\nContent-Range: bytes malformed";
+        append_etag_header(response, _fault.failed_get_etag);
+      } else {
+        response += "\r\nContent-Range: bytes " + std::to_string(start) + "-" +
+                    std::to_string(end) + "/" + std::to_string(_object.size());
+        append_etag_header(response, _fault.successful_get_etag);
+      }
+      response += "\r\nConnection: close\r\n\r\n";
+      send_all(fd, response);
       send_all(fd, _object.data() + start, size);
       return;
     }
 
-    send_all(fd,
-             "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(_object.size()) +
-               "\r\nConnection: close\r\n\r\n");
+    std::string response = "HTTP/1.1 200 OK\r\nContent-Length: " + std::to_string(_object.size());
+    append_etag_header(response, _fault.successful_get_etag);
+    response += "\r\nConnection: close\r\n\r\n";
+    send_all(fd, response);
     send_all(fd, _object.data(), _object.size());
   }
 

--- a/test/io/rest/loopback_range_server.hpp
+++ b/test/io/rest/loopback_range_server.hpp
@@ -57,12 +57,18 @@ struct range_fault_policy {
   bool ignore_range_with_200{false};
   bool fail_range_with_416{false};
   bool malformed_content_range{false};
+  bool omit_successful_content_range{false};
   std::string failed_get_etag;
+  std::string failed_get_retry_after;
   std::string failed_head_etag;
+  std::string failed_head_retry_after;
   std::string successful_get_etag;
   std::string successful_head_etag;
   std::string interim_get_etag;
+  std::string interim_get_content_range;
+  std::string interim_get_retry_after;
   std::string interim_head_etag;
+  std::string interim_head_retry_after;
 };
 
 struct listed_object {
@@ -138,11 +144,24 @@ class loopback_range_server {
     if (!etag.empty()) { response += "\r\nETag: " + etag; }
   }
 
-  static void send_interim_headers(int fd, std::string const& etag)
+  static void append_header(std::string& response, std::string_view name, std::string const& value)
   {
-    if (etag.empty()) { return; }
+    if (value.empty()) { return; }
+    response += "\r\n";
+    response.append(name);
+    response += ": " + value;
+  }
+
+  static void send_interim_headers(int fd,
+                                   std::string const& etag,
+                                   std::string const& content_range,
+                                   std::string const& retry_after)
+  {
+    if (etag.empty() && content_range.empty() && retry_after.empty()) { return; }
     std::string response{"HTTP/1.1 100 Continue"};
     append_etag_header(response, etag);
+    append_header(response, "Content-Range", content_range);
+    append_header(response, "Retry-After", retry_after);
     response += "\r\n\r\n";
     send_all(fd, response);
   }
@@ -184,11 +203,12 @@ class loopback_range_server {
 
     if (is_head) {
       auto const head_idx = _head_count.fetch_add(1, std::memory_order_relaxed);
-      send_interim_headers(fd, _fault.interim_head_etag);
+      send_interim_headers(fd, _fault.interim_head_etag, {}, _fault.interim_head_retry_after);
       if (_fault.fail_all_heads || head_idx < _fault.fail_first_heads) {
         std::string response =
           "HTTP/1.1 " + std::to_string(_fault.head_fail_status) + " Error\r\nContent-Length: 0";
         append_etag_header(response, _fault.failed_head_etag);
+        append_header(response, "Retry-After", _fault.failed_head_retry_after);
         response += "\r\nConnection: close\r\n\r\n";
         send_all(fd, response);
         return;
@@ -216,11 +236,15 @@ class loopback_range_server {
     }
 
     auto const get_idx = _get_count.fetch_add(1, std::memory_order_relaxed);
-    send_interim_headers(fd, _fault.interim_get_etag);
+    send_interim_headers(fd,
+                         _fault.interim_get_etag,
+                         _fault.interim_get_content_range,
+                         _fault.interim_get_retry_after);
     if (_fault.fail_all_gets || get_idx < _fault.fail_first_gets) {
       std::string response =
         "HTTP/1.1 " + std::to_string(_fault.fail_status) + " Error\r\nContent-Length: 0";
       append_etag_header(response, _fault.failed_get_etag);
+      append_header(response, "Retry-After", _fault.failed_get_retry_after);
       response += "\r\nConnection: close\r\n\r\n";
       send_all(fd, response);
       return;
@@ -251,8 +275,10 @@ class loopback_range_server {
         response += "\r\nContent-Range: bytes malformed";
         append_etag_header(response, _fault.failed_get_etag);
       } else {
-        response += "\r\nContent-Range: bytes " + std::to_string(start) + "-" +
-                    std::to_string(end) + "/" + std::to_string(_object.size());
+        if (!_fault.omit_successful_content_range) {
+          response += "\r\nContent-Range: bytes " + std::to_string(start) + "-" +
+                      std::to_string(end) + "/" + std::to_string(_object.size());
+        }
         append_etag_header(response, _fault.successful_get_etag);
       }
       response += "\r\nConnection: close\r\n\r\n";

--- a/test/io/rest/test_rest_validation_tag.cpp
+++ b/test/io/rest/test_rest_validation_tag.cpp
@@ -287,6 +287,106 @@ TEST_CASE("interim response tags do not leak into the final response", "[rest][v
   }
 }
 
+TEST_CASE("footer probes do not reuse Content-Range from an interim response",
+          "[rest][validation_tag]")
+{
+  range_fault_policy fault{};
+  fault.interim_get_content_range = "bytes " + std::to_string(object_size - probe_size) + "-" +
+                                    std::to_string(object_size - 1) + "/" +
+                                    std::to_string(object_size);
+  fault.omit_successful_content_range = true;
+  fault.successful_get_etag           = "\"discarded-probe\"";
+  fault.successful_head_etag          = "\"fallback-head\"";
+  loopback_range_server server(test_payload(), fault);
+  auto ioctx  = make_ioctx(server, test_config());
+  auto object = ioctx->open_io_object(std::string{object_uri}, open_hint::parquet_footer_probe);
+
+  CHECK(object->size() == object_size);
+  CHECK(object->validation_tag() == "\"fallback-head\"");
+  CHECK(server.get_count() == 1);
+  CHECK(server.head_count() == 1);
+}
+
+TEST_CASE("retry backoff uses only the final response block", "[rest][validation_tag]")
+{
+  auto retry_config = [](std::chrono::milliseconds fallback) {
+    auto cfg               = test_config();
+    cfg.honor_retry_after  = true;
+    cfg.retry_backoff_base = fallback;
+    return cfg;
+  };
+
+  SECTION("HEAD ignores interim Retry-After when the final block omits it")
+  {
+    range_fault_policy fault{};
+    fault.fail_first_heads         = 1;
+    fault.interim_head_retry_after = "2";
+    loopback_range_server server(test_payload(), fault);
+    auto reactor = make_reactor(server, retry_config(1ms));
+
+    auto const start   = std::chrono::steady_clock::now();
+    auto const result  = reactor->head_object("bucket", "object.bin");
+    auto const elapsed = std::chrono::steady_clock::now() - start;
+
+    CHECK(result.object_size == object_size);
+    CHECK(elapsed < 1s);
+    CHECK(server.head_count() == 2);
+  }
+
+  SECTION("HEAD uses Retry-After from the final block")
+  {
+    range_fault_policy fault{};
+    fault.fail_first_heads         = 1;
+    fault.interim_head_retry_after = "2";
+    fault.failed_head_retry_after  = "0";
+    loopback_range_server server(test_payload(), fault);
+    auto reactor = make_reactor(server, retry_config(1500ms));
+
+    auto const start   = std::chrono::steady_clock::now();
+    auto const result  = reactor->head_object("bucket", "object.bin");
+    auto const elapsed = std::chrono::steady_clock::now() - start;
+
+    CHECK(result.object_size == object_size);
+    CHECK(elapsed < 1s);
+    CHECK(server.head_count() == 2);
+  }
+
+  SECTION("footer probe ignores interim Retry-After when the final block omits it")
+  {
+    range_fault_policy fault{};
+    fault.fail_first_gets         = 1;
+    fault.interim_get_retry_after = "2";
+    loopback_range_server server(test_payload(), fault);
+    auto reactor = make_reactor(server, retry_config(1ms));
+
+    auto const start   = std::chrono::steady_clock::now();
+    auto const probe   = reactor->fetch_footer_suffix("bucket", "object.bin", probe_size);
+    auto const elapsed = std::chrono::steady_clock::now() - start;
+
+    REQUIRE(probe.bytes != nullptr);
+    CHECK(elapsed < 1s);
+    CHECK(server.get_count() == 2);
+  }
+
+  SECTION("footer probe uses Retry-After from the final block")
+  {
+    range_fault_policy fault{};
+    fault.fail_first_gets         = 1;
+    fault.interim_get_retry_after = "2";
+    fault.failed_get_retry_after  = "0";
+    loopback_range_server server(test_payload(), fault);
+    auto reactor = make_reactor(server, retry_config(1500ms));
+
+    auto const start   = std::chrono::steady_clock::now();
+    auto const probe   = reactor->fetch_footer_suffix("bucket", "object.bin", probe_size);
+    auto const elapsed = std::chrono::steady_clock::now() - start;
+
+    REQUIRE(probe.bytes != nullptr);
+    CHECK(elapsed < 1s);
+    CHECK(server.get_count() == 2);
+  }
+}
+
 TEST_CASE("rest ioctx threads validation tags through every network open path",
           "[rest][validation_tag]")
 {

--- a/test/io/rest/test_rest_validation_tag.cpp
+++ b/test/io/rest/test_rest_validation_tag.cpp
@@ -1,0 +1,364 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "loopback_range_server.hpp"
+
+#include <cucascade/io/io_context.hpp>
+#include <cucascade/io/rest/mock_authorizer.hpp>
+#include <cucascade/io/rest/rest_ioctx.hpp>
+
+#include <catch2/catch_all.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using cucascade::io::open_hint;
+using cucascade::io::rest::config;
+using cucascade::io::rest::mock_authorizer;
+using cucascade::io::rest::rest_ioctx;
+using cucascade::io::rest::rest_reactor;
+using cucascade::test::loopback_range_server;
+using cucascade::test::range_fault_policy;
+using namespace std::chrono_literals;
+
+constexpr std::size_t object_size{4096};
+constexpr std::size_t probe_size{512};
+constexpr std::string_view object_uri{"s3://bucket/object.bin"};
+
+std::vector<std::uint8_t> test_payload()
+{
+  std::vector<std::uint8_t> bytes(object_size);
+  for (std::size_t i = 0; i < bytes.size(); ++i) {
+    bytes[i] = static_cast<std::uint8_t>((i * 37U + 11U) & 0xffU);
+  }
+  return bytes;
+}
+
+config test_config()
+{
+  config cfg{};
+  cfg.request_timeout_s       = 5;
+  cfg.tls_verify              = false;
+  cfg.max_retry_attempts      = 2;
+  cfg.max_auth_retry_attempts = 1;
+  cfg.retry_backoff_base      = 1ms;
+  cfg.retry_jitter            = 0ms;
+  cfg.honor_retry_after       = false;
+  cfg.footer_probe_bytes      = probe_size;
+  return cfg;
+}
+
+std::unique_ptr<rest_reactor> make_reactor(loopback_range_server const& server, config cfg)
+{
+  auto authorizer = std::make_shared<mock_authorizer>(
+    cucascade::io::rest::authorized_request{server.endpoint() + "/bucket/object.bin", {}});
+  auto context =
+    std::make_shared<rest_reactor::reactor_context>(cfg, std::move(authorizer), nullptr);
+  return std::make_unique<rest_reactor>(std::move(context), "validation-tag-test");
+}
+
+std::shared_ptr<rest_ioctx> make_ioctx(loopback_range_server const& server, config cfg)
+{
+  auto authorizer = std::make_shared<mock_authorizer>(
+    cucascade::io::rest::authorized_request{server.endpoint() + "/bucket/object.bin", {}});
+  auto context =
+    std::make_shared<rest_reactor::reactor_context>(cfg, std::move(authorizer), nullptr);
+  return std::make_shared<rest_ioctx>(1, std::move(context));
+}
+
+}  // namespace
+
+TEST_CASE("footer probes capture only the verified response validation tag",
+          "[rest][validation_tag]")
+{
+  SECTION("quoted ETag is preserved")
+  {
+    range_fault_policy fault{};
+    fault.successful_get_etag = "\"footer-v1\"";
+    loopback_range_server server(test_payload(), fault);
+    auto reactor = make_reactor(server, test_config());
+
+    auto const probe = reactor->fetch_footer_suffix("bucket", "object.bin", probe_size);
+
+    REQUIRE(probe.bytes != nullptr);
+    CHECK(probe.etag == "\"footer-v1\"");
+    CHECK(server.get_count() == 1);
+  }
+
+  SECTION("missing ETag stays empty on the probe and io object")
+  {
+    loopback_range_server server(test_payload());
+    auto reactor     = make_reactor(server, test_config());
+    auto const probe = reactor->fetch_footer_suffix("bucket", "object.bin", probe_size);
+    REQUIRE(probe.bytes != nullptr);
+    CHECK(probe.etag.empty());
+
+    auto ioctx  = make_ioctx(server, test_config());
+    auto object = ioctx->open_io_object(std::string{object_uri}, open_hint::parquet_footer_probe);
+    CHECK(object->validation_tag().empty());
+  }
+
+  SECTION("weak ETag is preserved verbatim")
+  {
+    range_fault_policy fault{};
+    fault.successful_get_etag = "W/\"weak\"";
+    loopback_range_server server(test_payload(), fault);
+    auto ioctx  = make_ioctx(server, test_config());
+    auto object = ioctx->open_io_object(std::string{object_uri}, open_hint::parquet_footer_probe);
+    CHECK(object->validation_tag() == "W/\"weak\"");
+  }
+
+  SECTION("empty entity-tag is distinct from a missing header")
+  {
+    range_fault_policy fault{};
+    fault.successful_get_etag = "\"\"";
+    loopback_range_server server(test_payload(), fault);
+    auto ioctx  = make_ioctx(server, test_config());
+    auto object = ioctx->open_io_object(std::string{object_uri}, open_hint::parquet_footer_probe);
+    CHECK(object->validation_tag() == "\"\"");
+  }
+}
+
+TEST_CASE("HEAD returns size and validation tag without changing the size wrapper",
+          "[rest][validation_tag]")
+{
+  SECTION("quoted ETag is preserved")
+  {
+    range_fault_policy fault{};
+    fault.successful_head_etag = "\"head-v1\"";
+    loopback_range_server server(test_payload(), fault);
+    auto reactor = make_reactor(server, test_config());
+
+    auto const result = reactor->head_object("bucket", "object.bin");
+
+    CHECK(result.object_size == object_size);
+    CHECK(result.etag == "\"head-v1\"");
+    CHECK(reactor->head_object_size("bucket", "object.bin") == object_size);
+    CHECK(server.head_count() == 2);
+  }
+
+  SECTION("missing ETag does not affect size discovery")
+  {
+    loopback_range_server server(test_payload());
+    auto reactor      = make_reactor(server, test_config());
+    auto const result = reactor->head_object("bucket", "object.bin");
+    CHECK(result.object_size == object_size);
+    CHECK(result.etag.empty());
+    CHECK(server.head_count() == 1);
+  }
+}
+
+TEST_CASE("validation tags are isolated between retry attempts", "[rest][validation_tag]")
+{
+  SECTION("HEAD uses the successful attempt tag")
+  {
+    range_fault_policy fault{};
+    fault.fail_first_heads     = 1;
+    fault.failed_head_etag     = "\"stale-head\"";
+    fault.successful_head_etag = "\"fresh-head\"";
+    loopback_range_server server(test_payload(), fault);
+    auto reactor = make_reactor(server, test_config());
+    CHECK(reactor->head_object("bucket", "object.bin").etag == "\"fresh-head\"");
+    CHECK(server.head_count() == 2);
+  }
+
+  SECTION("HEAD does not leak a failed attempt tag")
+  {
+    range_fault_policy fault{};
+    fault.fail_first_heads = 1;
+    fault.failed_head_etag = "\"stale-head\"";
+    loopback_range_server server(test_payload(), fault);
+    auto reactor = make_reactor(server, test_config());
+    CHECK(reactor->head_object("bucket", "object.bin").etag.empty());
+    CHECK(server.head_count() == 2);
+  }
+
+  SECTION("footer probe uses the successful attempt tag")
+  {
+    range_fault_policy fault{};
+    fault.fail_first_gets     = 1;
+    fault.failed_get_etag     = "\"stale-probe\"";
+    fault.successful_get_etag = "\"fresh-probe\"";
+    loopback_range_server server(test_payload(), fault);
+    auto reactor     = make_reactor(server, test_config());
+    auto const probe = reactor->fetch_footer_suffix("bucket", "object.bin", probe_size);
+    REQUIRE(probe.bytes != nullptr);
+    CHECK(probe.etag == "\"fresh-probe\"");
+    CHECK(server.get_count() == 2);
+  }
+
+  SECTION("footer probe does not leak a failed attempt tag")
+  {
+    range_fault_policy fault{};
+    fault.fail_first_gets = 1;
+    fault.failed_get_etag = "\"stale-probe\"";
+    loopback_range_server server(test_payload(), fault);
+    auto reactor     = make_reactor(server, test_config());
+    auto const probe = reactor->fetch_footer_suffix("bucket", "object.bin", probe_size);
+    REQUIRE(probe.bytes != nullptr);
+    CHECK(probe.etag.empty());
+    CHECK(server.get_count() == 2);
+  }
+}
+
+TEST_CASE("unusable footer responses discard their tag before HEAD fallback",
+          "[rest][validation_tag]")
+{
+  auto check_fallback = [](range_fault_policy fault) {
+    fault.failed_get_etag      = "\"discarded-probe\"";
+    fault.successful_head_etag = "\"fallback-head\"";
+    loopback_range_server server(test_payload(), fault);
+    auto ioctx  = make_ioctx(server, test_config());
+    auto object = ioctx->open_io_object(std::string{object_uri}, open_hint::parquet_footer_probe);
+
+    CHECK(object->size() == object_size);
+    CHECK(object->validation_tag() == "\"fallback-head\"");
+    CHECK(server.get_count() == 1);
+    CHECK(server.head_count() == 1);
+  };
+
+  SECTION("200 full-body response")
+  {
+    range_fault_policy fault{};
+    fault.ignore_range_with_200 = true;
+    check_fallback(fault);
+  }
+
+  SECTION("416 response")
+  {
+    range_fault_policy fault{};
+    fault.fail_range_with_416 = true;
+    check_fallback(fault);
+  }
+
+  SECTION("malformed 206 response")
+  {
+    range_fault_policy fault{};
+    fault.malformed_content_range = true;
+    check_fallback(fault);
+  }
+}
+
+TEST_CASE("interim response tags do not leak into the final response", "[rest][validation_tag]")
+{
+  SECTION("HEAD")
+  {
+    range_fault_policy fault{};
+    fault.interim_head_etag = "\"interim-head\"";
+    loopback_range_server server(test_payload(), fault);
+    auto reactor = make_reactor(server, test_config());
+    CHECK(reactor->head_object("bucket", "object.bin").etag.empty());
+    CHECK(server.head_count() == 1);
+  }
+
+  SECTION("footer probe")
+  {
+    range_fault_policy fault{};
+    fault.interim_get_etag = "\"interim-probe\"";
+    loopback_range_server server(test_payload(), fault);
+    auto reactor     = make_reactor(server, test_config());
+    auto const probe = reactor->fetch_footer_suffix("bucket", "object.bin", probe_size);
+    REQUIRE(probe.bytes != nullptr);
+    CHECK(probe.etag.empty());
+    CHECK(server.get_count() == 1);
+  }
+}
+
+TEST_CASE("rest ioctx threads validation tags through every network open path",
+          "[rest][validation_tag]")
+{
+  SECTION("HEAD open")
+  {
+    range_fault_policy fault{};
+    fault.successful_head_etag = "\"head-open\"";
+    loopback_range_server server(test_payload(), fault);
+    auto ioctx  = make_ioctx(server, test_config());
+    auto object = ioctx->open_io_object(std::string{object_uri});
+    CHECK(object->validation_tag() == "\"head-open\"");
+  }
+
+  SECTION("footer probe open")
+  {
+    range_fault_policy fault{};
+    fault.successful_get_etag = "\"probe-open\"";
+    loopback_range_server server(test_payload(), fault);
+    auto ioctx  = make_ioctx(server, test_config());
+    auto object = ioctx->open_io_object(std::string{object_uri}, open_hint::parquet_footer_probe);
+    CHECK(object->validation_tag() == "\"probe-open\"");
+  }
+
+  SECTION("footer fallback open")
+  {
+    range_fault_policy fault{};
+    fault.fail_range_with_416  = true;
+    fault.failed_get_etag      = "\"discarded-probe\"";
+    fault.successful_head_etag = "\"fallback-open\"";
+    loopback_range_server server(test_payload(), fault);
+    auto ioctx  = make_ioctx(server, test_config());
+    auto object = ioctx->open_io_object(std::string{object_uri}, open_hint::parquet_footer_probe);
+    CHECK(object->validation_tag() == "\"fallback-open\"");
+  }
+}
+
+TEST_CASE("validation tag capture adds no network requests", "[rest][validation_tag]")
+{
+  SECTION("HEAD open remains one HEAD")
+  {
+    range_fault_policy fault{};
+    fault.successful_head_etag = "\"head-v1\"";
+    loopback_range_server server(test_payload(), fault);
+    auto ioctx = make_ioctx(server, test_config());
+    (void)ioctx->open_io_object(std::string{object_uri});
+    CHECK(server.head_count() == 1);
+    CHECK(server.get_count() == 0);
+  }
+
+  SECTION("footer probe open remains one GET")
+  {
+    range_fault_policy fault{};
+    fault.successful_get_etag = "\"probe-v1\"";
+    loopback_range_server server(test_payload(), fault);
+    auto ioctx = make_ioctx(server, test_config());
+    (void)ioctx->open_io_object(std::string{object_uri}, open_hint::parquet_footer_probe);
+    CHECK(server.head_count() == 0);
+    CHECK(server.get_count() == 1);
+  }
+}
+
+TEST_CASE("known-size open stays tagless and performs no requests", "[rest][validation_tag]")
+{
+  range_fault_policy fault{};
+  fault.successful_get_etag  = "\"unused-get\"";
+  fault.successful_head_etag = "\"unused-head\"";
+  loopback_range_server server(test_payload(), fault);
+  auto ioctx  = make_ioctx(server, test_config());
+  auto object = ioctx->open_io_object(std::string{object_uri}, object_size);
+
+  CHECK(object->size() == object_size);
+  CHECK(object->validation_tag().empty());
+  CHECK(server.head_count() == 0);
+  CHECK(server.get_count() == 0);
+}


### PR DESCRIPTION
Porting https://github.com/sirius-db/sirius/pull/1401 IO part from Sirius.


## Problem

Embedders that layer a validating cache above `cucascade::io` need a per-open validation tag for the objects they read. DuckDB >= 1.5.5 is a concrete consumer: its external file cache refuses to cache any file whose filesystem reports no validation metadata, so an embedder running on `cucascade::io` silently loses all caching for object-store reads — every read goes back to the network (sirius-db/sirius#1401 is the downstream fix this generalizes).

## Change

Capture the HTTP ETag on the two blocking metadata requests the open path already makes, and expose it through the `io_object` seam:

- `io_object` gains `validation_tag()` — a defaulted virtual returning an empty view, documented as an opaque, equality-only cache validator (quotes and any weak `W/` prefix preserved; explicitly NOT a precondition token for `If-Match`/`If-Range`). Backends that don't override it are unaffected: an empty tag means "not validatable", which callers must treat as cache-degraded, never wrong-bytes.
- The suffix-range footer probe records the ETag of the verified 206 only; a 200, 416, or malformed 206 discards it (those responses also discard the probe itself). The tag resets on every HTTP status line, so interim responses within one transfer leave no residue, and a failed retry attempt's tag dies with its attempt.
- New `rest_reactor::head_object()` returns `head_object_result{object_size, etag}`; `head_object_size()` remains as a size-only wrapper with an unchanged signature. The HEAD path uses its own header callback (`head_capture`) so the async data-GET path parses nothing it does not consume.
- `rest_ioctx` threads the tag into `rest_io_object` on the HEAD open, probe open, and probe-fallback paths. The `known_size` open (size from ListObjectsV2) stays tag-less and network-free, and that is pinned by a test.

No additional network I/O: capture rides existing requests, and the async column-chunk read path is untouched. Per-open overhead is one extra header match per relevant header plus one `std::string` per REST object.

## ABI disclosure

This PR changes the `io_object` vtable, the public layouts of `footer_probe` and `rest_io_object`, and the `rest_io_object` constructor symbols. Consumers must rebuild against the same source pin. The existing `head_object_size` symbol and calling convention remain unchanged, but the PR as a whole is not ABI-compatible with previously built binaries.

## Tests

`test/io/rest/test_rest_validation_tag.cpp` (+8 cases, 103 -> 111 in `cucascade_io_tests`) on the loopback range server, which now optionally emits ETags, per-fault-response tags, and interim 1xx header blocks: quoted/weak/empty-entity tags preserved verbatim; missing tag stays empty end-to-end; retry attempts isolated in both directions (fresh tag wins; a failed attempt's tag never leaks); 200/416/malformed-206 discard then HEAD-fallback supplies the tag; interim-response tags do not leak into the final response; every network open path threads the tag; capture adds zero requests; known-size opens stay tag-less with zero requests. All pre-existing cases pass unchanged.