### PR TITLE
fix(cudf): stream-ordered reclaim safety — release_table stream rebind + consumer-event API

### DIFF
--- a/include/cucascade/cuda/event_pool.hpp
+++ b/include/cucascade/cuda/event_pool.hpp
@@ -1,0 +1,108 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <cucascade/cuda/event.hpp>
+
+#include <rmm/cuda_stream_view.hpp>
+
+#include <mutex>
+#include <vector>
+
+namespace cucascade {
+namespace cuda {
+
+/**
+ * @brief Thread-safe pool of recorded CUDA events tracking outstanding asynchronous work.
+ *
+ * Callers record() an event on the stream where they just enqueued work; later, another
+ * party either enqueues device-side waits on all outstanding events via enqueue_waits()
+ * (no host sync) or blocks the host until they complete via synchronize().
+ *
+ * Events are created lazily with cudaEventDisableTiming and recycled once
+ * cudaEventQuery reports completion, so steady-state record() calls perform no event
+ * creation. A default-constructed pool holds no events and no heap allocations — users
+ * that never record pay only the (empty) containers and the mutex.
+ *
+ * All public methods are internally synchronized by a single mutex. Note that
+ * synchronize() blocks the host while holding that mutex, so concurrent record() calls
+ * are delayed until it returns; callers coordinating record vs. reclaim through an
+ * external lock (e.g. data_batch's reader-writer lock) never hit this case.
+ */
+class event_pool {
+ public:
+  event_pool()  = default;
+  ~event_pool() = default;
+
+  // Non-copyable / non-movable: the pool is referenced concurrently by recorders and
+  // waiters, so its address must remain stable.
+  event_pool(const event_pool&)            = delete;
+  event_pool& operator=(const event_pool&) = delete;
+  event_pool(event_pool&&)                 = delete;
+  event_pool& operator=(event_pool&&)      = delete;
+
+  /**
+   * @brief Record an event on @p stream and track it as outstanding.
+   *
+   * Takes a recycled event from the pool when one is available, otherwise creates a new
+   * timing-disabled event. Cheap: one mutex lock, at most one cudaEventCreateWithFlags
+   * (amortized away by recycling), and one cudaEventRecord. Never host-syncs.
+   *
+   * @param stream The stream whose currently-enqueued work the event captures.
+   */
+  void record(rmm::cuda_stream_view stream);
+
+  /**
+   * @brief Enqueue device-side waits on @p stream for every outstanding event.
+   *
+   * Issues cudaStreamWaitEvent(@p stream, event) for each event that has not yet
+   * completed; work enqueued on @p stream afterwards is ordered after all captured
+   * work. Does NOT block the host. Events observed complete are recycled.
+   *
+   * @param stream The stream on which to enqueue the waits.
+   */
+  void enqueue_waits(rmm::cuda_stream_view stream);
+
+  /**
+   * @brief Block the host until every outstanding event has completed.
+   *
+   * All events are recycled on return. No-op (a mutex lock) when nothing is
+   * outstanding.
+   */
+  void synchronize();
+
+  /**
+   * @brief True if no outstanding event is still pending on the device.
+   *
+   * Non-blocking: polls each outstanding event with cudaEventQuery. Only events whose
+   * query reports success count as done (a query error is conservatively treated as
+   * still pending).
+   */
+  [[nodiscard]] bool is_done() const;
+
+ private:
+  /// Move every completed outstanding event to the available pool. Must hold @c mutex_.
+  void recycle_completed_locked();
+
+  mutable std::mutex mutex_;
+  std::vector<cuda_event> outstanding_;  ///< Recorded events, possibly still pending
+  std::vector<cuda_event> available_;    ///< Completed events awaiting reuse
+};
+
+}  // namespace cuda
+}  // namespace cucascade

