### PR TITLE
fix: pool pinned-slab CUDA events per device

### DIFF
--- a/include/cucascade/memory/small_pinned_host_memory_resource.hpp
+++ b/include/cucascade/memory/small_pinned_host_memory_resource.hpp
@@ -26,6 +26,7 @@
 #include <array>
 #include <cstddef>
 #include <mutex>
+#include <unordered_map>
 #include <vector>
 
 namespace cucascade {
@@ -149,24 +150,42 @@ class small_pinned_host_memory_resource {
   /// the freeing stream. Reusing the slab must wait on this event so an
   /// in-flight async H2D copy that still reads the slab (e.g. cuDF's parquet
   /// stats min/max buffers) completes before another stream overwrites it.
-  /// @c ready_event is null for freshly-carved slabs that were never used.
+  /// @c ready_event is null for freshly-carved slabs that were never used, and
+  /// for slabs whose freeing stream was synchronized outright (see deallocate).
+  ///
+  /// @c event_device records the device the event belongs to. A CUDA event is
+  /// bound to the device that was current when it was created, and
+  /// cudaEventRecord rejects an event/stream pair from different devices with
+  /// cudaErrorInvalidResourceHandle. This resource is shared by every GPU in a
+  /// NUMA domain, so events must be pooled per device rather than globally.
   struct free_slab {
     void* ptr;
     cudaEvent_t ready_event;
+    int event_device;
   };
 
-  /// Borrow a timing-disabled CUDA event (recycled from @c event_pool_ or newly
-  /// created). Returns null if event creation fails. Must hold @c mutex_.
-  cudaEvent_t acquire_event_locked();
+  /// The device @p stream belongs to, or the current device if that cannot be
+  /// determined. Events must be created on, and recorded against, this device.
+  static int device_of_stream(::cuda::stream_ref stream) noexcept;
 
-  /// Return an event to @c event_pool_ for reuse. Must hold @c mutex_.
-  void release_event_locked(cudaEvent_t event) noexcept;
+  /// Borrow a timing-disabled CUDA event owned by @p device (recycled from that
+  /// device's pool, or newly created with @p device current). Returns null if
+  /// event creation fails. Must hold @c mutex_.
+  cudaEvent_t acquire_event_locked(int device);
+
+  /// Return an event to @p device's pool for reuse, or destroy it if caching
+  /// would allocate and fail. Must hold @c mutex_.
+  void release_event_locked(cudaEvent_t event, int device) noexcept;
 
   fixed_size_host_memory_resource& upstream_;
   mutable std::mutex mutex_;
   std::array<std::vector<free_slab>, 5> free_lists_{};
-  std::vector<cudaEvent_t> event_pool_;
+  /// Idle events keyed by the device they were created on.
+  std::unordered_map<int, std::vector<cudaEvent_t>> event_pool_;
   std::vector<fixed_multiple_blocks_allocation> owned_allocations_;
+  /// A failed synchronization quarantines a slab and prevents its backing block
+  /// from being returned upstream during destruction.
+  bool has_quarantined_slab_{false};
 };
 
 static_assert(::cuda::mr::resource_with<small_pinned_host_memory_resource,

--- a/src/memory/small_pinned_host_memory_resource.cpp
+++ b/src/memory/small_pinned_host_memory_resource.cpp
@@ -37,39 +37,107 @@ small_pinned_host_memory_resource::~small_pinned_host_memory_resource()
   // free_lists_ entries are raw pointers into those blocks; no individual cleanup needed.
   // Destroy every CUDA event we own — both idle (pooled) and still attached to a
   // free slab that was never re-allocated.
-  for (auto& event : event_pool_) {
-    if (event != nullptr) { CUCASCADE_ASSERT_CUDA_SUCCESS(::cudaEventDestroy(event)); }
+  bool retain_backing_allocations = has_quarantined_slab_;
+  int prev_device                 = 0;
+  bool const have_prev            = (::cudaGetDevice(&prev_device) == cudaSuccess);
+  auto destroy_on                 = [&retain_backing_allocations](cudaEvent_t event, int device) {
+    if (event == nullptr) { return; }
+    // cudaEventDestroy is device-agnostic, but making the owning device current
+    // keeps the call on the context the event was created in.
+    if (device >= 0) { (void)::cudaSetDevice(device); }
+    // Destroying an incomplete event does not wait for its captured work. Wait
+    // explicitly before owned_allocations_ returns the backing slabs upstream.
+    if (::cudaEventSynchronize(event) != cudaSuccess) {
+      // Fail closed: cudaEventDestroy is non-blocking for incomplete events.
+      // Retain every backing allocation so upstream cannot reuse its slabs.
+      (void)::cudaGetLastError();
+      retain_backing_allocations = true;
+    }
+    CUCASCADE_ASSERT_CUDA_SUCCESS(::cudaEventDestroy(event));
+  };
+  for (auto& [device, events] : event_pool_) {
+    for (auto& event : events) {
+      destroy_on(event, device);
+    }
   }
   for (auto& list : free_lists_) {
     for (auto& slab : list) {
-      if (slab.ready_event != nullptr) {
-        CUCASCADE_ASSERT_CUDA_SUCCESS(::cudaEventDestroy(slab.ready_event));
-      }
+      destroy_on(slab.ready_event, slab.event_device);
+    }
+  }
+  if (have_prev) { (void)::cudaSetDevice(prev_device); }
+  if (retain_backing_allocations) {
+    // Intentionally leak the allocation handles on an unrecoverable CUDA error.
+    // Returning their blocks upstream would risk use-after-free or unordered reuse.
+    for (auto& allocation : owned_allocations_) {
+      (void)allocation.release();
     }
   }
 }
 
-cudaEvent_t small_pinned_host_memory_resource::acquire_event_locked()
+int small_pinned_host_memory_resource::device_of_stream(::cuda::stream_ref stream) noexcept
 {
-  if (!event_pool_.empty()) {
-    cudaEvent_t event = event_pool_.back();
-    event_pool_.pop_back();
+  int device = -1;
+  // A CUDA event is bound to the device current at creation time, and
+  // cudaEventRecord requires the event and stream to be on the same device.
+  // Ask the driver which device this stream belongs to rather than assuming it
+  // matches the calling thread's current device.
+  if (::cudaStreamGetDevice(stream.get(), &device) == cudaSuccess) { return device; }
+  (void)::cudaGetLastError();
+  if (::cudaGetDevice(&device) == cudaSuccess) { return device; }
+  (void)::cudaGetLastError();
+  return -1;
+}
+
+cudaEvent_t small_pinned_host_memory_resource::acquire_event_locked(int device)
+{
+  auto const pool_it = event_pool_.find(device);
+  if (pool_it != event_pool_.end() && !pool_it->second.empty()) {
+    auto& pool        = pool_it->second;
+    cudaEvent_t event = pool.back();
+    pool.pop_back();
     return event;
   }
+
+  // Create the event on the device it will be recorded against. Without this,
+  // an event created while another GPU was current fails cudaEventRecord with
+  // cudaErrorInvalidResourceHandle, and the slab would be recycled unordered.
+  int prev_device = -1;
+  bool switched   = false;
+  if (device >= 0 && ::cudaGetDevice(&prev_device) == cudaSuccess && prev_device != device) {
+    if (::cudaSetDevice(device) == cudaSuccess) {
+      switched = true;
+    } else {
+      (void)::cudaGetLastError();
+      return nullptr;
+    }
+  }
+
   cudaEvent_t event = nullptr;
   // Timing is not needed; disabling it makes record/wait cheaper.
-  if (::cudaEventCreateWithFlags(&event, cudaEventDisableTiming) != cudaSuccess) {
-    // Best effort: without an event this deallocation loses stream ordering, but
-    // allocation must never throw here. Clear the sticky error and carry on.
+  bool const created = (::cudaEventCreateWithFlags(&event, cudaEventDisableTiming) == cudaSuccess);
+  if (!created) {
+    // The caller synchronizes the freeing stream when no event is available, so
+    // losing an event costs performance but never ordering.
     (void)::cudaGetLastError();
-    return nullptr;
+    event = nullptr;
   }
+
+  if (switched) { (void)::cudaSetDevice(prev_device); }
   return event;
 }
 
-void small_pinned_host_memory_resource::release_event_locked(cudaEvent_t event) noexcept
+void small_pinned_host_memory_resource::release_event_locked(cudaEvent_t event, int device) noexcept
 {
-  if (event != nullptr) { event_pool_.push_back(event); }
+  if (event == nullptr) { return; }
+  try {
+    event_pool_[device].push_back(event);
+  } catch (...) {
+    // Pool growth is only a cache optimization. Avoid terminating a noexcept
+    // deallocation if host allocation fails; an already-enqueued wait is not
+    // affected by destroying the event handle.
+    CUCASCADE_ASSERT_CUDA_SUCCESS(::cudaEventDestroy(event));
+  }
 }
 
 void* small_pinned_host_memory_resource::allocate([[maybe_unused]] cuda::stream_ref stream,
@@ -105,8 +173,16 @@ void* small_pinned_host_memory_resource::allocate([[maybe_unused]] cuda::stream_
   // that copy completes. Recording the event again (on a later deallocate) does
   // not disturb this already-enqueued wait, so the event is safe to recycle.
   if (slab.ready_event != nullptr) {
-    CUCASCADE_ASSERT_CUDA_SUCCESS(::cudaStreamWaitEvent(stream.get(), slab.ready_event, 0));
-    release_event_locked(slab.ready_event);
+    // cudaStreamWaitEvent is legal across devices, so the reusing stream may
+    // belong to a different GPU than the one that recorded the event.
+    cudaError_t const wait_status = ::cudaStreamWaitEvent(stream.get(), slab.ready_event, 0);
+    if (wait_status != cudaSuccess) {
+      // The wait was not established, so returning this pointer would recreate
+      // the unordered-reuse race. Keep the slab tracked and propagate the error.
+      free_lists_[idx].push_back(slab);
+      CUCASCADE_CUDA_TRY(wait_status);
+    }
+    release_event_locked(slab.ready_event, slab.event_device);
   }
   return slab.ptr;
 }
@@ -122,18 +198,35 @@ void small_pinned_host_memory_resource::deallocate([[maybe_unused]] cuda::stream
     return;
   }
 
-  std::size_t idx = slab_index_for(bytes);
-  std::lock_guard<std::mutex> lock(mutex_);
+  std::size_t idx         = slab_index_for(bytes);
+  int const stream_device = device_of_stream(stream);
+  std::unique_lock<std::mutex> lock(mutex_);
   // Record an event on the freeing stream so a future reuse of this slab can wait
   // for any still-pending work on it (the async H2D copy in cuDF's stats filter).
-  // Best effort: a null event just means this slab is recycled without ordering.
-  cudaEvent_t event = acquire_event_locked();
+  cudaEvent_t event = acquire_event_locked(stream_device);
   if (event != nullptr && ::cudaEventRecord(event, stream.get()) != cudaSuccess) {
     (void)::cudaGetLastError();
-    release_event_locked(event);
+    release_event_locked(event, stream_device);
     event = nullptr;
   }
-  free_lists_[idx].push_back(free_slab{ptr, event});
+  if (event == nullptr) {
+    // No event means no ordering, and an unordered slab hands still-in-flight
+    // source memory to the next writer. Pay for a synchronize instead: dropping
+    // ordering here silently corrupts whatever the pending copy was reading.
+    // The slab is not published yet, so do not hold the allocator-wide mutex
+    // while waiting for unrelated work on this stream to complete.
+    lock.unlock();
+    if (::cudaStreamSynchronize(stream.get()) != cudaSuccess) {
+      // Synchronization failure leaves ordering unknown. Quarantine this slab
+      // instead of making it available for unsafe reuse.
+      (void)::cudaGetLastError();
+      lock.lock();
+      has_quarantined_slab_ = true;
+      return;
+    }
+    lock.lock();
+  }
+  free_lists_[idx].push_back(free_slab{ptr, event, stream_device});
 }
 
 bool small_pinned_host_memory_resource::operator==(
@@ -161,7 +254,7 @@ void small_pinned_host_memory_resource::expand_pool_locked(std::size_t slab_idx)
   for (std::byte* block : allocation->get_blocks()) {
     for (std::size_t i = 0; i < num_slabs; ++i) {
       // Freshly-carved slabs were never used, so they carry no pending-work event.
-      free_lists_[slab_idx].push_back(free_slab{block + i * slab_size, nullptr});
+      free_lists_[slab_idx].push_back(free_slab{block + i * slab_size, nullptr, -1});
     }
   }
   owned_allocations_.push_back(std::move(allocation));


### PR DESCRIPTION
## Summary

Fix cross-device CUDA event reuse in `small_pinned_host_memory_resource`. The resource previously kept one global event pool, so an event created on one GPU could be recorded on another GPU's stream. CUDA rejects that combination; in release builds, the slab could then be returned to the free list without correct stream ordering and reused during an in-flight transfer.

## Changes

- Pool events by the CUDA device that owns the stream.
- Create events on that device and preserve their device ownership with each free slab.
- Fail closed when event creation, recording, waiting, or synchronization fails.
- Synchronize outstanding events before releasing backing storage during teardown.

## Validation

- Formatting, pre-commit checks, the CUDA 13.2 Release build, and tests pass.
- Compute Sanitizer errors from this resource dropped from 2,361 `cudaErrorInvalidResourceHandle` failures to none.
- Multi-GPU behavior was verified on GB200 with CUDA 13.2.

## Context

This was found while debugging intermittent TPC-H query 6/9 correctness failures in Sirius.
