### PR TITLE
bug: Fix CUDA 13 build failure from deprecated stream_ref header

### DIFF
--- a/include/cucascade/memory/common.hpp
+++ b/include/cucascade/memory/common.hpp
@@ -21,7 +21,7 @@
 #include <rmm/version_config.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 #include <cstdint>

--- a/include/cucascade/memory/null_device_memory_resource.hpp
+++ b/include/cucascade/memory/null_device_memory_resource.hpp
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 

--- a/include/cucascade/memory/numa_region_pinned_host_allocator.hpp
+++ b/include/cucascade/memory/numa_region_pinned_host_allocator.hpp
@@ -18,7 +18,7 @@
 #pragma once
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 
 #include <cstddef>
 

--- a/include/cucascade/memory/small_pinned_host_memory_resource.hpp
+++ b/include/cucascade/memory/small_pinned_host_memory_resource.hpp
@@ -20,7 +20,7 @@
 #include <cucascade/memory/fixed_size_host_memory_resource.hpp>
 
 #include <cuda/memory_resource>
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <array>

--- a/test/memory/test_reservation_aware_resource_adaptor.cpp
+++ b/test/memory/test_reservation_aware_resource_adaptor.cpp
@@ -39,7 +39,7 @@
 #include <rmm/mr/cuda_memory_resource.hpp>
 #include <rmm/resource_ref.hpp>
 
-#include <cuda/stream_ref>
+#include <cuda/stream>
 #include <cuda_runtime_api.h>
 
 #include <catch2/catch_all.hpp>


### PR DESCRIPTION
## Summary

- replace deprecated `<cuda/stream_ref>` includes with `<cuda/stream>`
- preserve the existing `cuda::stream_ref` API and runtime behavior
- migrate the remaining test include so no deprecated-header call sites remain

## Root cause

Current CCCL emits a deprecation warning when `<cuda/stream_ref>` is included because its contents moved to `<cuda/stream>`. CUDA 13 CI promotes that warning to an error via `-Werror`, stopping the build before tests and benchmarks.

The replacement header provides `cuda::stream_ref` in every configured CUDA 12 and CUDA 13 environment, so no compatibility shim or `CCCL_IGNORE_DEPRECATED_STREAM_REF_HEADER` suppression is needed.

## Verification

- [x] `pixi run lint`
- [x] CUDA 12 stable build (NVCC 12.9.86, CCCL 3.4.0)
- [x] CUDA 12 nightly build (NVCC 12.9.86, CCCL 3.4.3)
- [x] CUDA 13 stable build (NVCC 13.2.86, CCCL 3.4.0)
- [x] CUDA 13 nightly build (NVCC 13.2.86, CCCL 3.4.3)
- [x] confirmed no `<cuda/stream_ref>` include or suppression macro remains

Tests were invoked in all four environments. The CPU-only topology suite passed, while the three GPU-dependent test executables could not run on the local host because it has no CUDA device/driver (`cudaErrorNoDevice`).