--- a/include/cucascade/cuda/event_pool.hpp
+++ b/include/cucascade/cuda/event_pool.hpp
@@ -87,6 +87,16 @@ class event_pool {
   void synchronize();
 
   /**
+   * @brief Like synchronize(), but never throws — for noexcept / destructor contexts.
+   *
+   * CUDA errors are handled with the destructor discipline (asserted in debug builds,
+   * discarded in release). Allocation-free: completed events are left outstanding
+   * rather than recycled; a later record() or enqueue_waits() recycles them. No-op
+   * (a mutex lock) when nothing is outstanding.
+   */
+  void synchronize_no_throw() noexcept;
+
+  /**
    * @brief True if no outstanding event is still pending on the device.
    *
    * Non-blocking: polls each outstanding event with cudaEventQuery. Only events whose

--- a/include/cucascade/cudf/gpu_data_representation.hpp
+++ b/include/cucascade/cudf/gpu_data_representation.hpp
@@ -140,7 +140,21 @@ class gpu_table_representation : public idata_representation {
    *
    * After calling this method, this representation no longer owns the table.
    *
-   * @param stream CUDA stream (used to materialize the table from a view path before release)
+   * The returned table's device buffers are bound to @p stream for deallocation ordering:
+   * when this representation owns the table, every column is rebound via cudf::rebind_stream
+   * before release; when it holds an owning_table_view, the deep copy is materialized directly
+   * on @p stream. Either way, the caller may destroy the returned table (or individual columns
+   * of it) from work ordered on @p stream without frees retiring early on an idle foreign
+   * stream and the allocator recycling blocks still read by in-flight kernels.
+   *
+   * @pre No stream other than @p stream may have in-flight work touching the table's device
+   * memory: rebinding does not insert cross-stream ordering (see the cross-stream
+   * premature-reuse note on mutable_data_batch::rebind_stream in cucascade/data/data_batch.hpp
+   * and cudf::rebind_stream). This holds for tables produced by cuCascade's built-in
+   * converters, which synchronize the conversion stream before publishing the representation.
+   *
+   * @param stream Stream that will own deallocation ordering of the returned table's buffers
+   *               (also used to materialize the table from a view path before release)
    * @return std::unique_ptr<cudf::table> The cuDF table
    */
   std::unique_ptr<cudf::table> release_table(rmm::cuda_stream_view stream);

--- a/include/cucascade/cudf/gpu_data_representation.hpp
+++ b/include/cucascade/cudf/gpu_data_representation.hpp
@@ -152,6 +152,10 @@ class gpu_table_representation : public idata_representation {
    * premature-reuse note on mutable_data_batch::rebind_stream in cucascade/data/data_batch.hpp
    * and cudf::rebind_stream). This holds for tables produced by cuCascade's built-in
    * converters, which synchronize the conversion stream before publishing the representation.
+   * When foreign-stream reads may still be in flight (recorded via
+   * data_batch::record_consumer_event), calling mutable_data_batch::await_consumers(@p stream)
+   * before release_table is the sanctioned way to satisfy this precondition: the enqueued
+   * waits order the released table's stream-ordered frees after those reads.
    *
    * @param stream Stream that will own deallocation ordering of the returned table's buffers
    *               (also used to materialize the table from a view path before release)

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -728,7 +728,18 @@ class mutable_data_batch {
     bool needs_sync = old_representation != nullptr &&
                       (old_representation->get_current_tier() == memory::Tier::GPU ||
                        _batch->_data->get_current_tier() == memory::Tier::GPU);
-    if (needs_sync) { stream.synchronize(); }
+    if (needs_sync) {
+      stream.synchronize();
+    } else {
+      // Non-GPU tier transitions (e.g. host->disk) skip the stream-sync tail above, so
+      // the device-side waits just enqueued on @p stream never gate this thread — but
+      // recorded GPU-side reads of the old representation's buffers (kernels or copies
+      // reading pinned host memory) must still complete before the old representation
+      // is destroyed host-side at scope exit. Mirror set_data's conservative approach
+      // and block the host on the recorded consumer events directly. Zero cost (one
+      // mutex lock) for batches that never recorded a consumer event.
+      _batch->_consumer_events.synchronize();
+    }
   }
 
   // INVARIANT: _batch must be declared before _lock -- destruction order is load-bearing.

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -158,9 +158,8 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
   // get_writer_event). Writer events let a cross-stream READER order its reads after the
   // producing stream's writes; consumer events let a RECLAIMER order the destruction of
   // this batch's buffers after every consumer stream's reads. Without them, freeing a
-  // representation whose buffers were produced on an idle stream while a consumer
-  // stream's kernels/copies still read them is a use-after-free — the only prior defense
-  // was a blunt host stream.synchronize() of the consumer stream at every call site.
+  // representation while a consumer stream's kernels/copies still read its buffers is a
+  // use-after-free unless every call site host-syncs the consumer stream first.
   //
   // Contract:
   //   - A consumer calls record_consumer_event(s) AFTER enqueuing its reads of this
@@ -189,8 +188,7 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
    * are not covered. May be called multiple times, from multiple threads, for multiple
    * streams; each call tracks one more outstanding event.
    *
-   * Cheap: a pooled cudaEvent record (created lazily with cudaEventDisableTiming and
-   * recycled once complete). Never host-syncs. Thread-safe.
+   * Cheap: a pooled event record (see cuda::event_pool) — never host-syncs. Thread-safe.
    *
    * @param consumer_stream The stream on which the consumer's reads were enqueued.
    */
@@ -340,9 +338,7 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
   std::atomic<batch_state> _state{batch_state::idle};  ///< Observable lock state
   std::atomic<size_t> _read_only_count{0};  ///< Count of active read_only_data_batch instances
 
-  /// Outstanding consumer-read events (see the consumer-event API above). Lazily
-  /// populated: batches that never record a consumer event hold no CUDA events and no
-  /// heap allocations here.
+  /// Outstanding consumer-read events (see the consumer-event API above).
   cuda::event_pool _consumer_events;
 
   std::unique_ptr<idata_batch_probe> _probe;
@@ -400,10 +396,8 @@ class read_only_data_batch {
    * @brief Record that this consumer has enqueued reads of the batch's device buffers
    *        on @p consumer_stream.
    *
-   * Delegates to data_batch::record_consumer_event(). Mirror of get_writer_event():
-   * where the writer event orders this consumer's reads after the producer's writes,
-   * the consumer event orders a later reclaimer's frees after this consumer's reads.
-   * Call after enqueuing the reads, while still holding this shared lock.
+   * Delegates to data_batch::record_consumer_event(). Call after enqueuing the reads,
+   * while still holding this shared lock.
    *
    * @param consumer_stream The stream on which the reads were enqueued.
    */
@@ -716,13 +710,11 @@ class mutable_data_batch {
     auto old_representation = std::move(_batch->_data);
     _batch->_data           = std::move(new_representation);
 
-    // CONSUMER-EVENTS: consumers may still have reads of the old representation's
-    // buffers in flight on their own streams (recorded via record_consumer_event).
-    // Enqueue device-side waits on @p stream BEFORE the synchronize below so the host
-    // sync — and therefore the destruction of the old representation — is also ordered
-    // after every recorded consumer read, regardless of which stream frees the buffers.
-    // We hold the exclusive lock, so no new consumer can record concurrently. No-op for
-    // batches that never recorded a consumer event.
+    // Consumers may still have reads of the old representation's buffers in flight on
+    // their own streams. Enqueue device-side waits on @p stream BEFORE the synchronize
+    // below so the host sync — and therefore the old representation's destruction — is
+    // ordered after every recorded consumer read, regardless of which stream frees the
+    // buffers. (Exclusive lock held: no new consumer can record concurrently.)
     _batch->await_consumers(stream);
 
     bool needs_sync = old_representation != nullptr &&
@@ -731,13 +723,11 @@ class mutable_data_batch {
     if (needs_sync) {
       stream.synchronize();
     } else {
-      // Non-GPU tier transitions (e.g. host->disk) skip the stream-sync tail above, so
-      // the device-side waits just enqueued on @p stream never gate this thread — but
-      // recorded GPU-side reads of the old representation's buffers (kernels or copies
-      // reading pinned host memory) must still complete before the old representation
-      // is destroyed host-side at scope exit. Mirror set_data's conservative approach
-      // and block the host on the recorded consumer events directly. Zero cost (one
-      // mutex lock) for batches that never recorded a consumer event.
+      // Non-GPU tier transitions (e.g. host->disk) skip the stream sync above, so the
+      // waits just enqueued never gate this thread — yet recorded GPU-side reads of the
+      // old representation's buffers (e.g. copies reading pinned host memory) must still
+      // complete before it is destroyed at scope exit. Block the host on the recorded
+      // consumer events directly.
       _batch->_consumer_events.synchronize();
     }
   }

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -88,7 +88,15 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
     std::unique_ptr<idata_representation> data,
     std::unique_ptr<idata_batch_probe> probe = std::make_unique<idata_batch_probe>());
 
-  ~data_batch() = default;
+  /**
+   * @brief Destructor. Host-syncs any outstanding consumer events (never throws).
+   *
+   * Plain destruction is the one reclaim path that does not go through
+   * install_converted_representation / set_data, so it must block on recorded
+   * consumer reads itself before the member representation (and its buffers) is
+   * destroyed. Free (a mutex lock) for batches that never recorded a consumer event.
+   */
+  ~data_batch();
 
   // -- Deleted move/copy --
   data_batch(data_batch&&)                 = delete;
@@ -174,6 +182,8 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
   //   - Consumer events complement rebind_stream (see mutable_data_batch::rebind_stream):
   //     rebinding only moves which stream frees the buffers and inserts NO cross-stream
   //     ordering; await_consumers supplies that ordering device-side.
+  //   - Plain destruction (~data_batch) host-syncs outstanding consumer events itself,
+  //     so dropping the last reference without a reclaimer transition is also safe.
   //
   // These methods are internally synchronized by their own mutex and are independent of
   // the reader-writer lock — like subscribe()/unsubscribe() they may be called on the

--- a/include/cucascade/data/data_batch.hpp
+++ b/include/cucascade/data/data_batch.hpp
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <cucascade/cuda/event_pool.hpp>
 #include <cucascade/data/common.hpp>
 #include <cucascade/data/representation_converter.hpp>
 #include <cucascade/memory/common.hpp>
@@ -151,6 +152,76 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
    */
   size_t get_read_only_count() const { return _read_only_count.load(std::memory_order_acquire); }
 
+  // -- Consumer-event API --
+  //
+  // Mirror of the writer-event mechanism (idata_representation::record_writer_event /
+  // get_writer_event). Writer events let a cross-stream READER order its reads after the
+  // producing stream's writes; consumer events let a RECLAIMER order the destruction of
+  // this batch's buffers after every consumer stream's reads. Without them, freeing a
+  // representation whose buffers were produced on an idle stream while a consumer
+  // stream's kernels/copies still read them is a use-after-free — the only prior defense
+  // was a blunt host stream.synchronize() of the consumer stream at every call site.
+  //
+  // Contract:
+  //   - A consumer calls record_consumer_event(s) AFTER enqueuing its reads of this
+  //     batch's buffers on stream s (typically while still holding the shared lock via
+  //     read_only_data_batch, which also delegates this call).
+  //   - A reclaimer calls await_consumers(t) BEFORE destroying or replacing the batch's
+  //     representation, where t is the stream that processes (or is host-synchronized
+  //     ahead of) the frees. Reclaimers hold the exclusive lock (mutable_data_batch), so
+  //     no new consumer can record concurrently with the await + destroy sequence — any
+  //     reader that could still enqueue reads also still holds the shared lock, which
+  //     blocks the reclaimer from acquiring the exclusive lock in the first place.
+  //   - Consumer events complement rebind_stream (see mutable_data_batch::rebind_stream):
+  //     rebinding only moves which stream frees the buffers and inserts NO cross-stream
+  //     ordering; await_consumers supplies that ordering device-side.
+  //
+  // These methods are internally synchronized by their own mutex and are independent of
+  // the reader-writer lock — like subscribe()/unsubscribe() they may be called on the
+  // idle handle at any time.
+
+  /**
+   * @brief Record that the calling consumer has enqueued reads of this batch's device
+   *        buffers on @p consumer_stream.
+   *
+   * Call AFTER the reads are enqueued (kernels launched / async copies issued) — the
+   * recorded event captures the stream's contents at call time, so reads enqueued later
+   * are not covered. May be called multiple times, from multiple threads, for multiple
+   * streams; each call tracks one more outstanding event.
+   *
+   * Cheap: a pooled cudaEvent record (created lazily with cudaEventDisableTiming and
+   * recycled once complete). Never host-syncs. Thread-safe.
+   *
+   * @param consumer_stream The stream on which the consumer's reads were enqueued.
+   */
+  void record_consumer_event(rmm::cuda_stream_view consumer_stream);
+
+  /**
+   * @brief Enqueue device-side waits on @p stream for all outstanding consumer events
+   *        (reads previously recorded via record_consumer_event()).
+   *
+   * Issues cudaStreamWaitEvent(@p stream, event) per outstanding event, so work enqueued
+   * on @p stream afterwards — notably stream-ordered frees of this batch's buffers — is
+   * ordered after every recorded consumer read. Does NOT host-sync. Completed events are
+   * recycled. Thread-safe.
+   *
+   * Reclaimers must call this on the stream that will process the frees (the buffers'
+   * bound stream) before destroying the representation, or combine it with existing
+   * host-sync semantics (a host sync of @p stream after this call transitively waits on
+   * all consumers, making frees safe on any stream).
+   *
+   * @param stream The stream on which to enqueue the waits.
+   */
+  void await_consumers(rmm::cuda_stream_view stream);
+
+  /**
+   * @brief True if no recorded consumer work is still pending on the device.
+   *
+   * Non-blocking poll (cudaEventQuery) of all outstanding consumer events. Trivially
+   * true for batches that never recorded a consumer event. Thread-safe.
+   */
+  [[nodiscard]] bool consumers_done() const;
+
   /**
    * @brief Transition from read-only back to idle (release shared lock).
    *
@@ -269,6 +340,11 @@ class data_batch : public std::enable_shared_from_this<data_batch> {
   std::atomic<batch_state> _state{batch_state::idle};  ///< Observable lock state
   std::atomic<size_t> _read_only_count{0};  ///< Count of active read_only_data_batch instances
 
+  /// Outstanding consumer-read events (see the consumer-event API above). Lazily
+  /// populated: batches that never record a consumer event hold no CUDA events and no
+  /// heap allocations here.
+  cuda::event_pool _consumer_events;
+
   std::unique_ptr<idata_batch_probe> _probe;
 };
 
@@ -319,6 +395,37 @@ class read_only_data_batch {
     auto* repr = get_data();
     return repr ? repr->get_writer_event() : nullptr;
   }
+
+  /**
+   * @brief Record that this consumer has enqueued reads of the batch's device buffers
+   *        on @p consumer_stream.
+   *
+   * Delegates to data_batch::record_consumer_event(). Mirror of get_writer_event():
+   * where the writer event orders this consumer's reads after the producer's writes,
+   * the consumer event orders a later reclaimer's frees after this consumer's reads.
+   * Call after enqueuing the reads, while still holding this shared lock.
+   *
+   * @param consumer_stream The stream on which the reads were enqueued.
+   */
+  void record_consumer_event(rmm::cuda_stream_view consumer_stream) const
+  {
+    _batch->record_consumer_event(consumer_stream);
+  }
+
+  /**
+   * @brief Enqueue device-side waits on @p stream for all outstanding consumer events.
+   *
+   * Delegates to data_batch::await_consumers(). See that method for the reclaim
+   * contract.
+   */
+  void await_consumers(rmm::cuda_stream_view stream) const { _batch->await_consumers(stream); }
+
+  /**
+   * @brief True if no recorded consumer work is still pending on the device.
+   *
+   * Delegates to data_batch::consumers_done().
+   */
+  [[nodiscard]] bool consumers_done() const { return _batch->consumers_done(); }
 
   /**
    * @brief Create an independent deep copy of the batch data.
@@ -492,10 +599,30 @@ class mutable_data_batch {
    * accessor.
    *
    * @note Does NOT insert cross-stream ordering -- see idata_representation::rebind_stream.
+   *       To order the rebound buffers' eventual free after consumer reads still in flight
+   *       on other streams, call await_consumers() on the rebound stream — the two calls
+   *       together make a reclaim fully stream-ordered with no host sync.
    *
    * @param stream Stream used for future asynchronous deallocation of the data's buffers.
    */
   void rebind_stream(rmm::cuda_stream_view stream);
+
+  /**
+   * @brief Enqueue device-side waits on @p stream for all outstanding consumer events.
+   *
+   * Delegates to data_batch::await_consumers(). Reclaimers holding this exclusive lock
+   * call this on the stream that will process the frees BEFORE destroying or replacing
+   * the representation; the exclusive lock guarantees no new consumer can record
+   * concurrently. Does NOT host-sync.
+   */
+  void await_consumers(rmm::cuda_stream_view stream) const { _batch->await_consumers(stream); }
+
+  /**
+   * @brief True if no recorded consumer work is still pending on the device.
+   *
+   * Delegates to data_batch::consumers_done().
+   */
+  [[nodiscard]] bool consumers_done() const { return _batch->consumers_done(); }
 
   /**
    * @brief Create an independent deep copy of the batch data.
@@ -588,6 +715,15 @@ class mutable_data_batch {
   {
     auto old_representation = std::move(_batch->_data);
     _batch->_data           = std::move(new_representation);
+
+    // CONSUMER-EVENTS: consumers may still have reads of the old representation's
+    // buffers in flight on their own streams (recorded via record_consumer_event).
+    // Enqueue device-side waits on @p stream BEFORE the synchronize below so the host
+    // sync — and therefore the destruction of the old representation — is also ordered
+    // after every recorded consumer read, regardless of which stream frees the buffers.
+    // We hold the exclusive lock, so no new consumer can record concurrently. No-op for
+    // batches that never recorded a consumer event.
+    _batch->await_consumers(stream);
 
     bool needs_sync = old_representation != nullptr &&
                       (old_representation->get_current_tier() == memory::Tier::GPU ||

--- a/include/cucascade/memory/detail/reservation_aware_resource_adaptor_impl.hpp
+++ b/include/cucascade/memory/detail/reservation_aware_resource_adaptor_impl.hpp
@@ -200,7 +200,7 @@ class reservation_aware_resource_adaptor_impl {
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t))
   {
-    auto def_stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto def_stream = ::cuda::stream_ref{cudaStream_t{nullptr}};
     auto* ptr       = allocate(def_stream, bytes, alignment);
     def_stream.sync();
     return ptr;
@@ -210,7 +210,7 @@ class reservation_aware_resource_adaptor_impl {
                        std::size_t bytes,
                        std::size_t alignment = alignof(std::max_align_t)) noexcept
   {
-    auto def_stream = cuda::stream_ref{cudaStream_t{nullptr}};
+    auto def_stream = ::cuda::stream_ref{cudaStream_t{nullptr}};
     deallocate(def_stream, ptr, bytes, alignment);
     def_stream.sync();
   }

--- a/include/cucascade/memory/small_pinned_host_memory_resource.hpp
+++ b/include/cucascade/memory/small_pinned_host_memory_resource.hpp
@@ -102,7 +102,7 @@ class small_pinned_host_memory_resource {
 
   void* allocate_sync(std::size_t bytes, std::size_t alignment = alignof(std::max_align_t))
   {
-    auto* ptr = allocate(cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
+    auto* ptr = allocate(::cuda::stream_ref{cudaStream_t{nullptr}}, bytes, alignment);
     rmm::cuda_stream_default.synchronize();
     return ptr;
   }
@@ -111,7 +111,7 @@ class small_pinned_host_memory_resource {
                        std::size_t bytes,
                        std::size_t alignment = alignof(std::max_align_t)) noexcept
   {
-    deallocate(cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
+    deallocate(::cuda::stream_ref{cudaStream_t{nullptr}}, ptr, bytes, alignment);
     rmm::cuda_stream_default.synchronize_no_throw();
   }
 

--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -15,4 +15,6 @@
 # the License.
 # =============================================================================
 
-target_sources(cucascade_objects PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/event.cpp)
+target_sources(cucascade_objects
+               PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/event.cpp
+                       ${CMAKE_CURRENT_SOURCE_DIR}/event_pool.cpp)

--- a/src/cuda/CMakeLists.txt
+++ b/src/cuda/CMakeLists.txt
@@ -15,6 +15,6 @@
 # the License.
 # =============================================================================
 
-target_sources(cucascade_objects
-               PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/event.cpp
-                       ${CMAKE_CURRENT_SOURCE_DIR}/event_pool.cpp)
+target_sources(
+  cucascade_objects PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/event.cpp
+                            ${CMAKE_CURRENT_SOURCE_DIR}/event_pool.cpp)

--- a/src/cuda/event_pool.cpp
+++ b/src/cuda/event_pool.cpp
@@ -1,0 +1,92 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cucascade/cuda/event_pool.hpp>
+
+#include <mutex>
+#include <utility>
+
+namespace cucascade {
+namespace cuda {
+
+void event_pool::record(rmm::cuda_stream_view stream)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  // Opportunistically recycle before taking from the pool so steady-state usage
+  // converges to a handful of events instead of growing without bound.
+  recycle_completed_locked();
+  cuda_event event = [this]() {
+    if (!available_.empty()) {
+      cuda_event recycled = std::move(available_.back());
+      available_.pop_back();
+      return recycled;
+    }
+    return cuda_event{cudaEventDisableTiming};
+  }();
+  event.record(stream);
+  outstanding_.push_back(std::move(event));
+}
+
+void event_pool::enqueue_waits(rmm::cuda_stream_view stream)
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  recycle_completed_locked();
+  // Still-pending events stay outstanding after the wait is enqueued: the wait only
+  // snapshots the captured work, it does not retire the event. They are recycled by a
+  // later call once cudaEventQuery reports completion.
+  for (auto& event : outstanding_) {
+    event.wait(stream);
+  }
+}
+
+void event_pool::synchronize()
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (auto& event : outstanding_) {
+    event.synchronize();
+  }
+  // Everything completed — recycle the lot.
+  for (auto& event : outstanding_) {
+    available_.push_back(std::move(event));
+  }
+  outstanding_.clear();
+}
+
+bool event_pool::is_done() const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (const auto& event : outstanding_) {
+    if (event.query() != event::query_result::success) { return false; }
+  }
+  return true;
+}
+
+void event_pool::recycle_completed_locked()
+{
+  auto it = outstanding_.begin();
+  while (it != outstanding_.end()) {
+    if (it->query() == event::query_result::success) {
+      available_.push_back(std::move(*it));
+      it = outstanding_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+}  // namespace cuda
+}  // namespace cucascade

--- a/src/cuda/event_pool.cpp
+++ b/src/cuda/event_pool.cpp
@@ -54,7 +54,6 @@ void event_pool::synchronize()
   for (auto& event : outstanding_) {
     event.synchronize();
   }
-  // Everything completed — recycle the lot.
   for (auto& event : outstanding_) {
     available_.push_back(std::move(event));
   }

--- a/src/cuda/event_pool.cpp
+++ b/src/cuda/event_pool.cpp
@@ -29,14 +29,9 @@ void event_pool::record(rmm::cuda_stream_view stream)
   // Opportunistically recycle before taking from the pool so steady-state usage
   // converges to a handful of events instead of growing without bound.
   recycle_completed_locked();
-  cuda_event event = [this]() {
-    if (!available_.empty()) {
-      cuda_event recycled = std::move(available_.back());
-      available_.pop_back();
-      return recycled;
-    }
-    return cuda_event{cudaEventDisableTiming};
-  }();
+  if (available_.empty()) { available_.emplace_back(cudaEventDisableTiming); }
+  cuda_event event = std::move(available_.back());
+  available_.pop_back();
   event.record(stream);
   outstanding_.push_back(std::move(event));
 }

--- a/src/cuda/event_pool.cpp
+++ b/src/cuda/event_pool.cpp
@@ -17,6 +17,7 @@
 
 #include <cucascade/cuda/event_pool.hpp>
 
+#include <cassert>
 #include <mutex>
 #include <utility>
 
@@ -58,6 +59,20 @@ void event_pool::synchronize()
     available_.push_back(std::move(event));
   }
   outstanding_.clear();
+}
+
+void event_pool::synchronize_no_throw() noexcept
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  // No recycling: pushing into available_ may allocate, which a noexcept
+  // destructor context must not risk. Completed events stay outstanding and are
+  // recycled by the next record() / enqueue_waits().
+  for (auto& event : outstanding_) {
+    // Destructor discipline (as CUCASCADE_ASSERT_CUDA_SUCCESS): assert in debug
+    // builds, discard the error in release — never throw.
+    [[maybe_unused]] cudaError_t const status = event.synchronize_no_throw();
+    assert(status == cudaSuccess);
+  }
 }
 
 bool event_pool::is_done() const

--- a/src/cudf/gpu_data_representation.cpp
+++ b/src/cudf/gpu_data_representation.cpp
@@ -25,28 +25,6 @@
 
 namespace cucascade {
 
-namespace {
-
-/**
- * @brief Rebind every column of @p table so its device buffers deallocate on @p stream.
- *
- * cudf::table move-assignment is deleted, so release the columns, rebind each (cudf::rebind_stream
- * recursively covers data buffers, null masks, and nested children), and rebuild the table in
- * place. No device memory is copied and no kernels are launched. Does not insert cross-stream
- * ordering.
- */
-void rebind_table_to_stream(std::unique_ptr<cudf::table>& table, rmm::cuda_stream_view stream)
-{
-  if (!table || table->num_columns() == 0) { return; }
-  auto columns = table->release();
-  for (auto& col : columns) {
-    col = cudf::rebind_stream(std::move(*col), stream);
-  }
-  table = std::make_unique<cudf::table>(std::move(columns));
-}
-
-}  // namespace
-
 gpu_table_representation::gpu_table_representation(std::unique_ptr<cudf::table> table,
                                                    cucascade::memory::memory_space& memory_space,
                                                    rmm::cuda_stream_view writer_stream)
@@ -107,7 +85,7 @@ std::unique_ptr<cudf::table> gpu_table_representation::release_table(rmm::cuda_s
     // that destroying (parts of) the returned table enqueues frees in the caller's stream
     // order instead of retiring instantly on the idle foreign stream, where the allocator
     // could recycle the blocks under the caller's in-flight kernels.
-    rebind_table_to_stream(std::get<std::unique_ptr<cudf::table>>(_table), stream);
+    gpu_table_representation::rebind_stream(stream);
   }
   return std::move(std::get<std::unique_ptr<cudf::table>>(_table));
 }
