### PR TITLE
fix: topology failure only validated by assert

### DIFF
--- a/src/memory/reservation_manager_configurator.cpp
+++ b/src/memory/reservation_manager_configurator.cpp
@@ -29,6 +29,7 @@
 #include <numeric>
 #include <set>
 #include <stdexcept>
+#include <set>
 #include <unordered_map>
 #include <variant>
 #include <vector>
@@ -202,8 +203,9 @@ builder_reference& reservation_manager_configurator::set_disk_mounting_point(
 std::vector<memory_space_config> reservation_manager_configurator::build() const
 {
   topology_discovery discovery;
-  [[maybe_unused]] bool status = discovery.discover();
-  assert(status);
+  if (!discovery.discover()) {
+    throw std::runtime_error("Failed to discover system topology");
+  }
   auto& topology = discovery.get_topology();
   return build(topology);
 }


### PR DESCRIPTION
This PR addresses the following issue in `src/memory/reservation_manager_configurator.cpp`: topology failure only validated by assert.

## Changes
- `src/memory/reservation_manager_configurator.cpp`: topology failure only validated by assert.

## Details
```diff
--- a/src/memory/reservation_manager_configurator.cpp
+++ b/src/memory/reservation_manager_configurator.cpp
@@ -1,8 +1,9 @@
-std::vector<memory_space_config> reservation_manager_configurator::build() const
-{
-  topology_discovery discovery;
-  [[maybe_unused]] bool status = discovery.discover();
-  assert(status);
-  auto& topology = discovery.get_topology();
-  return build(topology);
-}
+std::vector<memory_space_config> reservation_manager_configurator::build() const
+{
+  topology_discovery discovery;
+  if (!discovery.discover()) {
+    throw std::runtime_error("Failed to discover system topology");
+  }
+  auto& topology = discovery.get_topology();
+  return build(topology);
+}
```

## Tests
- `tests/memory/test_reservation_manager_configurator.cpp`

```diff
--- /dev/null
+++ b/tests/memory/test_reservation_manager_configurator.cpp
@@ -0,0 +1,25 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cucascade/memory/reservation_manager_configurator.hpp>
+#include <cucascade/memory/topology_discovery.hpp>
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+namespace cucascade::memory {
+
+TEST(reservation_manager_configurator, build_from_empty_topology_throws)
+{
+  reservation_manager_configurator configurator;
+  configurator.set_number_of_gpus(1);
+
+  system_topology_info empty_topology{};
+
+  EXPECT_THROW(configurator.build(empty_topology), std::runtime_error);
+}
+
+}  // namespace cucascade::memory
```