@@ -118,7 +96,16 @@ void gpu_table_representation::rebind_stream(rmm::cuda_stream_view stream)
   // references memory owned by an external (type-erased) owner, which manages its own
   // deallocation stream.
   if (!std::holds_alternative<std::unique_ptr<cudf::table>>(_table)) { return; }
-  rebind_table_to_stream(std::get<std::unique_ptr<cudf::table>>(_table), stream);
+  auto& table = std::get<std::unique_ptr<cudf::table>>(_table);
+  if (!table || table->num_columns() == 0) { return; }
+
+  // cudf::table move-assignment is deleted, so release the columns, rebind each, and rebuild
+  // the table in place. No device memory is copied and no kernels are launched.
+  auto columns = table->release();
+  for (auto& col : columns) {
+    col = cudf::rebind_stream(std::move(*col), stream);
+  }
+  table = std::make_unique<cudf::table>(std::move(columns));
 }
 
 std::unique_ptr<idata_representation> gpu_table_representation::clone(rmm::cuda_stream_view stream)

--- a/src/cudf/gpu_data_representation.cpp
+++ b/src/cudf/gpu_data_representation.cpp
@@ -25,6 +25,28 @@
 
 namespace cucascade {
 
+namespace {
+
+/**
+ * @brief Rebind every column of @p table so its device buffers deallocate on @p stream.
+ *
+ * cudf::table move-assignment is deleted, so release the columns, rebind each (cudf::rebind_stream
+ * recursively covers data buffers, null masks, and nested children), and rebuild the table in
+ * place. No device memory is copied and no kernels are launched. Does not insert cross-stream
+ * ordering.
+ */
+void rebind_table_to_stream(std::unique_ptr<cudf::table>& table, rmm::cuda_stream_view stream)
+{
+  if (!table || table->num_columns() == 0) { return; }
+  auto columns = table->release();
+  for (auto& col : columns) {
+    col = cudf::rebind_stream(std::move(*col), stream);
+  }
+  table = std::make_unique<cudf::table>(std::move(columns));
+}
+
+}  // namespace
+
 gpu_table_representation::gpu_table_representation(std::unique_ptr<cudf::table> table,
                                                    cucascade::memory::memory_space& memory_space,
                                                    rmm::cuda_stream_view writer_stream)
@@ -73,11 +95,19 @@ cudf::table_view gpu_table_representation::get_table_view() const
   }
 }
 
-std::unique_ptr<cudf::table> gpu_table_representation::release_table(
-  [[maybe_unused]] rmm::cuda_stream_view stream)
+std::unique_ptr<cudf::table> gpu_table_representation::release_table(rmm::cuda_stream_view stream)
 {
   if (std::holds_alternative<owning_table_view>(_table)) {
+    // View path: the deep copy is allocated directly on `stream`, so its buffers are already
+    // bound to it — no rebind needed.
     _table = std::make_unique<cudf::table>(std::get<owning_table_view>(_table).view, stream);
+  } else {
+    // Owned-table path: the buffers are still dealloc-bound to the stream they were allocated
+    // on (typically an idle conversion-pool stream). Rebind them to the caller's stream so
+    // that destroying (parts of) the returned table enqueues frees in the caller's stream
+    // order instead of retiring instantly on the idle foreign stream, where the allocator
+    // could recycle the blocks under the caller's in-flight kernels.
+    rebind_table_to_stream(std::get<std::unique_ptr<cudf::table>>(_table), stream);
   }
   return std::move(std::get<std::unique_ptr<cudf::table>>(_table));
 }
@@ -88,16 +118,7 @@ void gpu_table_representation::rebind_stream(rmm::cuda_stream_view stream)
   // references memory owned by an external (type-erased) owner, which manages its own
   // deallocation stream.
   if (!std::holds_alternative<std::unique_ptr<cudf::table>>(_table)) { return; }
-  auto& table = std::get<std::unique_ptr<cudf::table>>(_table);
-  if (!table || table->num_columns() == 0) { return; }
-
-  // cudf::table move-assignment is deleted, so release the columns, rebind each, and rebuild
-  // the table in place. No device memory is copied and no kernels are launched.
-  auto columns = table->release();
-  for (auto& col : columns) {
-    col = cudf::rebind_stream(std::move(*col), stream);
-  }
-  table = std::make_unique<cudf::table>(std::move(columns));
+  rebind_table_to_stream(std::get<std::unique_ptr<cudf::table>>(_table), stream);
 }
 
 std::unique_ptr<idata_representation> gpu_table_representation::clone(rmm::cuda_stream_view stream)

--- a/src/cudf/gpu_data_representation.cpp
+++ b/src/cudf/gpu_data_representation.cpp
@@ -80,11 +80,9 @@ std::unique_ptr<cudf::table> gpu_table_representation::release_table(rmm::cuda_s
     // bound to it — no rebind needed.
     _table = std::make_unique<cudf::table>(std::get<owning_table_view>(_table).view, stream);
   } else {
-    // Owned-table path: the buffers are still dealloc-bound to the stream they were allocated
-    // on (typically an idle conversion-pool stream). Rebind them to the caller's stream so
-    // that destroying (parts of) the returned table enqueues frees in the caller's stream
-    // order instead of retiring instantly on the idle foreign stream, where the allocator
-    // could recycle the blocks under the caller's in-flight kernels.
+    // Owned-table path: rebind the buffers from their allocation stream (typically an idle
+    // conversion-pool stream) to the caller's, so the returned table's frees are ordered on
+    // the caller's stream (see the release_table declaration for the full contract).
     gpu_table_representation::rebind_stream(stream);
   }
   return std::move(std::get<std::unique_ptr<cudf::table>>(_table));

--- a/src/data/data_batch.cpp
+++ b/src/data/data_batch.cpp
@@ -65,6 +65,20 @@ size_t data_batch::get_subscriber_count() const
   return _subscriber_count.load(std::memory_order_relaxed);
 }
 
+// ========== Consumer-event API ==========
+
+void data_batch::record_consumer_event(rmm::cuda_stream_view consumer_stream)
+{
+  _consumer_events.record(consumer_stream);
+}
+
+void data_batch::await_consumers(rmm::cuda_stream_view stream)
+{
+  _consumer_events.enqueue_waits(stream);
+}
+
+bool data_batch::consumers_done() const { return _consumer_events.is_done(); }
+
 // ========== data_batch private data accessors ==========
 
 memory::Tier data_batch::get_current_tier() const { return _data->get_current_tier(); }
@@ -80,6 +94,13 @@ memory::memory_space* data_batch::get_memory_space() const
 void data_batch::set_data(std::unique_ptr<idata_representation> data)
 {
   if (data == nullptr) { throw std::runtime_error("data is null in data_batch::set_data"); }
+  // CONSUMER-EVENTS: the old representation is destroyed here while the batch object
+  // survives, and consumers may still have reads of its buffers in flight on their own
+  // streams. No stream is available in this path to enqueue device-side waits on, so
+  // conservatively block the host until all recorded consumer events complete. This is
+  // a no-op (one mutex lock) for batches that never recorded a consumer event, and the
+  // caller holds the exclusive lock, so no new consumer can record concurrently.
+  _consumer_events.synchronize();
   _data = std::move(data);
   _probe->data_replaced(*_data);
 }

--- a/src/data/data_batch.cpp
+++ b/src/data/data_batch.cpp
@@ -42,6 +42,15 @@ data_batch::data_batch(uint64_t batch_id,
   _probe->created(get_batch_id(), *get_data());
 }
 
+data_batch::~data_batch()
+{
+  // Consumers may still have recorded reads of _data's buffers in flight on their
+  // own streams; _data is destroyed after this body runs, so block the host on them
+  // first. No lock is needed: reaching the destructor means no accessor (and thus no
+  // recorder) can still exist. noexcept-safe via the pool's no-throw sync.
+  _consumer_events.synchronize_no_throw();
+}
+
 uint64_t data_batch::get_batch_id() const { return _batch_id; }
 
 void data_batch::subscribe() { _subscriber_count.fetch_add(1, std::memory_order_relaxed); }

--- a/src/data/data_batch.cpp
+++ b/src/data/data_batch.cpp
@@ -94,12 +94,10 @@ memory::memory_space* data_batch::get_memory_space() const
 void data_batch::set_data(std::unique_ptr<idata_representation> data)
 {
   if (data == nullptr) { throw std::runtime_error("data is null in data_batch::set_data"); }
-  // CONSUMER-EVENTS: the old representation is destroyed here while the batch object
-  // survives, and consumers may still have reads of its buffers in flight on their own
-  // streams. No stream is available in this path to enqueue device-side waits on, so
-  // conservatively block the host until all recorded consumer events complete. This is
-  // a no-op (one mutex lock) for batches that never recorded a consumer event, and the
-  // caller holds the exclusive lock, so no new consumer can record concurrently.
+  // The old representation is destroyed here while consumers may still have reads of
+  // its buffers in flight. No stream is available in this path to enqueue device-side
+  // waits on, so conservatively block the host until all recorded consumer events
+  // complete. (Exclusive lock held: no new consumer can record concurrently.)
   _consumer_events.synchronize();
   _data = std::move(data);
   _probe->data_replaced(*_data);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -98,6 +98,8 @@ if(NOT CUCASCADE_TOPOLOGY_ONLY AND CUCASCADE_BUILD_CUDF)
     data/test_disk_host_converters.cpp
     data/test_gpu_disk_converters.cpp
     data/test_representation_converter.cpp
+    # cudf-coupled representation tests
+    cudf/test_release_table_stream.cpp
     # Main test runner
     unittest.cpp)
   set_target_properties(cucascade_cudf_tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -93,6 +93,7 @@ if(NOT CUCASCADE_TOPOLOGY_ONLY AND CUCASCADE_BUILD_CUDF)
     utils/cudf_test_utils.cpp
     # Data tests (cudf-backed representations / converters / profiler)
     data/test_bandwidth_profiler.cpp
+    data/test_consumer_events.cpp
     data/test_data_batch.cpp
     data/test_data_representation.cpp
     data/test_disk_host_converters.cpp

--- a/test/cudf/test_release_table_stream.cpp
+++ b/test/cudf/test_release_table_stream.cpp
@@ -21,15 +21,8 @@
 // device buffers are dealloc-bound to the stream passed to release_table --
 // owned tables are rebound via cudf::rebind_stream (recursively: data buffers,
 // null masks, nested children); the owning_table_view alternative deep-copies
-// directly on the passed stream.
-//
-// Historical context: pre-fix, release_table ignored its stream argument. A
-// converter-produced table stayed dealloc-bound to the (idle, already-synced)
-// conversion-pool stream, so destroying a released column enqueued a
-// stream-ordered free that retired instantly, and the allocator recycled the
-// block under kernels still reading it on the consumer's stream. This was a
-// confirmed use-after-free (258 hazards under compute-sanitizer; TPC-H Q18
-// result corruption via Sirius' cached-serving path).
+// directly on the passed stream. The UAF regression test below documents the
+// pre-fix failure mode this contract exists to prevent.
 
 #include "utils/cudf_test_utils.hpp"
 #include "utils/mock_test_utils.hpp"

--- a/test/cudf/test_release_table_stream.cpp
+++ b/test/cudf/test_release_table_stream.cpp
@@ -478,35 +478,9 @@ TEST_CASE("view-branch release_table deep-copies on the release stream and leave
 }
 
 // =============================================================================
-// 5. Precondition: converter-produced tables can be released and consumed
-//    immediately, with no caller-side synchronization.
-// =============================================================================
-
-TEST_CASE("release_table immediately after converter publish is safe", "[release_table][converter]")
-{
-  // Built-in converters synchronize the conversion stream before publishing
-  // the representation, which is exactly what makes release_table's @pre hold
-  // here with zero manual synchronization between convert and release.
-  rmm::cuda_stream release_stream;
-
-  auto reference = make_patterned_table(shared_stream());
-  auto gpu_rep =
-    make_converter_produced_rep(make_patterned_table(shared_stream()), shared_gpu_space());
-
-  auto released = gpu_rep->release_table(release_stream.view());
-  gpu_rep.reset();
-
-  test::expect_cudf_tables_equal_on_stream(
-    reference->view(), released->view(), release_stream.view());
-
-  // Destroy the released table: frees enqueue on the release stream.
-  released.reset();
-  release_stream.synchronize();
-}
-
-// =============================================================================
-// 6. Composition: release_table(S) followed by an explicit cudf::rebind_stream
-//    to the same S (the Sirius PR #1566 call-site pattern) is a harmless no-op.
+// 5. Composition: release_table(S) followed by an explicit cudf::rebind_stream
+//    to the same S (the Sirius call-site pattern: the type-restore path
+//    rebinds stolen columns before freeing them) is a harmless no-op.
 // =============================================================================
 
 TEST_CASE("release_table then cudf::rebind_stream to the same stream composes",

--- a/test/cudf/test_release_table_stream.cpp
+++ b/test/cudf/test_release_table_stream.cpp
@@ -1,0 +1,537 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for gpu_table_representation::release_table(stream) stream binding.
+//
+// Contract under test (see gpu_data_representation.hpp): the returned table's
+// device buffers are dealloc-bound to the stream passed to release_table --
+// owned tables are rebound via cudf::rebind_stream (recursively: data buffers,
+// null masks, nested children); the owning_table_view alternative deep-copies
+// directly on the passed stream.
+//
+// Historical context: pre-fix, release_table ignored its stream argument. A
+// converter-produced table stayed dealloc-bound to the (idle, already-synced)
+// conversion-pool stream, so destroying a released column enqueued a
+// stream-ordered free that retired instantly, and the allocator recycled the
+// block under kernels still reading it on the consumer's stream. This was a
+// confirmed use-after-free (258 hazards under compute-sanitizer; TPC-H Q18
+// result corruption via Sirius' cached-serving path).
+
+#include "utils/cudf_test_utils.hpp"
+#include "utils/mock_test_utils.hpp"
+
+#include <cucascade/cudf/builtin_converters.hpp>
+#include <cucascade/cudf/gpu_data_representation.hpp>
+#include <cucascade/cudf/host_data_representation.hpp>
+#include <cucascade/data/representation_converter.hpp>
+#include <cucascade/error.hpp>
+#include <cucascade/memory/memory_space.hpp>
+
+#include <cudf/column/column.hpp>
+#include <cudf/column/column_factories.hpp>
+#include <cudf/column/column_stream.hpp>
+#include <cudf/table/table.hpp>
+#include <cudf/types.hpp>
+
+#include <rmm/cuda_stream.hpp>
+#include <rmm/cuda_stream_view.hpp>
+#include <rmm/device_buffer.hpp>
+#include <rmm/mr/cuda_async_view_memory_resource.hpp>
+
+#include <cuda/memory_resource>
+#include <cuda_runtime_api.h>
+
+#include <catch2/catch_all.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace cucascade;
+
+namespace {
+
+/// Shared memory spaces -- reused across tests to avoid cumulative CUDA context
+/// degradation (same rationale as test_disk_host_converters.cpp).
+auto& shared_gpu_space()
+{
+  static auto s = test::make_mock_memory_space(memory::Tier::GPU, 0);
+  return s;
+}
+auto& shared_host_space()
+{
+  static auto s = test::make_mock_memory_space(memory::Tier::HOST, 0);
+  return s;
+}
+
+/// GPU memory space whose allocator is stream-ordered (cudaMallocAsync via the
+/// device-default mempool). The UAF regression test needs real stream-ordered
+/// frees: with the mock space's plain cudaMalloc resource, deallocation ignores
+/// the stream entirely and the test could not tell correct dealloc ordering
+/// from broken ordering.
+auto& async_gpu_space()
+{
+  static auto s = [] {
+    cudaMemPool_t pool{};
+    CUCASCADE_CUDA_TRY(cudaDeviceGetDefaultMemPool(&pool, 0));
+    // Keep freed blocks cached in the pool so later same-size allocations are
+    // eligible to reuse them (a release threshold of 0 hands memory back to
+    // the OS at sync points, defusing the reuse pressure this test applies).
+    uint64_t threshold = UINT64_MAX;
+    CUCASCADE_CUDA_TRY(cudaMemPoolSetAttribute(pool, cudaMemPoolAttrReleaseThreshold, &threshold));
+    memory::gpu_memory_space_config config;
+    config.device_id       = 0;
+    config.memory_capacity = 1024ull * 1024 * 1024;
+    config.mr_factory_fn   = [pool](int, std::size_t) {
+      return ::cuda::mr::any_resource<::cuda::mr::device_accessible>{
+        rmm::mr::cuda_async_view_memory_resource{pool}};
+    };
+    return std::make_shared<memory::memory_space>(config);
+  }();
+  return s;
+}
+
+/// Setup / writer stream shared across tests (distinct from every per-test
+/// release stream).
+rmm::cuda_stream_view shared_stream()
+{
+  static rmm::cuda_stream s;
+  return s.view();
+}
+
+/// Build a deterministic 3-column table on `stream` and synchronize:
+///   col 0: INT32, iota values, ALL_VALID null mask (a real mask buffer)
+///   col 1: STRING (nested: chars in the parent data buffer + offsets child)
+///   col 2: INT64, memset pattern
+/// All device buffers are allocated on -- and therefore dealloc-bound to --
+/// `stream`, the way converter-internal allocations bind to the conversion
+/// stream.
+std::unique_ptr<cudf::table> make_patterned_table(rmm::cuda_stream_view stream)
+{
+  auto const num_rows = cudf::size_type{257};  // not a multiple of 8: partial mask byte
+
+  // INT32 + ALL_VALID mask
+  auto int_col = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::INT32}, num_rows, cudf::mask_state::ALL_VALID, stream);
+  std::vector<int32_t> int_values(static_cast<std::size_t>(num_rows));
+  std::iota(int_values.begin(), int_values.end(), 100);
+  CUCASCADE_CUDA_TRY(cudaMemcpyAsync(int_col->mutable_view().data<int32_t>(),
+                                     int_values.data(),
+                                     int_values.size() * sizeof(int32_t),
+                                     cudaMemcpyHostToDevice,
+                                     stream.value()));
+
+  // STRING
+  std::vector<int32_t> host_offsets(static_cast<std::size_t>(num_rows) + 1);
+  std::vector<char> host_chars;
+  host_offsets[0] = 0;
+  for (cudf::size_type i = 0; i < num_rows; ++i) {
+    std::string s = "row_" + std::to_string(i);
+    host_chars.insert(host_chars.end(), s.begin(), s.end());
+    host_offsets[static_cast<std::size_t>(i) + 1] = static_cast<int32_t>(host_chars.size());
+  }
+  rmm::device_buffer dev_chars(host_chars.data(), host_chars.size(), stream);
+  auto offsets_col = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::INT32}, num_rows + 1, cudf::mask_state::UNALLOCATED, stream);
+  CUCASCADE_CUDA_TRY(cudaMemcpyAsync(offsets_col->mutable_view().data<int32_t>(),
+                                     host_offsets.data(),
+                                     host_offsets.size() * sizeof(int32_t),
+                                     cudaMemcpyHostToDevice,
+                                     stream.value()));
+  stream.synchronize();
+  auto str_col = cudf::make_strings_column(
+    num_rows, std::move(offsets_col), std::move(dev_chars), 0, rmm::device_buffer{});
+
+  // INT64
+  auto long_col = cudf::make_numeric_column(
+    cudf::data_type{cudf::type_id::INT64}, num_rows, cudf::mask_state::UNALLOCATED, stream);
+  CUCASCADE_CUDA_TRY(cudaMemsetAsync(const_cast<void*>(long_col->mutable_view().head()),
+                                     0x5A,
+                                     static_cast<std::size_t>(num_rows) * sizeof(int64_t),
+                                     stream.value()));
+
+  std::vector<std::unique_ptr<cudf::column>> cols;
+  cols.push_back(std::move(int_col));
+  cols.push_back(std::move(str_col));
+  cols.push_back(std::move(long_col));
+  stream.synchronize();
+  return std::make_unique<cudf::table>(std::move(cols));
+}
+
+/// Recursively assert every non-empty device buffer of `col` (data + null
+/// mask + all nested children) reports `expected` as its deallocation stream.
+/// Destructive: release()s the column to reach the rmm::device_buffers.
+void expect_column_buffers_bound_to(std::unique_ptr<cudf::column> col,
+                                    rmm::cuda_stream_view expected,
+                                    int& buffers_checked)
+{
+  auto contents = col->release();
+  if (contents.data && contents.data->size() > 0) {
+    CAPTURE(contents.data->stream().value(), expected.value());
+    CHECK(contents.data->stream().value() == expected.value());
+    ++buffers_checked;
+  }
+  if (contents.null_mask && contents.null_mask->size() > 0) {
+    CAPTURE(contents.null_mask->stream().value(), expected.value());
+    CHECK(contents.null_mask->stream().value() == expected.value());
+    ++buffers_checked;
+  }
+  for (auto& child : contents.children) {
+    expect_column_buffers_bound_to(std::move(child), expected, buffers_checked);
+  }
+}
+
+/// Destructively check all buffers of `table`; returns how many non-empty
+/// buffers were checked (callers REQUIRE a minimum so the assertions cannot
+/// pass vacuously).
+int expect_table_buffers_bound_to(cudf::table& table, rmm::cuda_stream_view expected)
+{
+  int buffers_checked = 0;
+  auto columns        = table.release();
+  for (auto& col : columns) {
+    expect_column_buffers_bound_to(std::move(col), expected, buffers_checked);
+  }
+  return buffers_checked;
+}
+
+/// Round-trip `source` through the registry (GPU -> host_data_representation
+/// -> GPU) so the returned gpu_table_representation is converter-produced: its
+/// buffers are allocated on a stream from `gpu_space`'s internal pool that the
+/// caller never sees (exactly the "conversion pool stream" of the original
+/// bug), and the converter synchronized that stream before publishing --
+/// which is what makes release_table's @pre hold with no caller-side sync.
+std::unique_ptr<gpu_table_representation> make_converter_produced_rep(
+  std::unique_ptr<cudf::table> source, const std::shared_ptr<memory::memory_space>& gpu_space)
+{
+  representation_converter_registry registry;
+  register_builtin_converters(registry);
+
+  auto gpu_rep =
+    std::make_unique<gpu_table_representation>(std::move(source), *gpu_space, shared_stream());
+  auto host_rep = registry.convert<host_data_representation>(
+    *gpu_rep, shared_host_space().get(), shared_stream());
+  gpu_rep.reset();
+  return registry.convert<gpu_table_representation>(*host_rep, gpu_space.get(), shared_stream());
+}
+
+/// Host callback that stalls a CUDA stream for a fixed wall-clock duration,
+/// creating a deterministic window during which work enqueued later on the
+/// same stream has not yet executed. Serves the same purpose as a busy-wait
+/// kernel without needing a .cu translation unit.
+void CUDART_CB stall_stream_callback(void* /*user_data*/)
+{
+  std::this_thread::sleep_for(std::chrono::milliseconds(40));
+}
+
+/// RAII pinned host buffer (pinned so the D2H readback enqueues truly
+/// asynchronously behind the stall callback instead of staging synchronously).
+struct pinned_buffer {
+  void* ptr{nullptr};
+  explicit pinned_buffer(std::size_t bytes) { CUCASCADE_CUDA_TRY(cudaMallocHost(&ptr, bytes)); }
+  ~pinned_buffer()
+  {
+    if (ptr != nullptr) { cudaFreeHost(ptr); }
+  }
+  pinned_buffer(const pinned_buffer&)            = delete;
+  pinned_buffer& operator=(const pinned_buffer&) = delete;
+};
+
+}  // namespace
+
+// =============================================================================
+// 1. The contract: owned-table buffers are rebound to the release stream
+// =============================================================================
+
+TEST_CASE("release_table rebinds owned-table buffers to the release stream",
+          "[release_table][stream]")
+{
+  rmm::cuda_stream alloc_stream;    // P: the stream the table's buffers were allocated on
+  rmm::cuda_stream release_stream;  // S: the stream passed to release_table
+  REQUIRE(alloc_stream.value() != release_stream.value());
+
+  // Control: cudf factories bind buffers to their allocation stream, so a
+  // table built on P must report P everywhere. This guards the accessor
+  // itself -- without it the rebind assertions below could pass vacuously if
+  // device_buffer::stream() didn't reflect binding at all.
+  {
+    auto control = make_patterned_table(alloc_stream.view());
+    int checked  = expect_table_buffers_bound_to(*control, alloc_stream.view());
+    REQUIRE(checked >= 5);  // int32 data+mask, string chars+offsets, int64 data
+  }
+
+  auto reference = make_patterned_table(shared_stream());
+  gpu_table_representation rep(
+    make_patterned_table(alloc_stream.view()), *shared_gpu_space(), alloc_stream.view());
+
+  auto released = rep.release_table(release_stream.view());
+  REQUIRE(released != nullptr);
+
+  // Rebinding must not copy or corrupt: contents unchanged.
+  test::expect_cudf_tables_equal_on_stream(
+    reference->view(), released->view(), release_stream.view());
+
+  // THE CONTRACT: every non-empty device buffer -- data, null mask, and the
+  // nested STRING offsets child -- is now dealloc-bound to S, not P.
+  int checked = expect_table_buffers_bound_to(*released, release_stream.view());
+  REQUIRE(checked >= 5);
+}
+
+// =============================================================================
+// 2. Same contract for converter-produced (host_data_representation-backed)
+//    tables, whose buffers live on an internal pool stream the caller never
+//    sees -- the exact shape of the original bug.
+// =============================================================================
+
+TEST_CASE("release_table rebinds converter-produced tables to the release stream",
+          "[release_table][stream][converter]")
+{
+  rmm::cuda_stream release_stream;  // S: never seen by any converter
+
+  auto reference = make_patterned_table(shared_stream());
+  auto gpu_rep =
+    make_converter_produced_rep(make_patterned_table(shared_stream()), shared_gpu_space());
+
+  auto released = gpu_rep->release_table(release_stream.view());
+  REQUIRE(released != nullptr);
+
+  test::expect_cudf_tables_equal_on_stream(
+    reference->view(), released->view(), release_stream.view());
+
+  // >= 4: the host round trip may drop the redundant ALL_VALID null mask
+  // (null_count == 0), but int32 data, string chars + offsets, and int64 data
+  // must all be present and rebound.
+  int checked = expect_table_buffers_bound_to(*released, release_stream.view());
+  REQUIRE(checked >= 4);
+}
+
+// =============================================================================
+// 3. The UAF regression: destroying a released column mid-read must not let
+//    the allocator recycle its memory under the in-flight read.
+// =============================================================================
+
+TEST_CASE("released table freed mid-read is not recycled under the read (Q18 UAF regression)",
+          "[release_table][uaf]")
+{
+  // The scenario that motivated the fix (Sirius #1371 cached-serving race,
+  // TPC-H Q18 corruption): a converter materializes a table on an internal
+  // pool stream P and synchronizes it; a consumer takes the table via
+  // release_table(S), enqueues a read on S, then destroys the column while
+  // that read is still in flight.
+  //
+  // Pre-fix, release_table ignored S: the buffers stayed dealloc-bound to the
+  // idle, already-synced P, the stream-ordered free retired immediately, and
+  // the pool recycled the block under the pending read on S -- the clobber
+  // loop below would scribble 0xFF over the bytes the readback was about to
+  // copy. With the fix, the free is enqueued on S *behind* the read, so every
+  // reuse path is ordered after it and this must be deterministically correct.
+  //
+  // NOTE: this test passing does not by itself prove the pre-fix bug existed
+  // (the pool may simply decline to reuse a block); it exists so a regression
+  // of the dealloc-stream binding has a realistic chance of failing loudly.
+
+  auto& gpu_space  = async_gpu_space();
+  auto& host_space = shared_host_space();
+
+  constexpr int num_iterations         = 20;
+  constexpr cudf::size_type num_values = 1 << 20;  // 4 MiB of int32
+  constexpr std::size_t payload_bytes  = static_cast<std::size_t>(num_values) * sizeof(int32_t);
+
+  rmm::cuda_stream release_stream;  // S: reader / new dealloc owner
+  rmm::cuda_stream clobber_stream;  // hammers same-size allocations to force block reuse
+
+  pinned_buffer readback(payload_bytes);
+  std::vector<int32_t> host_values(static_cast<std::size_t>(num_values));
+
+  representation_converter_registry registry;
+  register_builtin_converters(registry);
+
+  for (int iter = 0; iter < num_iterations; ++iter) {
+    // Distinct known pattern per iteration so stale data from a previous
+    // iteration can never satisfy the comparison.
+    std::iota(host_values.begin(), host_values.end(), iter * 7919);
+
+    // Build the source on the setup stream, then round-trip through host so
+    // the GPU-side result is converter-produced: buffers allocated on an
+    // internal pool stream (synced before publish) from the stream-ordered
+    // (cudaMallocAsync) memory space.
+    auto src_col = cudf::make_numeric_column(cudf::data_type{cudf::type_id::INT32},
+                                             num_values,
+                                             cudf::mask_state::UNALLOCATED,
+                                             shared_stream(),
+                                             gpu_space->get_default_allocator());
+    CUCASCADE_CUDA_TRY(cudaMemcpyAsync(src_col->mutable_view().data<int32_t>(),
+                                       host_values.data(),
+                                       payload_bytes,
+                                       cudaMemcpyHostToDevice,
+                                       shared_stream().value()));
+    shared_stream().synchronize();
+    std::vector<std::unique_ptr<cudf::column>> cols;
+    cols.push_back(std::move(src_col));
+    auto gpu_rep0 = std::make_unique<gpu_table_representation>(
+      std::make_unique<cudf::table>(std::move(cols)), *gpu_space, shared_stream());
+    auto host_rep =
+      registry.convert<host_data_representation>(*gpu_rep0, host_space.get(), shared_stream());
+    gpu_rep0.reset();  // drop the source copy; only the converter-produced one remains
+    auto gpu_rep =
+      registry.convert<gpu_table_representation>(*host_rep, gpu_space.get(), shared_stream());
+
+    // Take ownership on S (safe with no extra sync: converters sync before
+    // publishing -- release_table's @pre).
+    auto released = gpu_rep->release_table(release_stream.view());
+    auto columns  = released->release();
+    REQUIRE(columns.size() == 1);
+    const void* data_ptr = columns[0]->view().head();
+
+    // Enqueue on S: [stall ~40 ms] -> [D2H read of the released column]. The
+    // stall guarantees the read has not executed yet when the column is
+    // destroyed below.
+    CUCASCADE_CUDA_TRY(cudaLaunchHostFunc(release_stream.value(), stall_stream_callback, nullptr));
+    CUCASCADE_CUDA_TRY(cudaMemcpyAsync(
+      readback.ptr, data_ptr, payload_bytes, cudaMemcpyDeviceToHost, release_stream.value()));
+
+    // Destroy the column while the read is in flight. With the fix the
+    // stream-ordered free lands on S, behind the memcpy.
+    columns[0].reset();
+    released.reset();
+    gpu_rep.reset();
+
+    // Reuse pressure: same-size allocations from the same pool on another
+    // stream, scribbled with 0xFF. If the free above had retired on an idle
+    // foreign stream (pre-fix behavior), the pool could hand one of these the
+    // just-freed block while the readback is still pending.
+    for (int k = 0; k < 8; ++k) {
+      rmm::device_buffer scratch(
+        payload_bytes, clobber_stream.view(), gpu_space->get_default_allocator());
+      CUCASCADE_CUDA_TRY(
+        cudaMemsetAsync(scratch.data(), 0xFF, payload_bytes, clobber_stream.value()));
+    }
+    clobber_stream.synchronize();
+    release_stream.synchronize();
+
+    INFO("iteration " << iter);
+    REQUIRE(std::memcmp(readback.ptr, host_values.data(), payload_bytes) == 0);
+  }
+}
+
+// =============================================================================
+// 4. View branch: unchanged behavior -- deep copy materialized on the release
+//    stream, source untouched.
+// =============================================================================
+
+TEST_CASE("view-branch release_table deep-copies on the release stream and leaves source untouched",
+          "[release_table][view]")
+{
+  rmm::cuda_stream alloc_stream;    // P: owns the source buffers throughout
+  rmm::cuda_stream release_stream;  // S
+
+  auto owner     = std::shared_ptr<cudf::table>(make_patterned_table(alloc_stream.view()));
+  auto reference = make_patterned_table(shared_stream());
+
+  gpu_table_representation rep(owner->view(),
+                               std::shared_ptr<cudf::table>{owner},  // type-erased owner
+                               owner->alloc_size(),
+                               *shared_gpu_space(),
+                               alloc_stream.view());
+
+  auto released = rep.release_table(release_stream.view());
+  REQUIRE(released != nullptr);
+
+  // Deep copy, not an alias of the source.
+  REQUIRE(released->view().column(0).head() != owner->view().column(0).head());
+
+  // Copy is correct and every buffer was born on (hence dealloc-bound to) S.
+  test::expect_cudf_tables_equal_on_stream(
+    reference->view(), released->view(), release_stream.view());
+  int checked = expect_table_buffers_bound_to(*released, release_stream.view());
+  REQUIRE(checked >= 5);
+
+  // The view branch replaced the variant, dropping the representation's
+  // type-erased owner reference -- we hold the only remaining one, so the
+  // destructive source inspection below is safe.
+  release_stream.synchronize();
+  CHECK(owner.use_count() == 1);
+
+  // Source untouched: contents intact, buffers still bound to P (view-branch
+  // release must not rebind memory it does not own).
+  test::expect_cudf_tables_equal_on_stream(reference->view(), owner->view(), release_stream.view());
+  int src_checked = expect_table_buffers_bound_to(*owner, alloc_stream.view());
+  REQUIRE(src_checked >= 5);
+}
+
+// =============================================================================
+// 5. Precondition: converter-produced tables can be released and consumed
+//    immediately, with no caller-side synchronization.
+// =============================================================================
+
+TEST_CASE("release_table immediately after converter publish is safe", "[release_table][converter]")
+{
+  // Built-in converters synchronize the conversion stream before publishing
+  // the representation, which is exactly what makes release_table's @pre hold
+  // here with zero manual synchronization between convert and release.
+  rmm::cuda_stream release_stream;
+
+  auto reference = make_patterned_table(shared_stream());
+  auto gpu_rep =
+    make_converter_produced_rep(make_patterned_table(shared_stream()), shared_gpu_space());
+
+  auto released = gpu_rep->release_table(release_stream.view());
+  gpu_rep.reset();
+
+  test::expect_cudf_tables_equal_on_stream(
+    reference->view(), released->view(), release_stream.view());
+
+  // Destroy the released table: frees enqueue on the release stream.
+  released.reset();
+  release_stream.synchronize();
+}
+
+// =============================================================================
+// 6. Composition: release_table(S) followed by an explicit cudf::rebind_stream
+//    to the same S (the Sirius PR #1566 call-site pattern) is a harmless no-op.
+// =============================================================================
+
+TEST_CASE("release_table then cudf::rebind_stream to the same stream composes",
+          "[release_table][stream]")
+{
+  rmm::cuda_stream alloc_stream;
+  rmm::cuda_stream release_stream;
+
+  auto reference = make_patterned_table(shared_stream());
+  gpu_table_representation rep(
+    make_patterned_table(alloc_stream.view()), *shared_gpu_space(), alloc_stream.view());
+
+  auto released = rep.release_table(release_stream.view());
+  REQUIRE(released != nullptr);
+
+  // Rebind each released column to the same stream again, as the Sirius call
+  // site does defensively after release_table.
+  auto columns = released->release();
+  for (auto& col : columns) {
+    col = cudf::rebind_stream(std::move(*col), release_stream.view());
+  }
+  auto reassembled = std::make_unique<cudf::table>(std::move(columns));
+
+  test::expect_cudf_tables_equal_on_stream(
+    reference->view(), reassembled->view(), release_stream.view());
+  int checked = expect_table_buffers_bound_to(*reassembled, release_stream.view());
+  REQUIRE(checked >= 5);
+}

--- a/test/data/test_consumer_events.cpp
+++ b/test/data/test_consumer_events.cpp
@@ -671,6 +671,20 @@ TEST_CASE("set_data host-syncs pending consumer reads before destroying the old 
   fixture.verify_no_premature_reclaim();
 }
 
+TEST_CASE("~data_batch host-syncs pending consumer reads before destroying the representation",
+          "[consumer_events][data_batch][reclaim]")
+{
+  pending_consumer_read fixture;
+  REQUIRE_FALSE(fixture.batch->consumers_done());
+
+  // Plain destruction: drop the last reference without any reclaimer transition
+  // (no convert_to / set_data). The destructor itself must block on the recorded
+  // read before the poisoning representation is destroyed.
+  fixture.batch.reset();
+
+  fixture.verify_no_premature_reclaim();
+}
+
 // =============================================================================
 // Negative / edge cases
 // =============================================================================

--- a/test/data/test_consumer_events.cpp
+++ b/test/data/test_consumer_events.cpp
@@ -19,9 +19,13 @@
 // await_consumers / consumers_done (and the accessor delegates), backed by
 // cucascade::cuda::event_pool. Covers:
 //   - event_pool semantics (record / enqueue_waits / synchronize / is_done,
-//     recycling, thread safety, empty fast path)
-//   - data_batch API basics (pending-read visibility, device-side gating of a
-//     reclaimer stream, multi-consumer / multi-thread recording)
+//     recycling, thread safety, empty fast path). event_pool is the canonical
+//     layer for recycling and single-event gating; the data_batch tests below
+//     only add what the batch layer contributes (lock interplay, accessors,
+//     multi-consumer bookkeeping, reclaim hooks).
+//   - data_batch API: trivial fast path, multi-consumer pending visibility +
+//     device-side gating of a reclaimer stream (through the accessors),
+//     multi-thread recording under shared locks
 //   - reclaim-hook integration: install_converted_representation (GPU-tier
 //     sync path AND the non-GPU-tier else-branch host sync) and set_data must
 //     not destroy the old representation while consumer reads are in flight
@@ -471,74 +475,11 @@ TEST_CASE("data_batch consumer events trivial fast path when nothing was recorde
   REQUIRE(batch->consumers_done());
 }
 
-TEST_CASE("data_batch consumers_done reflects a pending consumer read",
-          "[consumer_events][data_batch]")
-{
-  auto batch = make_mock_batch();
-  rmm::cuda_stream consumer;
-  device_buffer_raw scratch(64);
-
-  stream_gate gate;
-  {
-    gate_guard guard{gate, consumer.view()};
-
-    auto ro = batch->to_read_only();
-    enqueue_gate(consumer.view(), gate);
-    CUCASCADE_CUDA_TRY(cudaMemsetAsync(scratch.ptr, 0xAB, scratch.bytes, consumer.value()));
-    ro.record_consumer_event(consumer.view());
-
-    // Gated: the consumer's read cannot have completed yet.
-    REQUIRE_FALSE(batch->consumers_done());
-    REQUIRE_FALSE(ro.consumers_done());
-
-    gate.release();
-    consumer.synchronize();
-    REQUIRE(batch->consumers_done());
-    REQUIRE(ro.consumers_done());
-  }
-}
-
-TEST_CASE("data_batch await_consumers gates reclaim-side work on the awaiting stream",
-          "[consumer_events][data_batch]")
-{
-  auto batch = make_mock_batch();
-  rmm::cuda_stream consumer;
-  rmm::cuda_stream reclaimer;
-
-  device_buffer_raw flag(1);
-  pinned_buffer observed(1);
-  CUCASCADE_CUDA_TRY(cudaMemset(flag.ptr, 0, 1));
-  observed.data()[0] = 0xEE;
-
-  stream_gate gate;
-  {
-    gate_guard guard{gate, consumer.view()};
-
-    {
-      auto ro = batch->to_read_only();
-      enqueue_gate(consumer.view(), gate);
-      CUCASCADE_CUDA_TRY(cudaMemsetAsync(flag.ptr, 1, 1, consumer.value()));
-      ro.record_consumer_event(consumer.view());
-    }  // shared lock released; the read is still in flight
-
-    // Reclaimer path: exclusive lock, then device-side waits before the "free"
-    // (modeled here as a read-back of the flag the consumer writes last).
-    auto mut = batch->to_mutable();
-    mut.await_consumers(reclaimer.view());
-    CUCASCADE_CUDA_TRY(
-      cudaMemcpyAsync(observed.ptr, flag.ptr, 1, cudaMemcpyDeviceToHost, reclaimer.value()));
-
-    // Blocked while the consumer is gated: the wait is real.
-    std::this_thread::sleep_for(std::chrono::milliseconds(20));
-    REQUIRE(cudaStreamQuery(reclaimer.value()) == cudaErrorNotReady);
-
-    gate.release();
-    reclaimer.synchronize();
-    REQUIRE(observed.data()[0] == 1);
-    REQUIRE(batch->consumers_done());
-  }
-}
-
+// The single-consumer pending-visibility and await-gating cases are strict
+// subsets of this multi-consumer test; their unique accessor-path coverage
+// (ro.consumers_done() while pending, mut.await_consumers under load) is
+// folded in here. The underlying single-event device-side gating primitive is
+// pinned at the event_pool layer above.
 TEST_CASE("data_batch awaits every consumer across multiple streams",
           "[consumer_events][data_batch]")
 {
@@ -579,9 +520,16 @@ TEST_CASE("data_batch awaits every consumer across multiple streams",
                                          consumers[static_cast<std::size_t>(i)].value()));
       ro.record_consumer_event(consumers[static_cast<std::size_t>(i)].view());
     }
-  }
+    // Gated: pending reads are visible through the read-only accessor too.
+    REQUIRE_FALSE(ro.consumers_done());
+  }  // shared lock released; the reads are still in flight
 
-  batch->await_consumers(reclaimer.view());
+  // Reclaimer path: exclusive lock, then device-side waits before the "free"
+  // (modeled here as a read-back of the flags each consumer writes last).
+  {
+    auto mut = batch->to_mutable();
+    mut.await_consumers(reclaimer.view());
+  }
   CUCASCADE_CUDA_TRY(cudaMemcpyAsync(
     observed.ptr, flags.ptr, kConsumers, cudaMemcpyDeviceToHost, reclaimer.value()));
 
@@ -649,23 +597,6 @@ TEST_CASE("data_batch record_consumer_event is thread-safe under concurrent reco
   rmm::cuda_stream check_stream;
   batch->await_consumers(check_stream.view());
   check_stream.synchronize();
-  REQUIRE(batch->consumers_done());
-}
-
-TEST_CASE("data_batch sequential record/complete cycles stay correct (event recycling)",
-          "[consumer_events][data_batch]")
-{
-  auto batch = make_mock_batch();
-  rmm::cuda_stream stream;
-  device_buffer_raw scratch(64);
-
-  for (int i = 0; i < 1000; ++i) {
-    CUCASCADE_CUDA_TRY(
-      cudaMemsetAsync(scratch.ptr, static_cast<int>(i & 0xFF), scratch.bytes, stream.value()));
-    batch->record_consumer_event(stream.view());
-    stream.synchronize();
-    if (i % 100 == 0) { REQUIRE(batch->consumers_done()); }
-  }
   REQUIRE(batch->consumers_done());
 }
 

--- a/test/data/test_consumer_events.cpp
+++ b/test/data/test_consumer_events.cpp
@@ -17,20 +17,10 @@
 
 // Tests for the consumer-event API: data_batch::record_consumer_event /
 // await_consumers / consumers_done (and the accessor delegates), backed by
-// cucascade::cuda::event_pool. Covers:
-//   - event_pool semantics (record / enqueue_waits / synchronize / is_done,
-//     recycling, thread safety, empty fast path). event_pool is the canonical
-//     layer for recycling and single-event gating; the data_batch tests below
-//     only add what the batch layer contributes (lock interplay, accessors,
-//     multi-consumer bookkeeping, reclaim hooks).
-//   - data_batch API: trivial fast path, multi-consumer pending visibility +
-//     device-side gating of a reclaimer stream (through the accessors),
-//     multi-thread recording under shared locks
-//   - reclaim-hook integration: install_converted_representation (GPU-tier
-//     sync path AND the non-GPU-tier else-branch host sync) and set_data must
-//     not destroy the old representation while consumer reads are in flight
-//     (poison-on-reclaim pattern)
-//   - edges: default-stream record, await on the recording stream itself.
+// cucascade::cuda::event_pool. event_pool is the canonical layer for recycling
+// and single-event gating; the data_batch tests only add what the batch layer
+// contributes (lock interplay, accessors, multi-consumer bookkeeping, reclaim
+// hooks).
 
 #include "utils/mock_test_utils.hpp"
 
@@ -157,8 +147,7 @@ std::shared_ptr<data_batch> make_mock_batch(memory::Tier tier = memory::Tier::GP
 }
 
 // =============================================================================
-// Poison-on-reclaim fixture (modeled on Sirius PR #1566's
-// test_owning_table_view.cpp reclaim probe)
+// Poison-on-reclaim fixture
 // =============================================================================
 
 constexpr std::uint8_t kSourcePattern = 0xAB;
@@ -475,10 +464,8 @@ TEST_CASE("data_batch consumer events trivial fast path when nothing was recorde
   REQUIRE(batch->consumers_done());
 }
 
-// The single-consumer pending-visibility and await-gating cases are strict
-// subsets of this multi-consumer test; their unique accessor-path coverage
-// (ro.consumers_done() while pending, mut.await_consumers under load) is
-// folded in here. The underlying single-event device-side gating primitive is
+// Also covers the accessor paths (ro.consumers_done() while pending,
+// mut.await_consumers); the single-event device-side gating primitive is
 // pinned at the event_pool layer above.
 TEST_CASE("data_batch awaits every consumer across multiple streams",
           "[consumer_events][data_batch]")
@@ -678,7 +665,6 @@ TEST_CASE("set_data host-syncs pending consumer reads before destroying the old 
     auto mut = fixture.batch->to_mutable();
     REQUIRE_FALSE(mut.consumers_done());
     mut.set_data(std::make_unique<mock_data_representation>(memory::Tier::HOST, 64));
-    // set_data's conservative host sync completed all consumer events.
     REQUIRE(mut.consumers_done());
   }
 

--- a/test/data/test_consumer_events.cpp
+++ b/test/data/test_consumer_events.cpp
@@ -1,0 +1,798 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Tests for the consumer-event API: data_batch::record_consumer_event /
+// await_consumers / consumers_done (and the accessor delegates), backed by
+// cucascade::cuda::event_pool. Covers:
+//   - event_pool semantics (record / enqueue_waits / synchronize / is_done,
+//     recycling, thread safety, empty fast path)
+//   - data_batch API basics (pending-read visibility, device-side gating of a
+//     reclaimer stream, multi-consumer / multi-thread recording)
+//   - reclaim-hook integration: install_converted_representation (GPU-tier
+//     sync path AND the non-GPU-tier else-branch host sync) and set_data must
+//     not destroy the old representation while consumer reads are in flight
+//     (poison-on-reclaim pattern)
+//   - edges: default-stream record, await on the recording stream itself.
+
+#include "utils/mock_test_utils.hpp"
+
+#include <cucascade/cuda/event.hpp>
+#include <cucascade/cuda/event_pool.hpp>
+#include <cucascade/data/data_batch.hpp>
+#include <cucascade/data/representation_converter.hpp>
+#include <cucascade/error.hpp>
+
+#include <rmm/cuda_stream.hpp>
+#include <rmm/cuda_stream_view.hpp>
+
+#include <cuda_runtime_api.h>
+
+#include <catch2/catch_all.hpp>
+
+#include <algorithm>
+#include <array>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <thread>
+#include <vector>
+
+using namespace cucascade;
+using cucascade::test::make_mock_memory_space;
+using cucascade::test::mock_data_representation;
+
+// `using namespace cucascade` makes plain `cuda` ambiguous with libcu++'s
+// global `::cuda` namespace, so alias the cucascade one explicitly.
+namespace cc_cuda = cucascade::cuda;
+
+namespace {
+
+// =============================================================================
+// Deterministic slow-consumer primitives
+// =============================================================================
+
+// Host callback that blocks the stream until the gate opens. Deterministic:
+// events recorded behind the gate CANNOT complete until release() is called.
+struct stream_gate {
+  std::atomic<bool> open{false};
+  void release() { open.store(true, std::memory_order_release); }
+};
+
+void CUDART_CB gate_callback(void* user_data)
+{
+  auto* gate = static_cast<stream_gate*>(user_data);
+  while (!gate->open.load(std::memory_order_acquire)) {
+    std::this_thread::sleep_for(std::chrono::microseconds(200));
+  }
+}
+
+void enqueue_gate(rmm::cuda_stream_view stream, stream_gate& gate)
+{
+  CUCASCADE_CUDA_TRY(cudaLaunchHostFunc(stream.value(), gate_callback, &gate));
+}
+
+// RAII: on scope exit (including REQUIRE-failure unwinding) release the gate
+// and drain the stream so the callback never outlives the gate object.
+struct gate_guard {
+  stream_gate& gate;
+  rmm::cuda_stream_view stream;
+  ~gate_guard()
+  {
+    gate.release();
+    cudaStreamSynchronize(stream.value());
+  }
+};
+
+// Host callback sleeping for a fixed duration encoded in the user-data pointer
+// value itself (no lifetime concerns).
+void CUDART_CB sleep_callback(void* user_data)
+{
+  auto ms = static_cast<int>(reinterpret_cast<std::intptr_t>(user_data));
+  std::this_thread::sleep_for(std::chrono::milliseconds(ms));
+}
+
+void enqueue_host_delay(rmm::cuda_stream_view stream, int ms)
+{
+  CUCASCADE_CUDA_TRY(cudaLaunchHostFunc(
+    stream.value(), sleep_callback, reinterpret_cast<void*>(static_cast<std::intptr_t>(ms))));
+}
+
+// Host callback that flips an atomic flag; used to observe host-visible stream
+// progress from the CPU side.
+void CUDART_CB set_flag_callback(void* user_data)
+{
+  static_cast<std::atomic<bool>*>(user_data)->store(true, std::memory_order_release);
+}
+
+// =============================================================================
+// Raw memory helpers (plain cudart, no cudf dependency)
+// =============================================================================
+
+struct pinned_buffer {
+  void* ptr{nullptr};
+  std::size_t bytes{0};
+
+  explicit pinned_buffer(std::size_t n) : bytes(n) { CUCASCADE_CUDA_TRY(cudaMallocHost(&ptr, n)); }
+  ~pinned_buffer() { cudaFreeHost(ptr); }
+  pinned_buffer(const pinned_buffer&)            = delete;
+  pinned_buffer& operator=(const pinned_buffer&) = delete;
+
+  std::uint8_t* data() const { return static_cast<std::uint8_t*>(ptr); }
+};
+
+struct device_buffer_raw {
+  void* ptr{nullptr};
+  std::size_t bytes{0};
+
+  explicit device_buffer_raw(std::size_t n) : bytes(n) { CUCASCADE_CUDA_TRY(cudaMalloc(&ptr, n)); }
+  ~device_buffer_raw() { cudaFree(ptr); }
+  device_buffer_raw(const device_buffer_raw&)            = delete;
+  device_buffer_raw& operator=(const device_buffer_raw&) = delete;
+};
+
+std::shared_ptr<data_batch> make_mock_batch(memory::Tier tier = memory::Tier::GPU, uint64_t id = 1)
+{
+  return data_batch::make(id, std::make_unique<mock_data_representation>(tier, 1024));
+}
+
+// =============================================================================
+// Poison-on-reclaim fixture (modeled on Sirius PR #1566's
+// test_owning_table_view.cpp reclaim probe)
+// =============================================================================
+
+constexpr std::uint8_t kSourcePattern = 0xAB;
+constexpr std::uint8_t kPoisonPattern = 0xFF;
+
+// Observations recorded at the moment the old representation is destroyed.
+struct reclaim_probe {
+  cc_cuda::cuda_event consumer_done_event;  ///< Recorded on the consumer stream after its read
+  std::atomic<bool> reclaimed{false};
+  std::atomic<bool> consumer_read_complete_at_reclaim{false};
+  void* pinned{nullptr};
+  std::size_t bytes{0};
+};
+
+// HOST-tier representation over externally-owned pinned memory. Destroying it
+// stands in for reclaim: it notes whether the consumer's recorded read had
+// completed, then poisons the pinned buffer the way a recycling cache would
+// overwrite it the instant the old representation is dropped.
+class poisoning_pinned_representation : private cucascade::test::mock_memory_space_holder,
+                                        public idata_representation {
+ public:
+  explicit poisoning_pinned_representation(reclaim_probe& probe)
+    : mock_memory_space_holder(memory::Tier::HOST, 0), idata_representation(*space), _probe(probe)
+  {
+  }
+
+  ~poisoning_pinned_representation() override
+  {
+    _probe.reclaimed.store(true, std::memory_order_release);
+    _probe.consumer_read_complete_at_reclaim.store(
+      _probe.consumer_done_event.query() == cc_cuda::event::query_result::success,
+      std::memory_order_release);
+    // Simulate the pinned chunk being reused the instant the representation dies.
+    std::memset(_probe.pinned, kPoisonPattern, _probe.bytes);
+  }
+
+  std::size_t get_size_in_bytes() const override { return _probe.bytes; }
+  std::size_t get_uncompressed_data_size_in_bytes() const override { return _probe.bytes; }
+  std::unique_ptr<idata_representation> clone(
+    [[maybe_unused]] rmm::cuda_stream_view stream) override
+  {
+    return nullptr;
+  }
+
+ private:
+  reclaim_probe& _probe;
+};
+
+// Common setup for the reclaim-ordering tests: a HOST-tier batch over
+// poison-on-reclaim pinned memory, plus one consumer whose H2D read of that
+// memory is still in flight (held behind a 150 ms host delay) and recorded via
+// record_consumer_event.
+struct pending_consumer_read {
+  static constexpr std::size_t kBytes = std::size_t{1} << 20;  // 1 MiB
+
+  pinned_buffer pinned{kBytes};
+  reclaim_probe probe;
+  std::shared_ptr<data_batch> batch;
+  rmm::cuda_stream consumer;
+  device_buffer_raw dst{kBytes};
+
+  pending_consumer_read()
+  {
+    std::memset(pinned.ptr, kSourcePattern, kBytes);
+    probe.pinned = pinned.ptr;
+    probe.bytes  = kBytes;
+    batch        = data_batch::make(1, std::make_unique<poisoning_pinned_representation>(probe));
+
+    auto ro = batch->to_read_only();
+    enqueue_host_delay(consumer.view(), 150);
+    CUCASCADE_CUDA_TRY(
+      cudaMemcpyAsync(dst.ptr, pinned.ptr, kBytes, cudaMemcpyHostToDevice, consumer.value()));
+    probe.consumer_done_event.record(consumer.view());
+    ro.record_consumer_event(consumer.view());
+    // Shared lock drops here; the read stays in flight on `consumer`.
+  }
+
+  ~pending_consumer_read()
+  {
+    // Drain the consumer before members are torn down, also on REQUIRE-failure
+    // unwinding, so the in-flight copy never touches freed memory.
+    cudaStreamSynchronize(consumer.value());
+  }
+
+  // The reclaim must have happened, strictly after the consumer's read.
+  void verify_no_premature_reclaim()
+  {
+    REQUIRE(probe.reclaimed.load(std::memory_order_acquire));
+    REQUIRE(probe.consumer_read_complete_at_reclaim.load(std::memory_order_acquire));
+
+    consumer.synchronize();
+    std::vector<std::uint8_t> host(kBytes);
+    CUCASCADE_CUDA_TRY(cudaMemcpy(host.data(), dst.ptr, kBytes, cudaMemcpyDeviceToHost));
+    const auto poisoned =
+      std::count(host.begin(), host.end(), static_cast<std::uint8_t>(kPoisonPattern));
+    INFO("poisoned bytes: " << poisoned << " / " << kBytes);
+    REQUIRE(poisoned == 0);
+    REQUIRE(host.front() == kSourcePattern);
+    REQUIRE(host.back() == kSourcePattern);
+  }
+};
+
+}  // namespace
+
+// =============================================================================
+// event_pool unit tests
+// =============================================================================
+
+TEST_CASE("event_pool empty pool is done and waits are no-ops", "[consumer_events][event_pool]")
+{
+  cc_cuda::event_pool pool;
+  REQUIRE(pool.is_done());
+
+  pool.synchronize();  // no outstanding events: returns immediately
+  REQUIRE(pool.is_done());
+
+  rmm::cuda_stream stream;
+  pool.enqueue_waits(stream.view());  // nothing to wait on: enqueues nothing
+  stream.synchronize();
+  REQUIRE(pool.is_done());
+}
+
+TEST_CASE("event_pool record tracks pending work until it completes",
+          "[consumer_events][event_pool]")
+{
+  cc_cuda::event_pool pool;
+  rmm::cuda_stream stream;
+  device_buffer_raw scratch(64);
+
+  stream_gate gate;
+  {
+    gate_guard guard{gate, stream.view()};
+
+    enqueue_gate(stream.view(), gate);
+    CUCASCADE_CUDA_TRY(cudaMemsetAsync(scratch.ptr, 0x11, scratch.bytes, stream.value()));
+    pool.record(stream.view());
+
+    // The gate is closed: the recorded event cannot possibly have completed.
+    REQUIRE_FALSE(pool.is_done());
+
+    gate.release();
+    stream.synchronize();
+    REQUIRE(pool.is_done());
+  }
+}
+
+TEST_CASE("event_pool synchronize blocks the host until recorded work completes",
+          "[consumer_events][event_pool]")
+{
+  cc_cuda::event_pool pool;
+  rmm::cuda_stream stream;
+
+  stream_gate gate;
+  std::atomic<bool> work_finished{false};
+  {
+    gate_guard guard{gate, stream.view()};
+
+    enqueue_gate(stream.view(), gate);
+    // This callback runs only after the gate opens; synchronize() returning
+    // proves it waited for everything recorded, not just returned early.
+    CUCASCADE_CUDA_TRY(cudaLaunchHostFunc(stream.value(), set_flag_callback, &work_finished));
+    pool.record(stream.view());
+
+    std::thread opener([&gate]() {
+      std::this_thread::sleep_for(std::chrono::milliseconds(50));
+      gate.release();
+    });
+
+    pool.synchronize();
+    REQUIRE(work_finished.load(std::memory_order_acquire));
+    REQUIRE(pool.is_done());
+    opener.join();
+  }
+}
+
+TEST_CASE("event_pool enqueue_waits gates cross-stream work device-side",
+          "[consumer_events][event_pool]")
+{
+  cc_cuda::event_pool pool;
+  rmm::cuda_stream producer;
+  rmm::cuda_stream waiter;
+
+  device_buffer_raw flag(1);
+  pinned_buffer observed(1);
+  CUCASCADE_CUDA_TRY(cudaMemset(flag.ptr, 0, 1));
+  observed.data()[0] = 0xEE;
+
+  stream_gate gate;
+  {
+    gate_guard guard{gate, producer.view()};
+
+    // Producer: (gated) write flag = 1, then record.
+    enqueue_gate(producer.view(), gate);
+    CUCASCADE_CUDA_TRY(cudaMemsetAsync(flag.ptr, 1, 1, producer.value()));
+    pool.record(producer.view());
+
+    // Waiter: device-side wait, then read the flag back. No host sync anywhere.
+    pool.enqueue_waits(waiter.view());
+    CUCASCADE_CUDA_TRY(
+      cudaMemcpyAsync(observed.ptr, flag.ptr, 1, cudaMemcpyDeviceToHost, waiter.value()));
+
+    // While the gate is closed the waiter must be blocked by the enqueued wait.
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    REQUIRE(cudaStreamQuery(waiter.value()) == cudaErrorNotReady);
+
+    gate.release();
+    waiter.synchronize();
+    // The copy was ordered after the producer's write: it must see 1, not 0.
+    REQUIRE(observed.data()[0] == 1);
+  }
+}
+
+TEST_CASE("event_pool recycles events across many record/complete cycles",
+          "[consumer_events][event_pool]")
+{
+  cc_cuda::event_pool pool;
+  rmm::cuda_stream stream;
+  device_buffer_raw scratch(64);
+
+  // 1000 records with periodic completion. Recycling has no size accessor, so
+  // assert sustained correctness: records keep succeeding and is_done stays
+  // accurate after every drain point.
+  for (int i = 0; i < 1000; ++i) {
+    CUCASCADE_CUDA_TRY(
+      cudaMemsetAsync(scratch.ptr, static_cast<int>(i & 0xFF), scratch.bytes, stream.value()));
+    pool.record(stream.view());
+    if (i % 4 == 3) { stream.synchronize(); }
+    if (i % 16 == 15) { REQUIRE(pool.is_done()); }  // follows the drain above
+  }
+  stream.synchronize();
+  pool.synchronize();
+  REQUIRE(pool.is_done());
+}
+
+TEST_CASE("event_pool concurrent record from multiple threads is safe",
+          "[consumer_events][event_pool]")
+{
+  cc_cuda::event_pool pool;
+  constexpr int kThreads          = 8;
+  constexpr int kRecordsPerThread = 100;
+
+  std::atomic<int> failures{0};
+  std::atomic<int> done_threads{0};
+  {
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+      threads.emplace_back([&pool, &failures, &done_threads]() {
+        try {
+          rmm::cuda_stream stream;
+          device_buffer_raw scratch(16);
+          for (int j = 0; j < kRecordsPerThread; ++j) {
+            CUCASCADE_CUDA_TRY(
+              cudaMemsetAsync(scratch.ptr, j & 0xFF, scratch.bytes, stream.value()));
+            pool.record(stream.view());
+          }
+          stream.synchronize();
+        } catch (...) {
+          failures.fetch_add(1);
+        }
+        done_threads.fetch_add(1);
+      });
+    }
+
+    // Poll the pool concurrently with the recorders to stress the mutex from
+    // the reader/waiter side too.
+    rmm::cuda_stream check_stream;
+    while (done_threads.load() < kThreads) {
+      (void)pool.is_done();
+      pool.enqueue_waits(check_stream.view());
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    check_stream.synchronize();
+
+    for (auto& t : threads) {
+      t.join();
+    }
+  }
+  REQUIRE(failures.load() == 0);
+
+  pool.synchronize();
+  REQUIRE(pool.is_done());
+}
+
+// =============================================================================
+// data_batch consumer-event API basics
+// =============================================================================
+
+TEST_CASE("data_batch consumer events trivial fast path when nothing was recorded",
+          "[consumer_events][data_batch]")
+{
+  auto batch = make_mock_batch();
+  rmm::cuda_stream stream;
+
+  REQUIRE(batch->consumers_done());
+  batch->await_consumers(stream.view());  // no-op, no error
+  stream.synchronize();
+
+  {
+    auto ro = batch->to_read_only();
+    REQUIRE(ro.consumers_done());
+    ro.await_consumers(stream.view());
+  }
+  {
+    auto mut = batch->to_mutable();
+    REQUIRE(mut.consumers_done());
+    mut.await_consumers(stream.view());
+
+    // set_data's conservative host sync must be a no-op for a batch that never
+    // recorded a consumer event.
+    mut.set_data(std::make_unique<mock_data_representation>(memory::Tier::HOST, 512));
+    REQUIRE(mut.get_current_tier() == memory::Tier::HOST);
+  }
+  REQUIRE(batch->consumers_done());
+}
+
+TEST_CASE("data_batch consumers_done reflects a pending consumer read",
+          "[consumer_events][data_batch]")
+{
+  auto batch = make_mock_batch();
+  rmm::cuda_stream consumer;
+  device_buffer_raw scratch(64);
+
+  stream_gate gate;
+  {
+    gate_guard guard{gate, consumer.view()};
+
+    auto ro = batch->to_read_only();
+    enqueue_gate(consumer.view(), gate);
+    CUCASCADE_CUDA_TRY(cudaMemsetAsync(scratch.ptr, 0xAB, scratch.bytes, consumer.value()));
+    ro.record_consumer_event(consumer.view());
+
+    // Gated: the consumer's read cannot have completed yet.
+    REQUIRE_FALSE(batch->consumers_done());
+    REQUIRE_FALSE(ro.consumers_done());
+
+    gate.release();
+    consumer.synchronize();
+    REQUIRE(batch->consumers_done());
+    REQUIRE(ro.consumers_done());
+  }
+}
+
+TEST_CASE("data_batch await_consumers gates reclaim-side work on the awaiting stream",
+          "[consumer_events][data_batch]")
+{
+  auto batch = make_mock_batch();
+  rmm::cuda_stream consumer;
+  rmm::cuda_stream reclaimer;
+
+  device_buffer_raw flag(1);
+  pinned_buffer observed(1);
+  CUCASCADE_CUDA_TRY(cudaMemset(flag.ptr, 0, 1));
+  observed.data()[0] = 0xEE;
+
+  stream_gate gate;
+  {
+    gate_guard guard{gate, consumer.view()};
+
+    {
+      auto ro = batch->to_read_only();
+      enqueue_gate(consumer.view(), gate);
+      CUCASCADE_CUDA_TRY(cudaMemsetAsync(flag.ptr, 1, 1, consumer.value()));
+      ro.record_consumer_event(consumer.view());
+    }  // shared lock released; the read is still in flight
+
+    // Reclaimer path: exclusive lock, then device-side waits before the "free"
+    // (modeled here as a read-back of the flag the consumer writes last).
+    auto mut = batch->to_mutable();
+    mut.await_consumers(reclaimer.view());
+    CUCASCADE_CUDA_TRY(
+      cudaMemcpyAsync(observed.ptr, flag.ptr, 1, cudaMemcpyDeviceToHost, reclaimer.value()));
+
+    // Blocked while the consumer is gated: the wait is real.
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    REQUIRE(cudaStreamQuery(reclaimer.value()) == cudaErrorNotReady);
+
+    gate.release();
+    reclaimer.synchronize();
+    REQUIRE(observed.data()[0] == 1);
+    REQUIRE(batch->consumers_done());
+  }
+}
+
+TEST_CASE("data_batch awaits every consumer across multiple streams",
+          "[consumer_events][data_batch]")
+{
+  constexpr int kConsumers = 3;
+  auto batch               = make_mock_batch();
+  rmm::cuda_stream reclaimer;
+
+  std::array<rmm::cuda_stream, kConsumers> consumers{};
+  std::array<stream_gate, kConsumers> gates{};
+
+  device_buffer_raw flags(kConsumers);
+  pinned_buffer observed(kConsumers);
+  CUCASCADE_CUDA_TRY(cudaMemset(flags.ptr, 0, kConsumers));
+  std::memset(observed.ptr, 0xEE, kConsumers);
+
+  struct all_gates_guard {
+    std::array<stream_gate, kConsumers>& gates;
+    std::array<rmm::cuda_stream, kConsumers>& streams;
+    ~all_gates_guard()
+    {
+      for (auto& g : gates) {
+        g.release();
+      }
+      for (auto& s : streams) {
+        cudaStreamSynchronize(s.value());
+      }
+    }
+  } guard{gates, consumers};
+
+  {
+    auto ro = batch->to_read_only();
+    for (int i = 0; i < kConsumers; ++i) {
+      enqueue_gate(consumers[static_cast<std::size_t>(i)].view(),
+                   gates[static_cast<std::size_t>(i)]);
+      CUCASCADE_CUDA_TRY(cudaMemsetAsync(static_cast<std::uint8_t*>(flags.ptr) + i,
+                                         1,
+                                         1,
+                                         consumers[static_cast<std::size_t>(i)].value()));
+      ro.record_consumer_event(consumers[static_cast<std::size_t>(i)].view());
+    }
+  }
+
+  batch->await_consumers(reclaimer.view());
+  CUCASCADE_CUDA_TRY(cudaMemcpyAsync(
+    observed.ptr, flags.ptr, kConsumers, cudaMemcpyDeviceToHost, reclaimer.value()));
+
+  REQUIRE_FALSE(batch->consumers_done());
+
+  // Release the gates one at a time; the reclaimer may only proceed once the
+  // LAST consumer has finished its write.
+  for (int i = kConsumers - 1; i >= 0; --i) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    REQUIRE(cudaStreamQuery(reclaimer.value()) == cudaErrorNotReady);
+    gates[static_cast<std::size_t>(i)].release();
+  }
+
+  reclaimer.synchronize();
+  for (int i = 0; i < kConsumers; ++i) {
+    REQUIRE(observed.data()[i] == 1);
+  }
+  REQUIRE(batch->consumers_done());
+}
+
+TEST_CASE("data_batch record_consumer_event is thread-safe under concurrent recording",
+          "[consumer_events][data_batch]")
+{
+  auto batch                      = make_mock_batch();
+  constexpr int kThreads          = 8;
+  constexpr int kRecordsPerThread = 50;
+
+  std::atomic<int> failures{0};
+  std::atomic<int> done_threads{0};
+  {
+    std::vector<std::thread> threads;
+    threads.reserve(kThreads);
+    for (int t = 0; t < kThreads; ++t) {
+      threads.emplace_back([&batch, &failures, &done_threads]() {
+        try {
+          rmm::cuda_stream stream;
+          device_buffer_raw scratch(16);
+          // Concurrent shared-lock holders all recording, as real consumers do.
+          auto ro = batch->to_read_only();
+          for (int j = 0; j < kRecordsPerThread; ++j) {
+            CUCASCADE_CUDA_TRY(
+              cudaMemsetAsync(scratch.ptr, j & 0xFF, scratch.bytes, stream.value()));
+            ro.record_consumer_event(stream.view());
+          }
+          stream.synchronize();
+        } catch (...) {
+          failures.fetch_add(1);
+        }
+        done_threads.fetch_add(1);
+      });
+    }
+
+    // Poll consumers_done concurrently — it must never throw or race.
+    while (done_threads.load() < kThreads) {
+      (void)batch->consumers_done();
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+
+    for (auto& t : threads) {
+      t.join();
+    }
+  }
+  REQUIRE(failures.load() == 0);
+
+  rmm::cuda_stream check_stream;
+  batch->await_consumers(check_stream.view());
+  check_stream.synchronize();
+  REQUIRE(batch->consumers_done());
+}
+
+TEST_CASE("data_batch sequential record/complete cycles stay correct (event recycling)",
+          "[consumer_events][data_batch]")
+{
+  auto batch = make_mock_batch();
+  rmm::cuda_stream stream;
+  device_buffer_raw scratch(64);
+
+  for (int i = 0; i < 1000; ++i) {
+    CUCASCADE_CUDA_TRY(
+      cudaMemsetAsync(scratch.ptr, static_cast<int>(i & 0xFF), scratch.bytes, stream.value()));
+    batch->record_consumer_event(stream.view());
+    stream.synchronize();
+    if (i % 100 == 0) { REQUIRE(batch->consumers_done()); }
+  }
+  REQUIRE(batch->consumers_done());
+}
+
+// =============================================================================
+// Reclaim-hook integration (poison-on-reclaim)
+// =============================================================================
+
+TEST_CASE(
+  "convert_to GPU-tier path defers old-representation reclaim until consumer reads complete",
+  "[consumer_events][data_batch][reclaim]")
+{
+  pending_consumer_read fixture;
+
+  // Host -> GPU conversion: the new representation is GPU-tier, so
+  // install_converted_representation takes the await_consumers +
+  // stream.synchronize() path.
+  representation_converter_registry registry;
+  registry.register_converter<poisoning_pinned_representation, mock_data_representation>(
+    [](idata_representation& /*source*/,
+       const memory::memory_space* /*target_space*/,
+       rmm::cuda_stream_view /*stream*/,
+       memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
+      return std::make_unique<mock_data_representation>(memory::Tier::GPU,
+                                                        pending_consumer_read::kBytes);
+    });
+
+  auto gpu_space = make_mock_memory_space(memory::Tier::GPU, 0);
+  rmm::cuda_stream convert_stream;
+  {
+    auto mut = fixture.batch->to_mutable();
+    // The consumer's delayed read is still in flight when the reclaimer starts.
+    REQUIRE_FALSE(mut.consumers_done());
+    mut.convert_to<mock_data_representation>(registry, gpu_space.get(), convert_stream.view());
+  }
+
+  fixture.verify_no_premature_reclaim();
+  REQUIRE(fixture.batch->to_read_only().get_current_tier() == memory::Tier::GPU);
+}
+
+TEST_CASE("convert_to non-GPU-tier swap host-syncs pending consumer reads (else-branch)",
+          "[consumer_events][data_batch][reclaim]")
+{
+  pending_consumer_read fixture;
+
+  // Host -> host swap: neither tier is GPU, so install_converted_representation
+  // skips the stream sync and must host-sync the consumer events instead (its
+  // else-branch) before the old pinned representation is destroyed.
+  representation_converter_registry registry;
+  registry.register_converter<poisoning_pinned_representation, mock_data_representation>(
+    [](idata_representation& /*source*/,
+       const memory::memory_space* /*target_space*/,
+       rmm::cuda_stream_view /*stream*/,
+       memory::reservation* /*reservation*/) -> std::unique_ptr<idata_representation> {
+      return std::make_unique<mock_data_representation>(memory::Tier::HOST,
+                                                        pending_consumer_read::kBytes);
+    });
+
+  auto host_space = make_mock_memory_space(memory::Tier::HOST, 0);
+  rmm::cuda_stream convert_stream;
+  {
+    auto mut = fixture.batch->to_mutable();
+    REQUIRE_FALSE(mut.consumers_done());
+    mut.convert_to<mock_data_representation>(registry, host_space.get(), convert_stream.view());
+    // The else-branch host sync means the consumer events are complete the
+    // moment convert_to returns.
+    REQUIRE(mut.consumers_done());
+  }
+
+  fixture.verify_no_premature_reclaim();
+  REQUIRE(fixture.batch->to_read_only().get_current_tier() == memory::Tier::HOST);
+}
+
+TEST_CASE("set_data host-syncs pending consumer reads before destroying the old representation",
+          "[consumer_events][data_batch][reclaim]")
+{
+  pending_consumer_read fixture;
+
+  {
+    auto mut = fixture.batch->to_mutable();
+    REQUIRE_FALSE(mut.consumers_done());
+    mut.set_data(std::make_unique<mock_data_representation>(memory::Tier::HOST, 64));
+    // set_data's conservative host sync completed all consumer events.
+    REQUIRE(mut.consumers_done());
+  }
+
+  fixture.verify_no_premature_reclaim();
+}
+
+// =============================================================================
+// Negative / edge cases
+// =============================================================================
+
+TEST_CASE("data_batch record with the default stream works", "[consumer_events][data_batch]")
+{
+  auto batch = make_mock_batch();
+  device_buffer_raw scratch(64);
+
+  CUCASCADE_CUDA_TRY(cudaMemsetAsync(scratch.ptr, 0x5A, scratch.bytes, nullptr));
+  batch->record_consumer_event(rmm::cuda_stream_default);
+
+  rmm::cuda_stream other;
+  batch->await_consumers(other.view());  // wait on another stream: legal
+  other.synchronize();
+  CUCASCADE_CUDA_TRY(cudaStreamSynchronize(nullptr));
+  REQUIRE(batch->consumers_done());
+}
+
+TEST_CASE("data_batch await_consumers on the recording stream itself does not deadlock",
+          "[consumer_events][data_batch]")
+{
+  auto batch = make_mock_batch();
+  rmm::cuda_stream stream;
+  device_buffer_raw scratch(64);
+
+  enqueue_host_delay(stream.view(), 50);
+  CUCASCADE_CUDA_TRY(cudaMemsetAsync(scratch.ptr, 0x77, scratch.bytes, stream.value()));
+  batch->record_consumer_event(stream.view());
+
+  // Waiting on your own event from the same stream is a device-side no-op; the
+  // call must only ENQUEUE the wait, never block the host on the 50 ms delay.
+  const auto before = std::chrono::steady_clock::now();
+  batch->await_consumers(stream.view());
+  const auto elapsed = std::chrono::steady_clock::now() - before;
+  REQUIRE(elapsed < std::chrono::milliseconds(40));
+
+  // The stream still drains normally afterwards.
+  CUCASCADE_CUDA_TRY(cudaMemsetAsync(scratch.ptr, 0x78, scratch.bytes, stream.value()));
+  stream.synchronize();
+  REQUIRE(batch->consumers_done());
+}


### PR DESCRIPTION
## Problem

Buffers of GPU tables produced by the built-in host→GPU converter are allocated on an internal `memory_space` pool stream. Their stream-ordered frees (`cudaFreeAsync`) therefore execute on an idle, foreign, shared stream — unordered against reads still in flight on the consumer's stream. When a consumer drops such a buffer mid-read (e.g. a `cudf::cast` column replacement), the async allocator recycles the block into a concurrent conversion's H2D write while the reader kernel is still consuming it.

Downstream (Sirius), this caused silent, transient data corruption: TPC-H SF1000 Q18 returned wrong aggregates in ~39% of warm pinned-host executions; `compute-sanitizer memcheck` captured 258 identical stream-ordered use-after-free hazards at the consuming cast. ASan/TSan are structurally blind to this class (GPU-timeline race; pool memory is never poisoned).

## Changes

1. **`gpu_table_representation::release_table(stream)` now honors its stream parameter** — the owned-table branch rebinds every column's buffers (recursively, incl. null masks and children) to the passed stream before transferring ownership, so the eventual frees are ordered behind the new owner's reads. The view branch already deep-copies on the passed stream. The drained-previous-stream precondition is documented (`@pre`), and holds for all built-in converters (they synchronize before publishing).
2. **Consumer-event API on `data_batch`** — the mirror of the existing writer event: readers call `record_consumer_event(stream)` after enqueuing reads; reclaimers call `await_consumers(stream)` (device-side waits, no host stall) or observe `consumers_done()`. Backed by a new pooled-event utility (`cuda::event_pool`, `cudaEventDisableTiming`, thread-safe, recycling). Wired into the two in-library reclaim sites: `install_converted_representation` (including a host-sync fallback for non-GPU-tier swaps, where the stream-sync tail doesn't run) and `set_data`.
3. **Namespace hygiene** — qualified 4 pre-existing unqualified `cuda::stream_ref` uses that break once `cucascade::cuda` enters those TUs' lookup.

## Tests

- `test/data/test_consumer_events.cpp` (14 cases): API contracts, device-side gating (verified via device flags + `cudaErrorNotReady` probes), 1000-cycle recycling, 8-thread concurrency at both the pool and batch layers, and deterministic poison-on-reclaim regression tests for all three reclaim hooks.
- `test/cudf/test_release_table_stream.cpp` (5 cases): first coverage of `release_table` — recursive stream-binding assertions with an anti-vacuity control block, the motivating 20-iteration allocator-reuse UAF stress, view-branch semantics, and composition with caller-side rebinds.
- Full `cucascade_cudf_tests` suite green on GB300 (203 assertions in the new suites; no regressions elsewhere).

## Downstream validation

Together with sirius-db/sirius#1566, TPC-H SF1000 full-suite (22 queries × 4 iterations × 4 sessions, full untruncated result validation): **352/352 clean**, vs ~77% corrupt sessions before. No performance regression (same-machine controls).

## Note

The core `cucascade_tests` target currently fails to compile on `main` due to a pre-existing Catch2 v2 include (`test/memory/test_reservation_manager_configurator.cpp:29`, introduced in #173) — unrelated to this PR and not fixed here; the new tests live in `cucascade_cudf_tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
